### PR TITLE
Remove MONGOOSE_NO_DAV on DAV_AUTH_FILE options

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -1082,9 +1082,7 @@ enum {
   CGI_INTERPRETER,
   CGI_PATTERN,
 #endif
-#ifndef MONGOOSE_NO_DAV
   DAV_AUTH_FILE,
-#endif
   DOCUMENT_ROOT,
 #ifndef MONGOOSE_NO_DIRECTORY_LISTING
   ENABLE_DIRECTORY_LISTING,
@@ -1123,9 +1121,7 @@ static const char *static_config_options[] = {
   "cgi_interpreter", NULL,
   "cgi_pattern", DEFAULT_CGI_PATTERN,
 #endif
-#ifndef MONGOOSE_NO_DAV
   "dav_auth_file", NULL,
-#endif
   "document_root",  NULL,
 #ifndef MONGOOSE_NO_DIRECTORY_LISTING
   "enable_directory_listing", "yes",


### PR DESCRIPTION
Building with -DMONGOOSE_NO_DAV will fail.

```
$ gcc -DMONGOOSE_NO_DAV -I. mongoose.c -o mongoose.o
mongoose.c: In function ‘is_authorized_for_dav’:
mongoose.c:3634:56: error: ‘DAV_AUTH_FILE’ undeclared (first use in this
function)
   const char *auth_file = conn->server->config_options[DAV_AUTH_FILE];
                                                        ^
mongoose.c:3634:56: note: each undeclared identifier is reported only
once for each function it appears in
```
