### PR TITLE
Added get_server_name_from_headers option.

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -431,7 +431,8 @@ struct socket {
 // NOTE(lsm): this enum shoulds be in sync with the config_options below.
 enum {
   CGI_EXTENSIONS, CGI_ENVIRONMENT, PUT_DELETE_PASSWORDS_FILE, CGI_INTERPRETER,
-  PROTECT_URI, AUTHENTICATION_DOMAIN, SSI_EXTENSIONS, THROTTLE,
+  PROTECT_URI, GET_SERVER_NAME_FROM_HEADERS, AUTHENTICATION_DOMAIN,
+  SSI_EXTENSIONS, THROTTLE,
   ACCESS_LOG_FILE, ENABLE_DIRECTORY_LISTING, ERROR_LOG_FILE,
   GLOBAL_PASSWORDS_FILE, INDEX_FILES, ENABLE_KEEP_ALIVE, ACCESS_CONTROL_LIST,
   EXTRA_MIME_TYPES, LISTENING_PORTS, DOCUMENT_ROOT, SSL_CERTIFICATE,
@@ -445,6 +446,7 @@ static const char *config_options[] = {
   "G", "put_delete_auth_file", NULL,
   "I", "cgi_interpreter", NULL,
   "P", "protect_uri", NULL,
+  "N", "get_server_name_from_headers", "no",
   "R", "authentication_domain", "mydomain.com",
   "S", "ssi_pattern", "**.shtml$|**.shtm$",
   "T", "throttle", NULL,
@@ -3087,7 +3089,11 @@ static void prepare_cgi_environment(struct mg_connection *conn,
   blk->conn = conn;
   sockaddr_to_string(src_addr, sizeof(src_addr), &conn->client.rsa);
 
-  addenv(blk, "SERVER_NAME=%s", conn->ctx->config[AUTHENTICATION_DOMAIN]);
+  if ( mg_strcasecmp(conn->ctx->config[GET_SERVER_NAME_FROM_HEADERS], "yes") == 0 ) {
+    s = mg_get_header(conn, "Host");
+    addenv(blk, "SERVER_NAME=%s", s);
+  } else 
+    addenv(blk, "SERVER_NAME=%s", conn->ctx->config[AUTHENTICATION_DOMAIN]);
   addenv(blk, "SERVER_ROOT=%s", conn->ctx->config[DOCUMENT_ROOT]);
   addenv(blk, "DOCUMENT_ROOT=%s", conn->ctx->config[DOCUMENT_ROOT]);
 


### PR DESCRIPTION
If this option is set to yes (by default - "no"), then
SERVER_NAME environment variable (that used by cgi) set to a value of
Host http header.

This is need for cgi scripts, when a redirection uri is constructed from SERVER_NAME, SERVER_PORT and SCRIPT_NAME and a box with mongoose has several interfaces, for example. So, it wrong to set SERVER_NAME to one domain or IP. If user requests 192.168.0.1, then he must receive a redirection uri with 192.168.0.1; if user requests my-box (which is hardcoded in his hosts file), then he must receive a redirection uri with my-box in it. Apache, cherooke etc implement this behaviour.

I don't understand why mongoose get SERVER_NAME value from authentication_domain option, instead of getting it from Host http-header. May be this some security or anything else issue, therefore i added this as an option to make this behaviour switchable.
