### PR TITLE
Fix building error under mingw

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,8 @@ mingw:
 	windres build\res.rc build\res.o
 	$(CC) $(MINGWOPT) mongoose.c -lws2_32 \
 		-shared -Wl,--out-implib=$(PROG).lib -o $(PROG).dll
-	$(CC) $(MINGWOPT) -build mongoose.c main.c build\res.o \
-	-lws2_32 -ladvapi32 -o $(PROG).exe
+	$(CC) $(MINGWOPT) mongoose.c main.c build\res.o \
+	-lws2_32 -ladvapi32 -lcomdlg32 -o $(PROG).exe
 
 # Build for Windows under Cygwin
 #CYGWINDBG= -DDEBUG -O0 -ggdb


### PR DESCRIPTION
Two building error under mingw fixed
- `cc: error: unrecognized option '-build'`
- `C:\Users\xxx\AppData\Local\Temp\ccLfW9xj.o:main.c:(.text+0x13af): undefined
  reference to`GetOpenFileNameA@4'`
