### PR TITLE
Implementing array varibles

### DIFF
--- a/examples/array_vars/Makefile
+++ b/examples/array_vars/Makefile
@@ -1,0 +1,21 @@
+# Copyright (c) 2014 Cesanta Software
+# All rights reserved
+
+PROG = array_vars
+CFLAGS = -W -Wall -I../.. -pthread -g -O0 $(CFLAGS_EXTRA)
+SOURCES = $(PROG).c ../../mongoose.c
+
+all: $(PROG)
+
+run: $(PROG)
+	./$(PROG)
+
+$(PROG): $(SOURCES) Makefile
+	$(CC) -o $(PROG) $(SOURCES) $(CFLAGS)
+
+win:
+	wine cl $(SOURCES) /MD /nologo /DNDEBUG /O1 /I../.. /Fe$(PROG).exe
+	wine $(PROG).exe
+
+clean:
+	rm -rf $(PROG) *.exe *.dSYM *.obj *.exp .*o *.lib *.gc*

--- a/examples/array_vars/array_vars.c
+++ b/examples/array_vars/array_vars.c
@@ -1,0 +1,46 @@
+// Copyright (c) 2014 Cesanta Software
+// All rights reserved
+//
+// This example demostrates basic use of Mongoose embedded web server.
+// $Date: 2014-09-09 22:20:23 UTC $
+
+#include <stdio.h>
+#include <string.h>
+#include "mongoose.h"
+
+static int ev_handler(struct mg_connection *conn, enum mg_event ev) {
+  switch (ev) {
+    case MG_AUTH: return MG_TRUE;
+    case MG_REQUEST:
+    {
+      mg_printf_data(conn, "Hello! Requested URI is [%s] ", conn->uri);
+      char buffer[1024];
+      int ret,
+        i;
+      for(i=0; (ret = mg_get_n_var(conn, "foo[]", buffer, 1024, i)) > 0; i++)
+        mg_printf_data(conn, "\nfoo[%d] = %s", i, buffer);
+
+      return MG_TRUE;
+    }
+    default: return MG_FALSE;
+  }
+}
+
+int main(void) {
+  struct mg_server *server;
+
+  // Create and configure the server
+  server = mg_create_server(NULL, ev_handler);
+  mg_set_option(server, "listening_port", "8080");
+
+  // Serve request. Hit Ctrl-C to terminate the program
+  printf("Starting on port %s\n", mg_get_option(server, "listening_port"));
+  for (;;) {
+    mg_poll_server(server, 1000);
+  }
+
+  // Cleanup, and free server instance
+  mg_destroy_server(&server);
+
+  return 0;
+}

--- a/examples/array_vars/array_vars.c
+++ b/examples/array_vars/array_vars.c
@@ -1,7 +1,7 @@
 // Copyright (c) 2014 Cesanta Software
 // All rights reserved
 //
-// This example demostrates basic use of Mongoose embedded web server.
+// This example demostrates how to use array get variables using mg_get_n_var
 // $Date: 2014-09-09 22:20:23 UTC $
 
 #include <stdio.h>
