### PR TITLE
Better komma detection in parse_header

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -4043,7 +4043,7 @@ static int parse_header(const char *str, int str_len, const char *var_name,
     s += n + 1;
     if (*s == '"' || *s == '\'') ch = *s++;
     p = s;
-    while (p < end && p[0] != ch && p[0] != ',' && len < (int) buf_size) {
+    while (p < end && p[0] != ch && (!(p[0] == ',' && (strlen(p) > 1 && p[1] == ' ')) || p[0] != ',') && len < (int) buf_size) {
       if (p[0] == '\\' && p[1] == ch) p++;
       buf[len++] = *p++;
     }


### PR DESCRIPTION
The komma is not the most reliable way to check if a HTTP headers variable ends. Take this case:

http://x.x.x.x/?name=foo,bar

However, the current header parsing, thinks the uri variable ends after the word foo because of the komma. To properly determine if a variable ends, you should not just look at the komma, but instead check the komma space sequence. Spaces are not allowed in HTTP headers so they will automatically be translated to %20. Therefor, you can be sure that a komma space sequence actually means the end of the variable.

This bug made it impossible to authenticate when using these kinds of GET urls.
