### PR TITLE
Fixed build warning of signed/unsigned conditional expression

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3556,7 +3556,7 @@ static void handle_put(struct connection *conn, const char *path) {
 
 static void forward_put_data(struct connection *conn) {
   struct iobuf *io = &conn->ns_conn->recv_iobuf;
-  size_t k = conn->cl < (int64_t) io->len ? conn->cl : io->len;   // To write
+  size_t k = conn->cl < (int64_t) io->len ? conn->cl : (int64_t) io->len;   // To write
   int n = write(conn->endpoint.fd, io->buf, k);   // Write them!
   if (n > 0) {
     iobuf_remove(io, n);


### PR DESCRIPTION
When building mongoose with this command line

gcc -c -m64 -Wall -W mongoose.c -o mongoose

the following build warning appears:

mongoose.c: In function ‘forward_put_data’:
mongoose.c:3559:54: warning: signed and unsigned type in conditional expression [-Wsign-compare]
   size_t k = conn->cl < (int64_t) io->len ? conn->cl : io->len;   // To write
