### PR TITLE
fix double definition error (for c++) and cast to void* warning in -peda...

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -323,8 +323,6 @@ struct ssl_func {
   void  (*ptr)(void); // Function pointer
 };
 
-static struct ssl_func ssl_sw[30];
-
 #define SSL_free (* (void (*)(SSL *)) ssl_sw[0].ptr)
 #define SSL_accept (* (int (*)(SSL *)) ssl_sw[1].ptr)
 #define SSL_connect (* (int (*)(SSL *)) ssl_sw[2].ptr)
@@ -5024,7 +5022,7 @@ static void process_new_connection(struct mg_connection *conn) {
 
     if (ebuf[0] == '\0') {
       handle_request(conn);
-      call_user(MG_REQUEST_END, conn, (void *) conn->status_code);
+      call_user(MG_REQUEST_END, conn, (void *)(intptr_t)conn->status_code);
       log_access(conn);
     }
     if (ri->remote_user != NULL) {


### PR DESCRIPTION
Hi, I got an error when compiling mongoose.c with a C++ program. `static struct ssl_func ssl_sw[30]` was double-defined. This is a blocker for C++ development. I removed the extra definition. There was also a warning about casting integer to void\* which I removed by casting to intptr_t first.
