### PR TITLE
Fix remove_double_dots_and_double_slashes removing all the dots leading http server to serve wrong URI

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -2428,7 +2428,8 @@ static void remove_double_dots_and_double_slashes(char *s) {
       // Skip all following slashes, backslashes and double-dots
       while (s[0] != '\0') {
         if (s[0] == '/' || s[0] == '\\') { s++; }
-        else if (s[0] == '.' && s[1] == '.') { s += 2; }
+        else if (s[0] == '.' && (s[1] == '/' || s[1] == '\\')) { s += 2; }
+        else if (s[0] == '.' && s[1] == '.' && (s[2] == '/' || s[2] == '\\')) { s += 3; }
         else { break; }
       }
     }

--- a/mongoose.c
+++ b/mongoose.c
@@ -2429,6 +2429,7 @@ static void remove_double_dots_and_double_slashes(char *s) {
       while (s[0] != '\0') {
         if (s[0] == '/' || s[0] == '\\') { s++; }
         else if (s[0] == '.' && (s[1] == '/' || s[1] == '\\')) { s += 2; }
+		else if (s[0] == '.' && s[1] == '.' && s[2] == '\0') { s += 2; }
         else if (s[0] == '.' && s[1] == '.' && (s[2] == '/' || s[2] == '\\')) { s += 3; }
         else { break; }
       }

--- a/mongoose.c
+++ b/mongoose.c
@@ -2429,7 +2429,7 @@ static void remove_double_dots_and_double_slashes(char *s) {
       while (s[0] != '\0') {
         if (s[0] == '/' || s[0] == '\\') { s++; }
         else if (s[0] == '.' && (s[1] == '/' || s[1] == '\\')) { s += 2; }
-		else if (s[0] == '.' && s[1] == '.' && s[2] == '\0') { s += 2; }
+        else if (s[0] == '.' && s[1] == '.' && s[2] == '\0') { s += 2; }
         else if (s[0] == '.' && s[1] == '.' && (s[2] == '/' || s[2] == '\\')) { s += 3; }
         else { break; }
       }

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -198,17 +198,19 @@ static const char *test_match_prefix(void) {
 }
 
 static const char *test_remove_double_dots() {
-  struct { char before[20], after[20]; } data[] = {
+  struct { char before[30], after[30]; } data[] = {
     {"////a", "/a"},
-    {"/.....", "/."},
-    {"/......", "/"},
+    {"/.....", "/....."},
+    {"/......", "/......"},
     {"...", "..."},
-    {"/...///", "/./"},
+    {"/...///", "/.../"},
     {"/a...///", "/a.../"},
     {"/.x", "/.x"},
     {"/\\", "/"},
     {"/a\\", "/a\\"},
-    {"/a\\\\...", "/a\\."},
+    {"/a\\\\...", "/a\\..."},
+    {"foo/x..y/././y/../../..", "foo/x..y/y/"},
+    {"foo/..x", "foo/..x"},
   };
   size_t i;
 


### PR DESCRIPTION
If the uri is something like '/js/...jquery.js', remove_double_dots_and_double_slashes will remove the 3 dots and the http server will serves the /js/jquery.js file.
remove_double_dots_and_double_slashes should check if a dot or double dots is followed by a slash (or backslash) and only remove this to avoid disclosure attack.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/485)
<!-- Reviewable:end -->
