### PR TITLE
Inspect POST buffer in mg_get_var() only if first call of get_var() returns -1

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -168,7 +168,7 @@ Changes in pre-compiled binaries:
     since mongoose buffers all data prior to calling the callback
    * keep-alive support is the default
    * Dropped SSI support and throttling support
-   *  Several configuraition parameters are gone:
+   *  Several configuration parameters are gone:
     *  `cgi_environment` (replaced with MONGOOSE_CGI),
     *  `protect_uri` (not useful)
     *  `ssi_pattern` (SSI support is gone)
@@ -214,5 +214,5 @@ Changes in pre-compiled binaries:
   *  Couple of bugfixes, thanks to contributors
 
 
-Eearlier release notes could be found by searching
+Earlier release notes could be found by searching
 [Mongoose mailing list](https://groups.google.com/forum/#!forum/mongoose-users)

--- a/mongoose.c
+++ b/mongoose.c
@@ -5043,7 +5043,7 @@ int mg_get_var(const struct mg_connection *conn, const char *name,
                char *dst, size_t dst_len) {
   int len = get_var(conn->query_string, conn->query_string == NULL ? 0 :
                     strlen(conn->query_string), name, dst, dst_len);
-  if (len < 0) {
+  if (len == -1) {
     len = get_var(conn->content, conn->content_len, name, dst, dst_len);
   }
   return len;

--- a/mongoose.c
+++ b/mongoose.c
@@ -1403,7 +1403,7 @@ struct dir_entry {
   file_stat_t st;
 };
 
-// NOTE(lsm): this enum shoulds be in sync with the config_options.
+// NOTE(lsm): this enum should be in sync with the config_options.
 enum {
   ACCESS_CONTROL_LIST,
 #ifndef MONGOOSE_NO_FILESYSTEM
@@ -1993,7 +1993,7 @@ static void *push_to_stdin(void *arg) {
       if (!WriteFile(tp->hPipe, buf + sent, n - sent, &k, 0)) stop = 1;
     }
   }
-  DBG(("%s", "FORWARED EVERYTHING TO CGI"));
+  DBG(("%s", "FORWARDED EVERYTHING TO CGI"));
   CloseHandle(tp->hPipe);
   NS_FREE(tp);
   _endthread();
@@ -2504,7 +2504,7 @@ static size_t parse_http_message(char *buf, size_t len,
 
   buf[len - 1] = '\0';
 
-  // RFC says that all initial whitespaces should be ingored
+  // RFC says that all initial whitespaces should be ignored
   while (*buf != '\0' && isspace(* (unsigned char *) buf)) {
     buf++;
   }
@@ -3514,11 +3514,11 @@ static int scan_directory(struct connection *conn, const char *dir,
     }
     mg_snprintf(path, sizeof(path), "%s%c%s", dir, '/', dp->d_name);
 
-    // Resize the array if nesessary
+    // Resize the array if necessary
     if (arr_ind >= arr_size) {
       if ((p = (struct dir_entry *)
            NS_REALLOC(*arr, (inc + arr_size) * sizeof(**arr))) != NULL) {
-        // Memset new chunk to zero, otherwize st_mtime will have garbage which
+        // Memset new chunk to zero, otherwise st_mtime will have garbage which
         // can make strftime() segfault, see
         // http://code.google.com/p/mongoose/issues/detail?id=79
         memset(p + arr_size, 0, sizeof(**arr) * inc);
@@ -4291,7 +4291,7 @@ static void do_ssi_include(struct mg_connection *conn, const char *ssi,
     mg_snprintf(path, sizeof(path), "%s", file_name);
   } else if (sscanf(tag, " file=\"%[^\"]\"", file_name) == 1 ||
              sscanf(tag, " \"%[^\"]\"", file_name) == 1) {
-    // File name is relative to the currect document
+    // File name is relative to the current document
     mg_snprintf(path, sizeof(path), "%s", ssi);
     if ((p = strrchr(path, '/')) != NULL) {
       p[1] = '\0';


### PR DESCRIPTION
In mg_get_var() the first call of get_var() inspects the variables of the query string. If the requested variable is found but the destination buffer is too small to hold the variable, return -2 right away. If it's not found, make the second call of get_var() to inspect the POST buffer.

What happens now: if the destination buffer is too small to hold the value of a variable from the query string, the POST buffer is inspected. If the variable is not found in the POST buffer, -1 is returned. Thus, it looks as if the variable wasn't found at all, which is not true.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/505)
<!-- Reviewable:end -->
