### PR TITLE
bugfix: set the correct status if we still have pending data

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3876,7 +3876,7 @@ unsigned int mg_poll_server(struct mg_server *server, int milliseconds) {
     if (conn->flags & CONN_LONG_RUNNING) {
       conn->mg_conn.wsbits = conn->flags & CONN_CLOSE ? 1 : 0;
       if (call_request_handler(conn) == MG_REQUEST_PROCESSED) {
-        conn->flags |= CONN_CLOSE;
+        conn->flags |= conn->remote_iobuf.len == 0 ? CONN_CLOSE : CONN_SPOOL_DONE;
       }
     }
     if (conn->flags & CONN_CLOSE || conn->last_activity_time < expire_time) {


### PR DESCRIPTION
A request handler can return MG_REQUEST_PROCESSED after writing some data 
which might be still pending so 'close' should be postponed until the buffer has been emptied
(later in write_to_socket()).

This happens especially with long running connections (CONN_LONG_RUNNING) which 
can queue multiple chunks of data (using either mg_write() or mg_send_data()) when providing a big response.
Returning MG_REQUEST_PROCESSED once done shouldn't immediately close the connection
if there is still data queued in the internal io buffer.
