### PR TITLE
_CRT_SECURE_NO_WARNINGS should not generate a warning if already defined

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -19,7 +19,9 @@
 // THE SOFTWARE.
 
 #if defined(_WIN32)
+#if !defined(_CRT_SECURE_NO_WARNINGS)
 #define _CRT_SECURE_NO_WARNINGS // Disable deprecation warning in VS2005
+#endif
 #else
 #ifdef __linux__
 #define _XOPEN_SOURCE 600     // For flockfile() on Linux


### PR DESCRIPTION
modified:   mongoose.c

If mongoose.c is included in a project that already defines _CRT_SECURE_NO_WARNINGS, redefinition of _CRT_SECURE_NO_WARNINGS in mongoose.c will generate a warning.  This fix prevents the redefinition and thus avoids this warning.
