### PR TITLE
Winsock2.h included after windows.h

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -59,8 +59,8 @@
 
 #if defined(_WIN32) && !defined(__SYMBIAN32__) // Windows specific
 #define _WIN32_WINNT 0x0400 // To make it link in VS2005
-#include <windows.h>
 #include <winsock2.h>
+#include <windows.h>
 #include <ws2tcpip.h>
 
 #ifndef PATH_MAX


### PR DESCRIPTION
Fixed an error in mongoose.c where winsock2.h was included twice, since it was included after windows.h.
