### PR TITLE
added a new handler callback to be used when the http connection is being closed

### DIFF
--- a/mongoose.h
+++ b/mongoose.h
@@ -67,6 +67,7 @@ void mg_destroy_server(struct mg_server **);
 const char *mg_set_option(struct mg_server *, const char *opt, const char *val);
 unsigned int mg_poll_server(struct mg_server *, int milliseconds);
 void mg_set_request_handler(struct mg_server *, mg_handler_t);
+void mg_set_http_close_handler(struct mg_server *, mg_handler_t);
 void mg_set_http_error_handler(struct mg_server *, mg_handler_t);
 void mg_set_auth_handler(struct mg_server *, mg_handler_t);
 const char **mg_get_valid_option_names(void);


### PR DESCRIPTION
so that in case of connections closed prematurely, the user can still clear resources
eventually bound to the connection using the 'connection_param' member of the
mg_connection structure.
