### PR TITLE
gcc complains about _MSC_VER being an undefined macro.

### DIFF
--- a/mongoose.h
+++ b/mongoose.h
@@ -234,9 +234,9 @@ enum {
 
 // Macros for enabling compiler-specific checks for printf-like arguments.
 #undef PRINTF_FORMAT_STRING
-#if _MSC_VER >= 1400
+#if defined(_MSC_VER) && _MSC_VER >= 1400
 #include <sal.h>
-#if _MSC_VER > 1400
+#if defined(_MSC_VER) && _MSC_VER > 1400
 #define PRINTF_FORMAT_STRING(s) _Printf_format_string_ s
 #else
 #define PRINTF_FORMAT_STRING(s) __format_string s


### PR DESCRIPTION
This is a minor fix to resolve some gcc compilation warnings
for the XCode 3.1 toolchain on the Mac.
