### PR TITLE
Fix parameter 1 for select in poll()

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -1221,6 +1221,7 @@ static int poll(struct pollfd *pfd, int n, int milliseconds) {
   struct timeval tv;
   fd_set set;
   int i, result;
+  int maxfd = 0;
 
   tv.tv_sec = milliseconds / 1000;
   tv.tv_usec = (milliseconds % 1000) * 1000;
@@ -1229,9 +1230,13 @@ static int poll(struct pollfd *pfd, int n, int milliseconds) {
   for (i = 0; i < n; i++) {
     FD_SET((SOCKET) pfd[i].fd, &set);
     pfd[i].revents = 0;
+
+    if (pfd[i].fd > maxfd) {
+        maxfd = pfd[i].fd;
+    }
   }
 
-  if ((result = select(0, &set, NULL, NULL, &tv)) > 0) {
+  if ((result = select(maxfd+1, &set, NULL, NULL, &tv)) > 0) {
     for (i = 0; i < n; i++) {
       if (FD_ISSET(pfd[i].fd, &set)) {
         pfd[i].revents = POLLIN;


### PR DESCRIPTION
Hi, I'm embedding mongoose to my application on eCos OS.When client connecting to mongoose, I found none pollfd in poll could be set to POLLIN state in poll().But it works well on Linux.Try to change the first parameter of select() to max socket descriptor plus 1 then my eCos application is ok.
Thanks.
