### PR TITLE
fix compiler warnings for 64 bit compilation

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -262,7 +262,7 @@ struct ns_connection *ns_bind(struct ns_mgr *, const char *,
 struct ns_connection *ns_connect(struct ns_mgr *, const char *,
                                  ns_callback_t, void *);
 
-int ns_send(struct ns_connection *, const void *buf, int len);
+int ns_send(struct ns_connection *, const void *buf, size_t len);
 int ns_printf(struct ns_connection *, const char *fmt, ...);
 int ns_vprintf(struct ns_connection *, const char *fmt, va_list ap);
 
@@ -1017,14 +1017,14 @@ static void ns_write_to_socket(struct ns_connection *conn) {
   }
 }
 
-int ns_send(struct ns_connection *conn, const void *buf, int len) {
+int ns_send(struct ns_connection *conn, const void *buf, size_t len) {
   return (int) ns_out(conn, buf, len);
 }
 
 static void ns_handle_udp(struct ns_connection *ls) {
   struct ns_connection nc;
   char buf[NS_UDP_RECEIVE_BUFFER_SIZE];
-  int n;
+  ssize_t n;
   socklen_t s_len = sizeof(nc.sa);
 
   memset(&nc, 0, sizeof(nc));
@@ -1381,7 +1381,7 @@ typedef pid_t process_id_t;
 
 struct vec {
   const char *ptr;
-  int len;
+  uintptr_t len;
 };
 
 // For directory listing and WevDAV support
@@ -1501,7 +1501,7 @@ struct connection {
   char *request;
   int64_t num_bytes_recv; // Total number of bytes received
   int64_t cl;             // Reply content length, for Range support
-  int request_len;  // Request length, including last \r\n after last header
+  ssize_t request_len;  // Request length, including last \r\n after last header
 };
 
 #define MG_CONN_2_CONN(c) ((struct connection *) ((char *) (c) - \
@@ -1743,7 +1743,7 @@ static int mg_snprintf(char *buf, size_t buflen, const char *fmt, ...) {
 //   -1  if request is malformed
 //    0  if request is not yet fully buffered
 //   >0  actual request length, including last \r\n\r\n
-static int get_request_len(const char *s, int buf_len) {
+static int get_request_len(const char *s, size_t buf_len) {
   const unsigned char *buf = (unsigned char *) s;
   int i;
 
@@ -1785,7 +1785,7 @@ static char *skip(char **buf, const char *delimiters) {
 // Parse HTTP headers from the given buffer, advance buffer to the point
 // where parsing stopped.
 static void parse_http_headers(char **buf, struct mg_connection *ri) {
-  size_t i;
+  int i;
 
   for (i = 0; i < ARRAY_SIZE(ri->http_headers); i++) {
     ri->http_headers[i].name = skip(buf, ": ");
@@ -2336,13 +2336,13 @@ static void on_cgi_data(struct ns_connection *nc) {
   // If reply has not been parsed yet, parse it
   if (conn->ns_conn->flags & NSF_BUFFER_BUT_DONT_SEND) {
     struct iobuf *io = &conn->ns_conn->send_iobuf;
-    int s_len = sizeof(cgi_status) - 1;
-    int len = get_request_len(io->buf + s_len, io->len - s_len);
+    size_t s_len = sizeof(cgi_status) - 1;
+    ssize_t len = get_request_len(io->buf + s_len, io->len - s_len);
     char buf[MAX_REQUEST_SIZE], *s = buf;
 
     if (len == 0) return;
 
-    if (len < 0 || len > (int) sizeof(buf)) {
+    if (len < 0 || len > sizeof(buf)) {
       len = io->len;
       iobuf_remove(io, io->len);
       send_http_error(conn, 500, "CGI program sent malformed headers: [%.*s]",
@@ -2436,8 +2436,8 @@ static void remove_double_dots_and_double_slashes(char *s) {
   *p = '\0';
 }
 
-int mg_url_decode(const char *src, int src_len, char *dst,
-                  int dst_len, int is_form_url_encoded) {
+int mg_url_decode(const char *src, size_t src_len, char *dst,
+                  size_t dst_len, int is_form_url_encoded) {
   int i, j, a, b;
 #define HEXTOI(x) (isdigit(x) ? x - '0' : x - 'W')
 
@@ -2471,7 +2471,7 @@ static int is_valid_http_method(const char *s) {
 // This function modifies the buffer by NUL-terminating
 // HTTP request components, header names and header values.
 // Note that len must point to the last \n of HTTP headers.
-static int parse_http_message(char *buf, int len, struct mg_connection *ri) {
+static size_t parse_http_message(char *buf, size_t len, struct mg_connection *ri) {
   int is_request, n;
 
   // Reset the connection. Make sure that we don't touch fields that are
@@ -2553,7 +2553,7 @@ const char *mg_get_header(const struct mg_connection *ri, const char *s) {
 }
 
 // Perform case-insensitive match of string against pattern
-int mg_match_prefix(const char *pattern, int pattern_len, const char *str) {
+int mg_match_prefix(const char *pattern, ssize_t pattern_len, const char *str) {
   const char *or_str;
   int len, res, i = 0, j = 0;
 
@@ -2644,12 +2644,12 @@ static int convert_uri_to_file_name(struct connection *conn, char *buf,
 #endif
   const char *uri = conn->mg_conn.uri;
   const char *domain = mg_get_header(&conn->mg_conn, "Host");
-  int match_len, root_len = root == NULL ? 0 : strlen(root);
+  size_t match_len, root_len = root == NULL ? 0 : strlen(root);
 
   // Perform virtual hosting rewrites
   if (rewrites != NULL && domain != NULL) {
     const char *colon = strchr(domain, ':');
-    int domain_len = colon == NULL ? (int) strlen(domain) : colon - domain;
+    ssize_t domain_len = colon == NULL ? strlen(domain) : colon - domain;
 
     while ((rewrites = next_option(rewrites, &a, &b)) != NULL) {
       if (a.len > 1 && a.ptr[0] == '@' && a.len == domain_len + 1 &&
@@ -2709,7 +2709,7 @@ static int should_keep_alive(const struct mg_connection *conn) {
      (header == NULL && http_version && !strcmp(http_version, "1.1")));
 }
 
-size_t mg_write(struct mg_connection *c, const void *buf, int len) {
+size_t mg_write(struct mg_connection *c, const void *buf, size_t len) {
   struct connection *conn = MG_CONN_2_CONN(c);
   ns_send(conn->ns_conn, buf, len);
   return conn->ns_conn->send_iobuf.len;
@@ -2869,8 +2869,8 @@ static void SHA1Init(SHA1_CTX *context) {
 }
 
 static void SHA1Update(SHA1_CTX *context, const unsigned char *data,
-                       uint32_t len) {
-  uint32_t i, j;
+                       size_t len) {
+  size_t i, j;
 
   j = context->count[0];
   if ((context->count[0] += len << 3) < j)
@@ -2958,7 +2958,7 @@ static void send_websocket_handshake(struct mg_connection *conn,
   mg_write(conn, buf, strlen(buf));
 }
 
-static int deliver_websocket_frame(struct connection *conn) {
+static size_t deliver_websocket_frame(struct connection *conn) {
   // Having buf unsigned char * is important, as it is used below in arithmetic
   unsigned char *buf = (unsigned char *) conn->ns_conn->recv_iobuf.buf;
   size_t i, len, buf_len = conn->ns_conn->recv_iobuf.len, frame_len = 0,
@@ -3236,7 +3236,8 @@ static int find_index_file(struct connection *conn, char *path,
   const char *list = conn->server->config_options[INDEX_FILES];
   file_stat_t st;
   struct vec filename_vec;
-  size_t n = strlen(path), found = 0;
+  size_t n = strlen(path);
+  int found = 0;
 
   // The 'path' given to us points to the directory. Remove all trailing
   // directory separator characters from the end of the path, and
@@ -3494,7 +3495,7 @@ static int scan_directory(struct connection *conn, const char *dir,
   return arr_ind;
 }
 
-int mg_url_encode(const char *src, size_t s_len, char *dst, size_t dst_len) {
+size_t mg_url_encode(const char *src, size_t s_len, char *dst, size_t dst_len) {
   static const char *dont_escape = "._-$,;~()";
   static const char *hex = "0123456789abcdef";
   size_t i = 0, j = 0;
@@ -3791,7 +3792,7 @@ static void handle_put(struct connection *conn, const char *path) {
 static void forward_put_data(struct connection *conn) {
   struct iobuf *io = &conn->ns_conn->recv_iobuf;
   size_t k = conn->cl < (int64_t) io->len ? conn->cl : (int64_t) io->len;   // To write
-  int n = write(conn->endpoint.fd, io->buf, k);   // Write them!
+  size_t n = write(conn->endpoint.fd, io->buf, k);   // Write them!
   if (n > 0) {
     iobuf_remove(io, n);
     conn->cl -= n;
@@ -4178,9 +4179,10 @@ static int is_dav_request(const struct connection *conn) {
 }
 #endif // MONGOOSE_NO_AUTH
 
-static int parse_header(const char *str, int str_len, const char *var_name,
+static int parse_header(const char *str, size_t str_len, const char *var_name,
                         char *buf, size_t buf_size) {
-  int ch = ' ', ch1 = ',', len = 0, n = strlen(var_name);
+  int ch = ' ', ch1 = ',', len = 0;
+  size_t n = strlen(var_name);
   const char *p, *end = str + str_len, *s = NULL;
 
   if (buf != NULL && buf_size > 0) buf[0] = '\0';
@@ -4221,7 +4223,7 @@ static void send_ssi_file(struct mg_connection *, const char *, FILE *, int);
 
 static void send_file_data(struct mg_connection *conn, FILE *fp) {
   char buf[IOBUF_SIZE];
-  int n;
+  size_t n;
   while ((n = fread(buf, 1, sizeof(buf), fp)) > 0) {
     mg_write(conn, buf, n);
   }
@@ -4893,7 +4895,7 @@ static void close_local_endpoint(struct connection *conn) {
 
 static void transfer_file_data(struct connection *conn) {
   char buf[IOBUF_SIZE];
-  int n;
+  size_t n;
 
   // If output buffer is too big, don't send anything. Wait until
   // mongoose drains already buffered data to the client.
@@ -4914,7 +4916,7 @@ static void transfer_file_data(struct connection *conn) {
   }
 }
 
-int mg_poll_server(struct mg_server *server, int milliseconds) {
+time_t mg_poll_server(struct mg_server *server, int milliseconds) {
   return ns_mgr_poll(&server->ns_mgr, milliseconds);
 }
 

--- a/mongoose.h
+++ b/mongoose.h
@@ -88,7 +88,7 @@ enum {
 struct mg_server *mg_create_server(void *server_param, mg_handler_t handler);
 void mg_destroy_server(struct mg_server **);
 const char *mg_set_option(struct mg_server *, const char *opt, const char *val);
-int mg_poll_server(struct mg_server *, int milliseconds);
+time_t mg_poll_server(struct mg_server *, int milliseconds);
 const char **mg_get_valid_option_names(void);
 const char *mg_get_option(const struct mg_server *server, const char *name);
 void mg_copy_listeners(struct mg_server *from, struct mg_server *to);
@@ -102,7 +102,7 @@ void mg_send_status(struct mg_connection *, int status_code);
 void mg_send_header(struct mg_connection *, const char *name, const char *val);
 size_t mg_send_data(struct mg_connection *, const void *data, int data_len);
 size_t mg_printf_data(struct mg_connection *, const char *format, ...);
-size_t mg_write(struct mg_connection *, const void *buf, int len);
+size_t mg_write(struct mg_connection *, const void *buf, size_t len);
 size_t mg_printf(struct mg_connection *conn, const char *fmt, ...);
 
 size_t mg_websocket_write(struct mg_connection *, int opcode,
@@ -128,8 +128,8 @@ int mg_parse_multipart(const char *buf, int buf_len,
 void *mg_start_thread(void *(*func)(void *), void *param);
 char *mg_md5(char buf[33], ...);
 int mg_authorize_digest(struct mg_connection *c, FILE *fp);
-int mg_url_encode(const char *src, size_t s_len, char *dst, size_t dst_len);
-int mg_url_decode(const char *src, int src_len, char *dst, int dst_len, int);
+size_t mg_url_encode(const char *src, size_t s_len, char *dst, size_t dst_len);
+int mg_url_decode(const char *src, size_t src_len, char *dst, size_t dst_len, int);
 int mg_terminate_ssl(struct mg_connection *c, const char *cert);
 int mg_forward(struct mg_connection *c, const char *addr);
 void *mg_mmap(FILE *fp, size_t size);


### PR DESCRIPTION
I use mongoose in my program (https://bitbucket.org/dmilligan/mlvfs), it's really great and easy to use, thanks for all the hard work! 

I compile for 64-bit and I get a lot of compiler warnings, mostly due to the fact that int and size_t are sometimes used interchangeably in mongoose, but on 64-bit systems they are different sizes. Mostly this is just a matter of correcting function prototypes or variable declarations. I see you are already using size_t somewhat, so I assume this won't cause any issues. I did need to use uintptr_t in one place to be technically correct (since size_t isn't necessarily uint64_t even on 64 bit systems, though it is usually), but IDK how portable that definition is.