### PR TITLE
Added embedded auth support, PF_INET --> AF_INET, and conn. open handler

### DIFF
--- a/mongoose.h
+++ b/mongoose.h
@@ -68,6 +68,7 @@ const char *mg_set_option(struct mg_server *, const char *opt, const char *val);
 unsigned int mg_poll_server(struct mg_server *, int milliseconds);
 void mg_set_request_handler(struct mg_server *, mg_handler_t);
 void mg_set_http_close_handler(struct mg_server *, mg_handler_t);
+void mg_set_http_open_handler(struct mg_server *, mg_handler_t);
 void mg_set_http_error_handler(struct mg_server *, mg_handler_t);
 void mg_set_auth_handler(struct mg_server *, mg_handler_t);
 const char **mg_get_valid_option_names(void);
@@ -103,6 +104,7 @@ int mg_parse_multipart(const char *buf, int buf_len,
 void *mg_start_thread(void *(*func)(void *), void *param);
 char *mg_md5(char buf[33], ...);
 int mg_authorize_digest(struct mg_connection *c, FILE *fp);
+int mg_authorize_input(struct mg_connection *c, char *username, char *password, const char *domain);
 
 // Callback function return codes
 enum { MG_REQUEST_NOT_PROCESSED, MG_REQUEST_PROCESSED, MG_REQUEST_CALL_AGAIN };


### PR DESCRIPTION
1. I'm using mongoose as an embedded webserver. This means that
   users set a webserver password and username in the global settings
   of my program. That means that i don't want to rely on additional
   files to use the mongoose authentication functionality. This commit
   allows developers to use an embedded authentication method by calling
   the new mg_authorize_input function with the username, password
   and domain as arguments.
2. The old and considered obsolete PF_INET socket constant has been
   replaced by the AF_INET constant. The code didn't compile on
   FreeBSD 10.0 with the PF_INET constant.
3. Users have the option to set a whitelist in my program. This means
   that all socket connections are checked against this whitelist and
   only those ip addresses that match are kept open. This commit adds
   an additional open handler instead of just the close handler. When
   the open handler returns a different value than 0 the connection
   will be closed.
