### PR TITLE
Allow for compilation in Visual Studio with NS_ENABLE_IPV6.

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -79,6 +79,7 @@
 #ifdef _MSC_VER
 #pragma comment(lib, "ws2_32.lib")    // Linking with winsock library
 #endif
+#include <Ws2tcpip.h>
 #include <windows.h>
 #include <process.h>
 #ifndef EINPROGRESS
@@ -2961,9 +2962,9 @@ size_t mg_websocket_write(struct mg_connection *conn, int opcode,
       copy_len = 4 + data_len;
     } else {
       // 64-bit length field
-      copy[1] = 127;
       const uint32_t hi = htonl((uint32_t) ((uint64_t) data_len >> 32));
       const uint32_t lo = htonl(data_len & 0xffffffff);
+      copy[1] = 127;
       memcpy(copy+2,&hi,sizeof(hi));
       memcpy(copy+6,&lo,sizeof(lo));
       memcpy(copy + 10, data, data_len);


### PR DESCRIPTION
This adds #include \<Ws2tcpip.h\>, which is required for IPv6 support in VS9.
Also, VS9 does not allow c99 in-block declarations, so there's a change to move an assignment to be after some const declarations.

Tested with VS 2008 x86 and VS 2013 x64 (and x86) by running:

    mhttpd.exe -listening_port "[::1]:8080"

Tested with IE11 and Chrome 40.
