### PR TITLE
safety belt : scan_directory() can return without setting arr to a valid value

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3639,12 +3639,14 @@ static void send_directory_listing(struct connection *conn, const char *dir) {
               sort_direction, sort_direction, sort_direction);
 
   num_entries = scan_directory(conn, dir, &arr);
-  qsort(arr, num_entries, sizeof(arr[0]), compare_dir_entries);
-  for (i = 0; i < num_entries; i++) {
-    print_dir_entry(&arr[i]);
-    NS_FREE(arr[i].file_name);
+  if (arr) {
+      qsort(arr, num_entries, sizeof(arr[0]), compare_dir_entries);
+      for (i = 0; i < num_entries; i++) {
+        print_dir_entry(&arr[i]);
+        NS_FREE(arr[i].file_name);
+      }
+      NS_FREE(arr);
   }
-  NS_FREE(arr);
 
   write_terminating_chunk(conn);
   close_local_endpoint(conn);


### PR DESCRIPTION
reported by the clang static analyser ... note that the fault path might be incomplete (perhaps the error should be reported up instead of just ignoring it)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/501)
<!-- Reviewable:end -->
