### PR TITLE
mg_printf_data was ignored if mg_destroy_server was called directly afte...

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3536,6 +3536,7 @@ void mg_destroy_server(struct mg_server **server) {
   struct ll *lp, *tmp;
 
   if (server != NULL && *server != NULL) {
+    mg_poll_server(*server, 0);
     closesocket((*server)->listening_sock);
     closesocket((*server)->ctl[0]);
     closesocket((*server)->ctl[1]);


### PR DESCRIPTION
...r

closes #286

this feels like a hack though, because when i look at mg_poll_server, the write truly happens after the read, and the uri_handler is called in the read.
