### PR TITLE
Fix bugs about range request and explorer crashes

### DIFF
--- a/main.c
+++ b/main.c
@@ -690,6 +690,7 @@ static LRESULT CALLBACK WindowProc(HWND hWnd, UINT msg, WPARAM wParam,
   char buf[200], *service_argv[] = {__argv[0], NULL};
   POINT pt;
   HMENU hMenu;
+  static UINT s_uTaskbarRestart; // for taskbar creation
 
   switch (msg) {
     case WM_CREATE:
@@ -700,6 +701,7 @@ static LRESULT CALLBACK WindowProc(HWND hWnd, UINT msg, WPARAM wParam,
         exit(EXIT_SUCCESS);
       } else {
         start_mongoose(__argc, __argv);
+        s_uTaskbarRestart = RegisterWindowMessage(TEXT("TaskbarCreated"));
       }
       break;
     case WM_COMMAND:
@@ -757,6 +759,9 @@ static LRESULT CALLBACK WindowProc(HWND hWnd, UINT msg, WPARAM wParam,
       Shell_NotifyIcon(NIM_DELETE, &TrayIcon);
       PostQuitMessage(0);
       return 0;  // We've just sent our own quit message, with proper hwnd.
+    default:
+      if (msg==s_uTaskbarRestart)
+        Shell_NotifyIcon(NIM_ADD, &TrayIcon);
   }
 
   return DefWindowProc(hWnd, msg, wParam, lParam);

--- a/mongoose.c
+++ b/mongoose.c
@@ -2786,7 +2786,7 @@ static void handle_file_request(struct mg_connection *conn, const char *path,
   r1 = r2 = 0;
   hdr = mg_get_header(conn, "Range");
   if (hdr != NULL && (n = parse_range_header(hdr, &r1, &r2)) > 0 &&
-      r1 >= 0 && r2 > 0) {
+      r1 >= 0 && r2 >= 0) {
     conn->status_code = 206;
     cl = n == 2 ? (r2 > cl ? cl : r2) - r1 + 1: cl - r1;
     mg_snprintf(conn, range, sizeof(range),


### PR DESCRIPTION
1. fix a bug that when header contains "Range: 100-", the range request
   support will fail
2. (windows) fix a bug that when explorer.exe crashes due to some
   reason, the tray icon will disappear.
