### PR TITLE
Disallow WebDAV MKCOL/PUT/DELETE requests to protected files

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -4266,10 +4266,10 @@ static void open_local_endpoint(struct connection *conn, int skip_user) {
     close_local_endpoint(conn);
 #endif
 #ifndef MONGOOSE_NO_DAV
-  } else if (!strcmp(conn->mg_conn.request_method, "PROPFIND")) {
-    handle_propfind(conn, path, &st, exists);
   } else if (must_hide_file(conn, path)) {
     send_http_error(conn, 404, NULL);
+  } else if (!strcmp(conn->mg_conn.request_method, "PROPFIND")) {
+    handle_propfind(conn, path, &st, exists);
   } else if (!strcmp(conn->mg_conn.request_method, "MKCOL")) {
     handle_mkcol(conn, path);
   } else if (!strcmp(conn->mg_conn.request_method, "DELETE")) {


### PR DESCRIPTION
Currently protected paths can be modified by authorized user (or anyone, if authorization is disabled).
