### PR TITLE
scan_directory should default to document root if passed an empty uri

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3506,6 +3506,11 @@ static int scan_directory(struct connection *conn, const char *dir,
   int arr_size = 0, arr_ind = 0, inc = 100;
   DIR *dirp;
 
+  // default to document root if passed an empty uri
+  if (dir && strcmp(dir, "") == 0) {
+    dir = conn->server->config_options[DOCUMENT_ROOT];
+  }
+
   *arr = NULL;
   if ((dirp = (opendir(dir))) == NULL) return 0;
 


### PR DESCRIPTION
Otherwise... scan_directory returns an empty listing in the document root if a request was made for httx://server:port

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/522)
<!-- Reviewable:end -->
