### PR TITLE
Potential Issue in `thread_stop` in `worker_thread`

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -5135,7 +5135,7 @@ static void *worker_thread(void *thread_func_param) {
     conn->request_info.user_data = ctx->user_data;
 
     if (ctx->callbacks.thread_start != NULL) {
-      ctx->callbacks.thread_start(&conn->request_info.user_data,
+      ctx->callbacks.thread_start(conn->request_info.user_data,
                                   &conn->request_info.conn_data);
     }
 
@@ -5164,12 +5164,13 @@ static void *worker_thread(void *thread_func_param) {
 
       close_connection(conn);
     }
-    free(conn);
-
+    
     if (ctx->callbacks.thread_stop != NULL) {
-      ctx->callbacks.thread_stop(&conn->request_info.user_data,
+      ctx->callbacks.thread_stop(conn->request_info.user_data,
                                      &conn->request_info.conn_data);
     }
+    
+    free(conn);
   }
 
   // Signal master that we're done with connection and exiting
@@ -5265,7 +5266,7 @@ static void *master_thread(void *thread_func_param) {
 #endif
 
   if (ctx->callbacks.thread_start != NULL) {
-    ctx->callbacks.thread_start(&ctx->user_data, NULL);
+    ctx->callbacks.thread_start(ctx->user_data, NULL);
   }
 
   pfd = (struct pollfd *) calloc(ctx->num_listening_sockets, sizeof(pfd[0]));
@@ -5315,7 +5316,7 @@ static void *master_thread(void *thread_func_param) {
   DEBUG_TRACE(("exiting"));
 
   if (ctx->callbacks.thread_stop != NULL) {
-    ctx->callbacks.thread_stop(&ctx->user_data, NULL);
+    ctx->callbacks.thread_stop(ctx->user_data, NULL);
   }
 
   // Signal mg_stop() that we're done.

--- a/mongoose.h
+++ b/mongoose.h
@@ -129,7 +129,7 @@ struct mg_callbacks {
   void (*thread_start)(void *user_data, void **conn_data);
 
   // Called when mongoose's thread is about to terminate.
-  // Same as thread_setup() callback, but called when thread is about to be
+  // Same as thread_start() callback, but called when thread is about to be
   // destroyed. Used to cleanup the state initialized by thread_setup().
   // Parameters: see thread_start().
   void (*thread_stop)(void *user_data, void **conn_data);


### PR DESCRIPTION
Currently, `worker_thread` calls `thread_stop` immediately _after_ is has freed `conn`. I believe this to be potentially a bug, because `thread_stop` does have members of `mg_connection` as parameters. Here, I've just reversed the order of the `free` and the `thread_stop`.

Another potential issue is the incompatibility of the signature of `thread_start` and `thread_stop` and their usage. While these two callbacks declares their first parameter (`user_data`) as `void*`, what gets passed in is actually a `void**` (i.e. `&ctx->user_data` or `&conn->request_info.user_data`.) I believe either the signature should be changed or the `&` in the calls be removed. Here, I haven't change the signature, as I see no use case for actually changing the `user_data`; but that very well might be a useful feature.

The third change is fixing a type in `mongoose.h` file, where `thread_start` is referred to by its old name `thread_setup`.
