### PR TITLE
adding include of openssl/err.h to fix errors when NO_SSL_DL is defined:

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -308,6 +308,7 @@ static const char *http_500_error = "Internal Server Error";
 
 #if defined(NO_SSL_DL)
 #include <openssl/ssl.h>
+#include <openssl/err.h>
 #else
 // SSL loaded dynamically from DLL.
 // I put the prototypes here to be independent from OpenSSL source installation.


### PR DESCRIPTION
mongoose.c:4680:23: error: ‘ERR_get_error’ was not declared in this scope
mongoose.c:4681:52: error: ‘ERR_error_string’ was not declared in this scope
