### PR TITLE
added function to read server param from mg_server

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -4203,3 +4203,8 @@ struct mg_server *mg_create_server(void *server_data) {
 
   return server;
 }
+
+void *mg_get_server_param(struct mg_server* server)
+{
+    return server->server_data;
+}

--- a/mongoose.h
+++ b/mongoose.h
@@ -62,6 +62,7 @@ typedef int (*mg_handler_t)(struct mg_connection *);
 
 // Server management functions
 struct mg_server *mg_create_server(void *server_param);
+void *mg_get_server_param(struct mg_server *);
 void mg_destroy_server(struct mg_server **);
 const char *mg_set_option(struct mg_server *, const char *opt, const char *val);
 unsigned int mg_poll_server(struct mg_server *, int milliseconds);


### PR DESCRIPTION
this is very useful when combining it with mg_start_thread, as only a mg_server object is usually passed
