### PR TITLE
Conditionally include dirent.h and dlfcn.h

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -1274,8 +1274,13 @@ typedef HANDLE process_id_t;
 
 #else                    ////////////// UNIX specific defines and includes
 
+#if !defined(MONGOOSE_NO_FILESYSTEM) &&\
+    (!defined(MONGOOSE_NO_DAV) || !defined(MONGOOSE_NO_DIRECTORY_LISTING))
 #include <dirent.h>
+#endif
+#if !defined(MONGOOSE_NO_FILESYSTEM) && !defined(MONGOOSE_NO_DL)
 #include <dlfcn.h>
+#endif
 #include <inttypes.h>
 #include <pwd.h>
 #define O_BINARY 0


### PR DESCRIPTION
If you do not have a filesystem or do not support dav or
dynamic loading, the corresponding header files need not
be included (some environments might not have them).
