### PR TITLE
Fix building of mongoose under FreeBSD.

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -21,7 +21,7 @@
 #if defined(_WIN32)
 #define _CRT_SECURE_NO_WARNINGS // Disable deprecation warning in VS2005
 #else
-#define _XOPEN_SOURCE 600     // For flockfile() on Linux
+#define _XOPEN_SOURCE      // For flockfile() on Linux
 #define _LARGEFILE_SOURCE     // Enable 64-bit file offsets
 #define __STDC_FORMAT_MACROS  // <inttypes.h> wants this for C++
 #define __STDC_LIMIT_MACROS   // C++ wants that for INT64_MAX


### PR DESCRIPTION
According to flockfile(3) under Linux you need only this:

```
#define _XOPEN_SOURCE
```
- http://man7.org/linux/man-pages/man3/flockfile.3.html

This also fixes the build under FreeBSD.
