### PR TITLE
Fixed 'variable set but not used' warning

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -662,6 +662,8 @@ static void read_from_socket(struct ns_connection *conn) {
         ok = 1;
       }
     }
+#else
+    (void) ret;
 #endif
     DBG(("%p ok=%d", conn, ok));
     if (ok != 0) {


### PR DESCRIPTION
This trick fixes the following warning when NS_ENABLE_SSL is not defined.:
../mongoose.c:646:17: warning: variable ‘ret’ set but not used [-Wunused-but-set-variable]
