### PR TITLE
PoC fix for issue #73

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -1694,7 +1694,7 @@ int mg_get_var(const char *data, size_t data_len, const char *name,
 
         // Decode variable into destination buffer
         len = url_decode(p, (size_t)(s - p), dst, dst_len, 1);
-        
+
         // Redirect error code from -1 to -2 (destination buffer too small).
         if (len == -1) {
           len = -2;
@@ -4645,6 +4645,8 @@ static void close_socket_gracefully(struct mg_connection *conn) {
 
   // Send FIN to the client
   (void) shutdown(sock, SHUT_WR);
+
+#if defined(_WIN32)
   set_non_blocking_mode(sock);
 
   // Read and discard pending incoming data. If we do not do that and close the
@@ -4655,6 +4657,7 @@ static void close_socket_gracefully(struct mg_connection *conn) {
   do {
     n = pull(NULL, conn, buf, sizeof(buf));
   } while (n > 0);
+#endif // _WIN32
 
   // Now we know that our FIN is ACK-ed, safe to close
   (void) closesocket(sock);


### PR DESCRIPTION
This limits exposure to the issue to Windows (and fixes our problems on Linux). But presumably the same thing can happen there, so it might be better to add an optional timeout to wait_until_socket_is_readable instead.
