### PR TITLE
Added #define's for deprecated POSIX names

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -1247,10 +1247,15 @@ void ns_mgr_free(struct ns_mgr *s) {
 #define fopen(x, y) mg_fopen((x), (y))
 #define open(x, y, z) mg_open((x), (y), (z))
 #define close(x) _close(x)
+#define fileno(x) _fileno(x)
 #define lseek(x, y, z) _lseeki64((x), (y), (z))
+#define read(x, y, z) _read((x), (y), (z))
+#define write(x, y, z) _write((x), (y), (z))
 #define popen(x, y) _popen((x), (y))
 #define pclose(x) _pclose(x)
 #define mkdir(x, y) _mkdir(x)
+#define rmdir(x) _rmdir(x)
+#define strdup(x) _strdup(x)
 #ifndef __func__
 #define STRX(x) #x
 #define STR(x) STRX(x)


### PR DESCRIPTION
Without these #define's to the current ISO C++ conformant names VS2013 throws the error C4996. E.g.:

> error C4996: 'rmdir': The POSIX name for this item is deprecated. Instead, use the ISO C++ conformant name: _rmdir. See online help for details.

There is a recent commit (https://github.com/cesanta/mongoose/commit/a6598a12781c395c87f7ff44a9d0a675b92da62a) related with this issue, but I wonder why weren't the other functions included too.
