### PR TITLE
Return the correct listening_port when binding to an IP with port 0

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -4662,7 +4662,15 @@ const char *mg_set_option(struct mg_server *server, const char *name,
     if (port < 0) {
       error_msg = "Cannot bind to port";
     } else {
-      if (!strcmp(value, "0")) {
+      size_t off = strlen(value);
+      off -= (off >= 2) ? 2 : 0;
+      if (!strcmp(value + off, ":0")) {
+        char buf[60]; // Space for a full IPV6 addr + port
+        mg_snprintf(buf, sizeof(buf), "%s", value);
+        mg_snprintf(buf + off, sizeof(buf) - off, ":%d", port);
+        free(*v);
+        *v = mg_strdup(buf);
+      } else if (!strcmp(value, "0")) {
         char buf[10];
         mg_snprintf(buf, sizeof(buf), "%d", port);
         free(*v);


### PR DESCRIPTION
mg_set_option(server, "listening_port", "127.0.0.1:0") works like intended, binding the server to the local host only and selecting a random free port. But mg_get_option(server, "listening_port") will return "127.0.0.1:0" instead of "127.0.0.1:50230" or whatever port was used. The attached patch fixes this behavior and makes it possible to retrieve the real port. The buffer is 60 bytes large to host any IPV6 address (max 45 chars) + 15 additional chars for the port number and the colon.
