### PR TITLE
prevent truncating '/' document root

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3319,9 +3319,9 @@ static int find_index_file(struct connection *conn, char *path,
     }
   }
 
-  // If no index file exists, restore directory path
+  // If no index file exists, restore directory path with trailing slash
   if (!found) {
-    path[n] = '\0';
+    path[n + 1] = '\0';
   }
 
   return found;

--- a/mongoose.c
+++ b/mongoose.c
@@ -3321,7 +3321,8 @@ static int find_index_file(struct connection *conn, char *path,
 
   // If no index file exists, restore directory path with trailing slash
   if (!found) {
-    path[n + 1] = '\0';
+    if (path[n] == '/' && n == 0) n++; // don't clobber "/"
+    path[n] = '\0';
   }
 
   return found;


### PR DESCRIPTION
This was causing directory listings to fail on the root directory when a document root of "/" was specified.

See also #522 

(possibly related: #510)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/523)
<!-- Reviewable:end -->
