### PR TITLE
Make mongoose asynchronous. Let idle connections detach from threads, and reattach later.

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -1547,6 +1547,19 @@ int mg_read(struct mg_connection *conn, void *buf, size_t len) {
   return nread;
 }
 
+int mg_set_sock_handle(struct mg_connection * conn, int new_sock_handle) {
+    int old_sock_handle = conn->client.sock; 
+    conn->client.sock = new_sock_handle;
+    return old_sock_handle;
+}
+
+int mg_get_sock_in_own(struct mg_connection * conn) {
+    int sock_handle = conn->client.sock;
+    conn->must_close = 1;
+    conn->client.sock = INVALID_SOCKET;
+    return sock_handle;
+}
+
 int mg_write(struct mg_connection *conn, const void *buf, size_t len) {
   time_t now;
   int64_t n, total, allowed;

--- a/mongoose.h
+++ b/mongoose.h
@@ -195,10 +195,16 @@ int mg_modify_passwords_file(const char *passwords_file_name,
                              const char *user,
                              const char *password);
 
-
 // Return information associated with the request.
 struct mg_request_info *mg_get_request_info(struct mg_connection *);
 
+// Attach new socket handle to connection
+// return old socket handle, 
+int mg_set_sock_handle(struct mg_connection * conn, int new_socket_handle);
+
+// Get socket handle in own of caller and invalidate for current connection
+// return underlying socket handle
+int mg_get_sock_in_own(struct mg_connection * conn);
 
 // Send data to the client.
 // Return:


### PR DESCRIPTION
Intro

Thanks and regards for good product!

Motivation

Currently mongoose work pretty bad with large data transferring for several reason : first is because mongoose have 1 - master + several worker threads + small fifo for connections querying, the second there are no way to add manually IO scheduling in embedded mode, to solve this problem see details at (1).

(1) new connection(request for getting a lot of data) -> clone connection(socket in my version) -> move socket handle to the IO scheduler loop(like round-robin), which will write small chunks of data per socket handle.

PS 
Me and my company(where I work) we love use mongoose in some back-ends but at high load(mean IO, transferring large data into over 1000 connection) mongoose works not well so I suggest a fix of this problem by using IO scheduling + mongoose embedded with dup sockets handles.

I could add into mongoose build-in IO scheduling. So if you have an interesting ping me.
