### PR TITLE
Lua page error handling cleanup

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3977,12 +3977,11 @@ static int lsp(struct mg_connection *conn, const char *path,
         if (p[j] == '\n') ++lualines;
         if (p[j] == '?' && p[j + 1] == '>') {
           mg_write(conn, p + pos, i - pos);
-	        // lua_settop(L, 0);
           lua_pushlightuserdata(L, conn);
           lua_pushcclosure(L, lsp_mg_error, 1);
           snprintf (chunkname, sizeof(chunkname), "@%s+%i", path, lines);
           if (luaL_loadbuffer(L, p + (i + 2), j - (i + 2), chunkname)) {
-            lua_pcall(L, 1, 0, 0);
+            lua_pcall(L, 1, 1, 0);
             result = lua_tointeger(L, -1);
             if (result) return result;
           } else {


### PR DESCRIPTION
- mg.onerror returning non-zero wasn't stopping processing as it was supposed to, fixed.
- Removed a line of dead code.
