### PR TITLE
websocket_ssl_proxy sample for polarsll

### DIFF
--- a/examples/websocket_ssl_proxy/Makefile
+++ b/examples/websocket_ssl_proxy/Makefile
@@ -2,14 +2,26 @@
 # All rights reserved
 
 PROG = ws_ssl
-CFLAGS = -W -Wall -I../.. -I. -pthread -g -O0 $(CFLAGS_EXTRA)
+CFLAGS = -W -Wall -I../.. -I. -pthread -g -O0 -DNS_ENABLE_SSL -DSSL_WRAPPER_USE_AS_LIBRARY $(CFLAGS_EXTRA)
+LDFLAGS = -lssl
 SOURCES = ws_ssl.c ../../mongoose.c ssl_wrapper.c
+
+# PolarSSL paths and flags
+POLARSSL_PATH = /usr/local
+POLARSSLCOMPAT_PATH = ./../../../polar
+SOURCES_POLAR = $(SOURCES) $(POLARSSLCOMPAT_PATH)/polarssl_compat.c
+INCDIR_POLAR = -I$(POLARSSLCOMPAT_PATH) -I$(POLARSSL_PATH)/include
+LDFLAGS_POLAR = -L$(POLARSSL_PATH)/lib -lmbedtls
+CFLAGS_POLAR = $(CFLAGS) $(INCDIR_POLAR)
+#
 
 all: $(PROG)
 
 $(PROG): $(SOURCES)
-	$(CC) -o $(PROG) $(SOURCES) \
-		-DNS_ENABLE_SSL -DSSL_WRAPPER_USE_AS_LIBRARY -lssl $(CFLAGS)
+	$(CC) -o $(PROG) $(SOURCES) $(LDFLAGS) $(CFLAGS)
+
+polarssl: $(SOURCES_POLAR)
+	$(CC) -o $(PROG) $(SOURCES_POLAR) $(LDFLAGS_POLAR) $(CFLAGS_POLAR)
 
 clean:
 	rm -rf $(PROG) *.exe *.dSYM *.obj *.exp .*o *.lib


### PR DESCRIPTION
Hi @cpq.

I've adopted websocket_ssl_proxy (its makefile) sample for polarssl.
By default (i.e. `make`) it builds with openssl. 
To build against polarssl use `make polarssl`

I prepared makefile for polar/polar_compat as well, I'll send PR then this one will be merged coz they are linked. 

As you can see, I've sent PR to master. I think we should make all changes here and then backport to another places (?).

Web_server will be next, I've started from websocket_ssl_proxy coz it was already completed, I've just changed makefile