### PR TITLE
Add a MONGOOSE_NO_URL_DECODE flag

### DIFF
--- a/docs/Embed.md
+++ b/docs/Embed.md
@@ -146,6 +146,7 @@ all Net Skeleton functions will be available too.
     -DMONGOOSE_NO_CGI           Disable CGI support
     -DMONGOOSE_NO_DAV           Disable WebDAV support
                                 (PUT, DELETE, MKCOL, PROPFIND methods)
+    -DMONGOOSE_NO_URL_DECODE    Disables decoding of URL pathes
     -DMONGOOSE_NO_DIRECTORY_LISTING  Disable directory listing
     -DMONGOOSE_NO_FILESYSTEM    Disables all file IO, serving from memory only
     -DMONGOOSE_NO_LOGGING       Disable access/error logging

--- a/mongoose.c
+++ b/mongoose.c
@@ -2402,7 +2402,7 @@ static int is_valid_http_method(const char *s) {
 // HTTP request components, header names and header values.
 // Note that len must point to the last \n of HTTP headers.
 static int parse_http_message(char *buf, int len, struct mg_connection *ri) {
-  int is_request, n;
+  int is_request;
 
   // Reset the connection. Make sure that we don't touch fields that are
   // set elsewhere: remote_ip, remote_port, server_param
@@ -2436,8 +2436,12 @@ static int parse_http_message(char *buf, int len, struct mg_connection *ri) {
     if ((ri->query_string = strchr(ri->uri, '?')) != NULL) {
       *(char *) ri->query_string++ = '\0';
     }
-    n = (int) strlen(ri->uri);
-    mg_url_decode(ri->uri, n, (char *) ri->uri, n + 1, 0);
+#ifndef MONGOOSE_NO_URL_DECODE
+    {
+        int n = (int) strlen(ri->uri);
+        mg_url_decode(ri->uri, n, (char *) ri->uri, n + 1, 0);
+    }
+#endif
     if (*ri->uri == '/' || *ri->uri == '.') {
       remove_double_dots_and_double_slashes((char *) ri->uri);
     }


### PR DESCRIPTION
For certain applications, it is essential that
http://host.name:80/path/with/inline%2fslash/
and
http://host.name:80/path/with/inline/slash/
are different.
Currently, mongoose always decodes the URL from the HTTP header,
thus irreversibly loosing that distinction.
This flag gives the user a chance to change this behaviour.

mongoose.c:
    Do not decode the request uri path if MONGOOSE_NO_URL_DECODE
    is defined.

docs/Embed.md:
    Document the MONGOOSE_NO_URL_DECODE flag.
