### PR TITLE
Added PATCH to list of valid HTTP Methods.

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -2469,7 +2469,8 @@ int mg_url_decode(const char *src, size_t src_len, char *dst,
 static int is_valid_http_method(const char *s) {
   return !strcmp(s, "GET") || !strcmp(s, "POST") || !strcmp(s, "HEAD") ||
     !strcmp(s, "CONNECT") || !strcmp(s, "PUT") || !strcmp(s, "DELETE") ||
-    !strcmp(s, "OPTIONS") || !strcmp(s, "PROPFIND") || !strcmp(s, "MKCOL");
+    !strcmp(s, "OPTIONS") || !strcmp(s, "PROPFIND") || !strcmp(s, "MKCOL") || 
+    !strcmp(s, "PATCH");
 }
 
 // Parse HTTP request, fill in mg_request structure.


### PR DESCRIPTION
The PATCH method is often used in REST API's.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/492)
<!-- Reviewable:end -->
