### PR TITLE
I think that when the socket invalid, the return value should be -1.

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -769,7 +769,7 @@ int ns_server_poll(struct ns_server *server, int milli) {
   time_t current_time = time(NULL);
 
   if (server->listening_sock == INVALID_SOCKET &&
-      server->active_connections == NULL) return 0;
+      server->active_connections == NULL) return -1;
 
   FD_ZERO(&read_set);
   FD_ZERO(&write_set);


### PR DESCRIPTION
For the return value
0:  to tell the caller none connection exist;
the positive number: to tell the caller the connection number
the negative number: to tell the caller some error for the server
