### PR TITLE
Added server_name option.

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -431,7 +431,7 @@ struct socket {
 // NOTE(lsm): this enum shoulds be in sync with the config_options below.
 enum {
   CGI_EXTENSIONS, CGI_ENVIRONMENT, PUT_DELETE_PASSWORDS_FILE, CGI_INTERPRETER,
-  PROTECT_URI, AUTHENTICATION_DOMAIN, SSI_EXTENSIONS, THROTTLE,
+  PROTECT_URI, SERVER_NAME, AUTHENTICATION_DOMAIN, SSI_EXTENSIONS, THROTTLE,
   ACCESS_LOG_FILE, ENABLE_DIRECTORY_LISTING, ERROR_LOG_FILE,
   GLOBAL_PASSWORDS_FILE, INDEX_FILES, ENABLE_KEEP_ALIVE, ACCESS_CONTROL_LIST,
   EXTRA_MIME_TYPES, LISTENING_PORTS, DOCUMENT_ROOT, SSL_CERTIFICATE,
@@ -445,6 +445,7 @@ static const char *config_options[] = {
   "G", "put_delete_auth_file", NULL,
   "I", "cgi_interpreter", NULL,
   "P", "protect_uri", NULL,
+  "N", "server_name", NULL,
   "R", "authentication_domain", "mydomain.com",
   "S", "ssi_pattern", "**.shtml$|**.shtm$",
   "T", "throttle", NULL,
@@ -3087,7 +3088,11 @@ static void prepare_cgi_environment(struct mg_connection *conn,
   blk->conn = conn;
   sockaddr_to_string(src_addr, sizeof(src_addr), &conn->client.rsa);
 
-  addenv(blk, "SERVER_NAME=%s", conn->ctx->config[AUTHENTICATION_DOMAIN]);
+  if ( conn->ctx->config[SERVER_NAME] == NULL ) {
+    s = mg_get_header(conn, "Host");
+    addenv(blk, "SERVER_NAME=%s", s);
+  } else 
+    addenv(blk, "SERVER_NAME=%s", conn->ctx->config[SERVER_NAME]);
   addenv(blk, "SERVER_ROOT=%s", conn->ctx->config[DOCUMENT_ROOT]);
   addenv(blk, "DOCUMENT_ROOT=%s", conn->ctx->config[DOCUMENT_ROOT]);
 


### PR DESCRIPTION
Without this option, SERVER_NAME env var is set from Host http header.
If SERVER_NAME must be a constant string, set server_name option to
a needed name.

 jmucchiello comment:

I agree this should have nothing to do with the authentication domain. But I'm wondering if a better way to go would be to have a "SERVER_NAME" option instead of the switch in this patch. If you want them to match, supply both. If you don't want them to match, supply them separately. If you want to use the incoming server header, don't set the SERVER_NAME option.

Then the coding change in the CGI section becomes:
if (option is set) SERVER=option value; else SERVER = client header;
