### PR TITLE
Avoid unconditional definition of _LARGEFILE_SOURCE

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -49,7 +49,9 @@
 #define _XOPEN_SOURCE 600       // For flockfile() on Linux
 #define __STDC_FORMAT_MACROS    // <inttypes.h> wants this for C++
 #define __STDC_LIMIT_MACROS     // C++ wants that for INT64_MAX
+#ifndef _LARGEFILE_SOURCE
 #define _LARGEFILE_SOURCE       // Enable fseeko() and ftello() functions
+#endif
 #define _FILE_OFFSET_BITS 64    // Enable 64-bit file offsets
 
 #ifdef _MSC_VER


### PR DESCRIPTION
On some build systems (i.e. Buildroot), _LARGEFILE_SOURCE is defined
at "higher level" as default CFLAG definition.
This fix avoids the following compilation warning:

mongoose-5.4/mongoose.c:52:0: warning: "_LARGEFILE_SOURCE" redefined [enabled by default]
 #define _LARGEFILE_SOURCE       // Enable fseeko() and ftello() functions
 ^
<command-line>:0:0: note: this is the location of the previous definition
