### PR TITLE
Use relative stack index for error handler in lsp()

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -4022,13 +4022,11 @@ static int lsp(struct mg_connection *conn, const char *path,
           snprintf (chunkname, sizeof(chunkname), "@%s+%i", path, lines);
           if (luaL_loadbuffer(L, p + (i + 2), j - (i + 2), chunkname)) {
             lua_pcall(L, 1, 1, 0);
-            result = lua_tointeger(L, -1);
-            if (result) return result;
           } else {
-            lua_pcall(L, 0, 0, 1);
-            result = lua_tointeger(L, -1);
-            if (result) return result;
+            lua_pcall(L, 0, 0, -2);
           }
+          result = lua_tointeger(L, -1);
+          if (result) return result;
           pos = j + 2;
           i = pos - 1;
           break;


### PR DESCRIPTION
Make mg.onerror work with mg.include, and clean up redundant code.

It turns out there can be things on the call stack here after all, so absolute indices are no good. The error handler was never firing for runtime errors on included pages. 

Adding lua_settop(L, 0) at the top of the block would "fix" it too (the "dead code" I was paranoid about), but it's probably better to leave the stack alone here.
