### PR TITLE
Reverting (socket < 0) checks to avoid Windows build failure.

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -1060,7 +1060,7 @@ static void ns_handle_udp(struct ns_connection *ls) {
 }
 
 static void ns_add_to_set(sock_t sock, fd_set *set, sock_t *max_fd) {
-  if ( (sock != INVALID_SOCKET) && (sock >= 0) && (sock < FD_SETSIZE) ) {
+  if ( (sock != INVALID_SOCKET) && (sock < FD_SETSIZE) ) {
     FD_SET(sock, set);
     if (*max_fd == INVALID_SOCKET || sock > *max_fd) {
       *max_fd = sock;
@@ -1971,9 +1971,9 @@ struct threadparam {
 };
 
 static int wait_until_ready(sock_t sock, int for_read) {
-  if ( (sock < 0) || (sock >= FD_SETSIZE) )
-    return 0;
   fd_set set;
+  if ( (sock == INVALID_SOCKET) || (sock >= FD_SETSIZE) )
+    return 0;
   FD_ZERO(&set);
   FD_SET(sock, &set);
   select(sock + 1, for_read ? &set : 0, for_read ? 0 : &set, 0, 0);


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/504)
<!-- Reviewable:end -->
