### PR TITLE
 Make websocket_ready callback capable to update Websocket response HEADER section

### DIFF
--- a/examples/websocket.c
+++ b/examples/websocket.c
@@ -7,6 +7,20 @@
 
 static void websocket_ready_handler(struct mg_connection *conn) {
   unsigned char buf[40];
+  // HEADER section
+  // A example to negoticate Protocol
+  // const char *prot = mg_get_header(conn, "Sec-WebSocket-Protocol");
+  // if (prot){
+  //    char *p = NULL;
+  //    snprintf(buf, sizeof(buf), "%s", prot);
+  //    if ((p = strrchr(buf, ',')) != NULL) {
+  //      *p = '\0';
+  //    }
+  //    mg_printf(conn, "Sec-WebSocket-Protocol: %s\r\n", buf);
+  // }
+  // End of HEADER section
+  mg_printf(conn, "\r\n");
+  // Start of CONTENT section
   buf[0] = 0x81;
   buf[1] = snprintf((char *) buf + 2, sizeof(buf) - 2, "%s", "server ready");
   mg_write(conn, buf, 2 + buf[1]);

--- a/mongoose.c
+++ b/mongoose.c
@@ -3847,7 +3847,7 @@ static void send_websocket_handshake(struct mg_connection *conn) {
             "HTTP/1.1 101 Switching Protocols\r\n"
             "Upgrade: websocket\r\n"
             "Connection: Upgrade\r\n"
-            "Sec-WebSocket-Accept: ", b64_sha, "\r\n\r\n");
+            "Sec-WebSocket-Accept: ", b64_sha, "\r\n");
 }
 
 static void read_websocket(struct mg_connection *conn) {
@@ -3952,6 +3952,8 @@ static void handle_websocket_request(struct mg_connection *conn) {
     send_websocket_handshake(conn);
     if (conn->ctx->callbacks.websocket_ready != NULL) {
       conn->ctx->callbacks.websocket_ready(conn);
+    } else {
+      mg_printf(conn, "\r\n");
     }
     read_websocket(conn);
   }

--- a/mongoose.h
+++ b/mongoose.h
@@ -80,7 +80,7 @@ struct mg_callbacks {
   int (*websocket_connect)(const struct mg_connection *);
 
   // Called when websocket handshake is successfully completed, and
-  // connection is ready for data exchange.
+  // connection is ready for both HEADER update and data exchange.
   void (*websocket_ready)(struct mg_connection *);
 
   // Called when data frame has been received from the client.


### PR DESCRIPTION
In send_websocket_handshake, it prints all HEADER in fix manner(end with "\r\n\r\n"), but leave no chance for user callback to hanlde HEADER. Actually
in some instance, user need update response HEADER such as "Sec-WebSocket-Protocol" after negotiation. Current implementation has websocket_ready callback,
which should be the place to allow user update both HEADER and Content. Thus, I replace "\r\n\r\n" with "\r\n" in send_websocket_handshake, and let
websocket_ready to handle remaining stuffs.
