### PR TITLE
Allow no SSL_CERTIFICATE when using init_ssl callback.

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -4741,8 +4741,10 @@ static int set_ssl_option(struct mg_context *ctx) {
   int i, size;
   const char *pem;
 
-  // If PEM file is not specified, skip SSL initialization.
-  if ((pem = ctx->config[SSL_CERTIFICATE]) == NULL) {
+  // If PEM file is not specified and the init_ssl callback
+  // is not specified, skip SSL initialization.
+  if ((pem = ctx->config[SSL_CERTIFICATE]) == NULL &&
+      ctx->callbacks.init_ssl == NULL) {
     return 1;
   }
 


### PR DESCRIPTION
I wanted to use the init_ssl callback to set up the CA certificates, certificate, and key, which are all in DER format not PEM. The function ssl_set_option() still required the SSL certificate option even when using the callback. The call to SSL_use_certificate_chain_file() is still skipped if the certificate option isn't set.

So, the initial check for the SSL certificate option also checks to see that the init_ssl callback is set if the pem is NULL.
