### PR TITLE
Correctly handle _CRT_SECURE_NO_WARNINGS already being set in project se...

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -44,7 +44,9 @@
 #undef _UNICODE                 // Use multibyte encoding on Windows
 #define _MBCS                   // Use multibyte encoding on Windows
 #define _INTEGRAL_MAX_BITS 64   // Enable _stati64() on Windows
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS // Disable deprecation warning in VS2005+
+#endif
 #undef WIN32_LEAN_AND_MEAN      // Let windows.h always include winsock2.h
 #ifdef __Linux__
 #define _XOPEN_SOURCE 600       // For flockfile() on Linux


### PR DESCRIPTION
We have _CRT_SECURE_NO_WARNINGS set in out project settings, so I've wrapped the define in an ifndef directive so it doesn't get defined twice.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/493)
<!-- Reviewable:end -->
