### PR TITLE
Allow passing a user_data pointer through the upload callbacks.

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -4223,7 +4223,7 @@ static uint32_t get_remote_ip(const struct mg_connection *conn) {
 #include "mod_lua.c"
 #endif // USE_LUA
 
-int mg_upload(struct mg_connection *conn, const char *destination_dir) {
+int mg_upload(struct mg_connection *conn, const char *destination_dir, void *user_data) {
   const char *content_type_header, *boundary_start;
   char buf[MG_BUF_LEN], path[PATH_MAX], fname[1024], boundary[100], *s;
   FILE *fp;
@@ -4330,7 +4330,7 @@ int mg_upload(struct mg_connection *conn, const char *destination_dir) {
     if (eof) {
       num_uploaded_files++;
       if (conn->ctx->callbacks.upload != NULL) {
-        conn->ctx->callbacks.upload(conn, path);
+        conn->ctx->callbacks.upload(conn, path, user_data);
       }
     }
   }

--- a/mongoose.h
+++ b/mongoose.h
@@ -116,7 +116,7 @@ struct mg_callbacks {
   // result of mg_upload() call.
   // Parameters:
   //    file_file: full path name to the uploaded file.
-  void (*upload)(struct mg_connection *, const char *file_name);
+  void (*upload)(struct mg_connection *, const char *file_name, void *user_data);
 
   // Called when mongoose is about to send HTTP error to the client.
   // Implementing this callback allows to create custom error pages.
@@ -342,7 +342,7 @@ void mg_close_connection(struct mg_connection *conn);
 // File upload functionality. Each uploaded file gets saved into a temporary
 // file and MG_UPLOAD event is sent.
 // Return number of uploaded files.
-int mg_upload(struct mg_connection *conn, const char *destination_dir);
+int mg_upload(struct mg_connection *conn, const char *destination_dir, void *user_data);
 
 
 // Convenience function -- create detached thread.


### PR DESCRIPTION
Makes it so much easier to get thread safe upload handling. Obviously breaks the existing API, though.