@@ -15,8 +15,7 @@ static int ev_handler(struct mg_connection *conn, enum mg_event ev) {
     {
       mg_printf_data(conn, "Hello! Requested URI is [%s] ", conn->uri);
       char buffer[1024];
-      int ret,
-        i;
+      int i, ret;
       for(i=0; (ret = mg_get_n_var(conn, "foo[]", buffer, 1024, i)) > 0; i++)
         mg_printf_data(conn, "\nfoo[%d] = %s", i, buffer);
 

--- a/mongoose.c
+++ b/mongoose.c
@@ -4998,7 +4998,7 @@ struct mg_connection *mg_next(struct mg_server *s, struct mg_connection *c) {
 }
 
 static int get_var(const char *data, size_t data_len, const char *name,
-                   char *dst, size_t dst_len) {
+                   char *dst, size_t dst_len, int n) {
   const char *p, *e, *s;
   size_t name_len;
   int len;
@@ -5014,10 +5014,14 @@ static int get_var(const char *data, size_t data_len, const char *name,
     len = -1;
     dst[0] = '\0';
 
+    int i = 0;
     // data is "var1=val1&var2=val2...". Find variable first
     for (p = data; p + name_len < e; p++) {
       if ((p == data || p[-1] == '&') && p[name_len] == '=' &&
           !mg_strncasecmp(name, p, name_len)) {
+
+        if(n != i++)
+          continue;
 
         // Point p to variable value
         p += name_len + 1;
@@ -5046,10 +5050,15 @@ static int get_var(const char *data, size_t data_len, const char *name,
 
 int mg_get_var(const struct mg_connection *conn, const char *name,
                char *dst, size_t dst_len) {
+  return mg_get_n_var(conn, name, dst, dst_len, 0);
+}
+
+int mg_get_n_var(const struct mg_connection *conn, const char *name,
+               char *dst, size_t dst_len, int n) {
   int len = get_var(conn->query_string, conn->query_string == NULL ? 0 :
-                    strlen(conn->query_string), name, dst, dst_len);
+                    strlen(conn->query_string), name, dst, dst_len, n);
   if (len == -1) {
-    len = get_var(conn->content, conn->content_len, name, dst, dst_len);
+    len = get_var(conn->content, conn->content_len, name, dst, dst_len, n);;
   }
   return len;
 }

--- a/mongoose.c
+++ b/mongoose.c
@@ -5001,7 +5001,7 @@ static int get_var(const char *data, size_t data_len, const char *name,
                    char *dst, size_t dst_len, int n) {
   const char *p, *e, *s;
   size_t name_len;
-  int len;
+  int i, len;
 
   if (dst == NULL || dst_len == 0) {
     len = -2;
@@ -5009,12 +5009,12 @@ static int get_var(const char *data, size_t data_len, const char *name,
     len = -1;
     dst[0] = '\0';
   } else {
+    i = 0;
     name_len = strlen(name);
     e = data + data_len;
     len = -1;
     dst[0] = '\0';
 
-    int i = 0;
     // data is "var1=val1&var2=val2...". Find variable first
     for (p = data; p + name_len < e; p++) {
       if ((p == data || p[-1] == '&') && p[name_len] == '=' &&

--- a/mongoose.h
+++ b/mongoose.h
@@ -119,6 +119,8 @@ const char *mg_get_header(const struct mg_connection *, const char *name);
 const char *mg_get_mime_type(const char *name, const char *default_mime_type);
 int mg_get_var(const struct mg_connection *conn, const char *var_name,
                char *buf, size_t buf_len);
+int mg_get_n_var(const struct mg_connection *conn, const char *var_name,
+               char *buf, size_t buf_len, int n);
 int mg_parse_header(const char *hdr, const char *var_name, char *buf, size_t);
 int mg_parse_multipart(const char *buf, int buf_len,
                        char *var_name, int var_name_len,


### PR DESCRIPTION
Mongoose didn't implement a way for retrieving array variables like:
```
http://www.example.com?foo[]=1&foo[]=2&foo[]=3
```

If you try to get them through `mg_get_var` you only get the first one. This patch implements `mg_get_n_var` which gets the `n` aparition of the desired var. An exmaple of how to use it is in `examples/array_vars`.

The basic idea is to iterate using `mg_get_n_var` until the function returns `-1`, which means that no more array value was found. E.g.:
```
// Supposing this is called inside an ev_handler.
// conn is a valid mg_connection
char buffer[1024];
int ret,
  i;
for(i=0; (ret = mg_get_n_var(conn, "foo[]", buffer, 1024, i)) > 0; i++)
  mg_printf_data(conn, "\nfoo[%d] = %s", i, buffer);
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/524)
<!-- Reviewable:end -->
