### PR TITLE
Fix default windows FD_SETSIZE, closes #506

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -95,6 +95,9 @@
 #include <BaseTsd.h>
 typedef SSIZE_T ssize_t;
 #endif
+#ifndef FD_SETSIZE
+#define FD_SETSIZE 1024
+#endif
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <windows.h>


### PR DESCRIPTION
https://support.microsoft.com/en-us/kb/111855 describes
that the user is expected to set the FD_SETSIZE macro
before including winsock2.h

It turns out to be very confusing and it's aggravated by
the fact that the default (64) far from being remotely practical.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/514)
<!-- Reviewable:end -->
