### PR TITLE
Better error handling and an include function for lua pages

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3934,14 +3934,12 @@ static int handle_lsp_request(struct mg_connection *, const char *,
 static int lsp_mg_error(lua_State *L) {
   struct mg_connection *conn = lua_touserdata(L, lua_upvalueindex(1));
   int top = lua_gettop(L);
-  if (top > 1) lua_settop(L, 1);
   if (top < 1) lua_pushstring(L, "unknown error");
   // Get mg.onerror.
   lua_getglobal(L, "mg");
   lua_getfield(L, -1, "onerror");
   // If mg.onerror is nil, silently stop processing chunks.
   if (lua_isnil(L, -1)) {
-    lua_settop(L, 0);
     lua_pushinteger(L, 1);
     return 1;
   }
@@ -3951,13 +3949,10 @@ static int lsp_mg_error(lua_State *L) {
   if (lua_pcall(L, 1, 1, 0)) {
     // If mg.onerror fails, cry the error message and stop processing chunks.
     cry(conn, "mg.onerror failed: %s", lua_tostring(L, -1));
-    lua_settop(L, 0);
     lua_pushinteger(L, 1);
     return 1;
   }
   // Return the return value from mg.onerror. Non-0 = stop processing chunks.
-  lua_replace(L, 1);
-  lua_settop(L, 1);
   return 1;
 }
 


### PR DESCRIPTION
Issues with current implementation:
- Errors in lua pages aren't logged. It can partly be worked around with xpcall, but:
  - You'd need to make a separate xpcall for each chunk / processing instruction.
  - xpcall won't catch syntax errors or other load-time errors, only runtime errors.
  - There is still no way to get messages into the error log.
- There is no way to stop processing when an error on a lua page is encountered.
- The chunk names and line numbers according to lua's debug module are not useful.

These features would also be nice:
- A way to include a lua page inside another.
- A way to redirect a request from a lua page.

---

This patch passes in useful names and line numbers when calling chunks, and adds these lua functions:
- mg.cry: Cries each string argument. Used to log errors.
- mg.include: Includes other lua pages.
- mg.onerror: Default error handler. 
  - Setting mg.onerror to a custom handler function is equivalent to calling set_exception_handler in PHP. 
  - It's up to mg.onerror to display or log errors, equivalent to log_errors and display_errors PHP settings.
  - If mg.onerror returns non-zero, processing will abort.
- mg.redirect: Redirects the request to another URL.
