### PR TITLE
allow to define a default mime-type

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -220,7 +220,6 @@ enum {
   CGI_PATTERN, DAV_AUTH_FILE, DOCUMENT_ROOT, ENABLE_DIRECTORY_LISTING,
 #endif
   EXTRA_MIME_TYPES,
-  DEFAULT_MIME_TYPE,
 #ifndef MONGOOSE_NO_FILESYSTEM
   GLOBAL_AUTH_FILE,
 #endif
@@ -250,7 +249,6 @@ static const char *static_config_options[] = {
   "enable_directory_listing", "yes",
 #endif
   "extra_mime_types", NULL,
-  "default_mime_type", "text/plain",
 #ifndef MONGOOSE_NO_FILESYSTEM
   "global_auth_file", NULL,
 #endif
@@ -1995,7 +1993,7 @@ static void write_to_socket(struct connection *conn) {
   }
 }
 
-const char *mg_get_mime_type(struct mg_server *server, const char *path) {
+const char *mg_get_mime_type(const char *path, const char *default_mime_type) {
   const char *ext;
   size_t i, path_len;
 
@@ -2009,7 +2007,7 @@ const char *mg_get_mime_type(struct mg_server *server, const char *path) {
     }
   }
 
-  return server->config_options[DEFAULT_MIME_TYPE];
+  return default_mime_type;
 }
 
 static struct uri_handler *find_uri_handler(struct mg_server *server,
@@ -2095,7 +2093,7 @@ static void get_mime_type(const struct mg_server *server, const char *path,
     }
   }
 
-  vec->ptr = mg_get_mime_type((struct mg_server *)server, path);
+  vec->ptr = mg_get_mime_type(path, "text/plain");
   vec->len = strlen(vec->ptr);
 }
 

--- a/mongoose.h
+++ b/mongoose.h
@@ -86,7 +86,7 @@ int mg_printf(struct mg_connection *conn, const char *fmt, ...);
 
 
 const char *mg_get_header(const struct mg_connection *, const char *name);
-const char *mg_get_mime_type(struct mg_server*, const char *file_name);
+const char *mg_get_mime_type(const char *file_name, const char *default_mime_type);
 int mg_get_var(const struct mg_connection *conn, const char *var_name,
                char *buf, size_t buf_len);
 int mg_parse_header(const char *hdr, const char *var_name, char *buf, size_t);


### PR DESCRIPTION
to use when lookup in the internal table fails instead of always returning 'text/plain'

To allow setting a different default mime-type the mg_get_mime_type() api has been
extended to require an mg_server parameter.

Note that using a static global as default mime type wouldn't have allowed us to
control it via a configuration option because there is not global initialization phase
and configuration options are provided (and specific) to each server instance.
This means that different servers can be configured to use a different default mime-type
(which is also a desired behaviour in many scenarios) when lookup fails.
