### PR TITLE
Added SERVER_SOFTWARE CGI variable

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3279,6 +3279,7 @@ static void prepare_cgi_environment(struct mg_connection *conn,
   addenv(blk, "SERVER_NAME=%s", conn->ctx->config[AUTHENTICATION_DOMAIN]);
   addenv(blk, "SERVER_ROOT=%s", conn->ctx->config[DOCUMENT_ROOT]);
   addenv(blk, "DOCUMENT_ROOT=%s", conn->ctx->config[DOCUMENT_ROOT]);
+  addenv(blk, "SERVER_SOFTWARE=%s/%s", "Mongoose", mg_version());
 
   // Prepare the environment block
   addenv(blk, "%s", "GATEWAY_INTERFACE=CGI/1.1");


### PR DESCRIPTION
This PR adds the SERVER_SOFTWARE meta-variable under the CGI1.1 spec, [RFC3875](http://tools.ietf.org/html/rfc3875#section-4.1.17):

```
4.1.17.  SERVER_SOFTWARE

   The SERVER_SOFTWARE meta-variable MUST be set to the name and version
   of the information server software making the CGI request (and
   running the gateway).  It SHOULD be the same as the server
   description reported to the client, if any.

      SERVER_SOFTWARE = 1*( product | comment )
      product         = token [ "/" product-version ]
      product-version = token
      comment         = "(" *( ctext | comment ) ")"
      ctext           = <any TEXT excluding "(" and ")">
```

The SERVER_SOFTWARE  meta-variable outputs as such, tested under a PHP script:  `Mongoose/3.9`
