### PR TITLE
Possible fix in order not to loose the reference of connection_param pointer

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -4967,7 +4967,7 @@ static void close_local_endpoint(struct connection *conn) {
   // (IP addresses & ports, server_param) must survive. Nullify the rest.
   c->request_method = c->uri = c->http_version = c->query_string = NULL;
   c->num_headers = c->status_code = c->is_websocket = c->content_len = 0;
-  c->connection_param = c->callback_param = NULL;
+  c->callback_param = NULL;
 
   if (keep_alive) {
     on_recv_data(conn);  // Can call us recursively if pipelining is used


### PR DESCRIPTION
I have run into a leak problem while using `connection_params`. My example is like this (it's the [hello_world example](https://github.com/cesanta/mongoose/blob/master/examples/hello_world/hello_world.c) with some modifications):
```
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include "mongoose.h"

int running = 1;

static int ev_handler(struct mg_connection *conn, enum mg_event ev) {
  if(conn->connection_param == NULL){
    printf("allocating memory\n");
    conn->connection_param = malloc(1000);
  }
  switch (ev) {
    case MG_AUTH: return MG_TRUE;
    case MG_REQUEST:
      mg_printf_data(conn, "Hello! Requested URI is [%s]", conn->uri);
      if(strcmp(conn->uri, "/exit") == 0)
          running = 0;
      return MG_TRUE;
    case MG_POLL:
      printf("poll\n");
      return MG_FALSE;
    case MG_CLOSE:
      if(conn->connection_param){
          printf("freeing memory\n");
          free(conn->connection_param);
          conn->connection_param = NULL;
      }
    default: return MG_FALSE;
  }
}

int main(void) {
  struct mg_server *server;

  // Create and configure the server
  server = mg_create_server(NULL, ev_handler);
  mg_set_option(server, "listening_port", "8080");

  // Serve request. Hit Ctrl-C to terminate the program
  printf("Starting on port %s\n", mg_get_option(server, "listening_port"));
  while (running) {
    mg_poll_server(server, 1000);
  }

  // Cleanup, and free server instance
  mg_destroy_server(&server);

  return 0;
}
```
**Note**: if the example is changed and the allocation is done in the `MG_REQUEST` event, the leak problem persist.

The little modification is that I allocate some memory store the pointer in `connection_param`. 
The output of the example ran with valgrind:
```
[nickcis@myhost hello_world]$ valgrind --leak-check=full ./hello_world
==17914== Memcheck, a memory error detector
==17914== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==17914== Using Valgrind-3.10.1 and LibVEX; rerun with -h for copyright info
==17914== Command: ./hello_world
==17914== 
mg_set_option        listening_port [8080]
ns_add_sock          0x4243278 5
ns_bind              0x4243278 sock 5/1 ssl (nil) (nil)
Starting on port 8080
ns_add_sock          0x4243340 6
accept_conn          0x4243340 6 (nil) (nil)
allocating memory
poll
ns_read_from_socket  0x4243340 0 <- 425 bytes (PLAIN)
on_recv_data         0x42433d0 425 0 0
close_local_endpoint 0x42433d0 3 1 3145728
on_recv_data         0x42433d0 0 0 0
ns_add_sock          0x4244088 7
accept_conn          0x4244088 7 (nil) (nil)
allocating memory
poll
allocating memory
poll
ns_write_to_socket   0x4243340 0 -> 85 bytes
poll
poll
poll
poll
ns_read_from_socket  0x4243340 0 <- 425 bytes (PLAIN)
on_recv_data         0x42433d0 425 0 0
close_local_endpoint 0x42433d0 3 1 3145728
on_recv_data         0x42433d0 0 0 0
poll
allocating memory
poll
ns_write_to_socket   0x4243340 0 -> 85 bytes
poll
poll
poll
poll
poll
poll
ns_read_from_socket  0x4243340 0 <- 429 bytes (PLAIN)
on_recv_data         0x42433d0 429 0 0
close_local_endpoint 0x42433d0 3 1 3145728
on_recv_data         0x42433d0 0 0 0
ns_mgr_free          0x4243028
poll
allocating memory
poll
ns_write_to_socket   0x4243340 0 -> 89 bytes
ns_close_conn        0x4244088 0
mg_ev_handler        0x4244118 0x4244088 0 closing
freeing memory
close_local_endpoint 0x4244118 0 0 0
ns_close_conn        0x4243340 0
mg_ev_handler        0x42433d0 0x4243340 0 closing
freeing memory
close_local_endpoint 0x42433d0 0 0 0
ns_close_conn        0x4243278 128
==17914== 
==17914== HEAP SUMMARY:
==17914==     in use at exit: 3,000 bytes in 3 blocks
==17914==   total heap usage: 32 allocs, 29 frees, 9,436 bytes allocated
==17914== 
==17914== 3,000 bytes in 3 blocks are definitely lost in loss record 1 of 1
==17914==    at 0x402A52C: malloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==17914==    by 0x804981A: ev_handler (hello_world.c:17)
==17914==    by 0x804C1AF: call_user (mongoose.c:1898)
==17914==    by 0x8056408: mg_ev_handler (mongoose.c:5401)
==17914==    by 0x804A0DB: ns_call (mongoose.c:543)
==17914==    by 0x804B34C: ns_mgr_poll (mongoose.c:1090)
==17914==    by 0x805551F: mg_poll_server (mongoose.c:5004)
==17914==    by 0x8049972: main (hello_world.c:49)
==17914== 
==17914== LEAK SUMMARY:
==17914==    definitely lost: 3,000 bytes in 3 blocks
==17914==    indirectly lost: 0 bytes in 0 blocks
==17914==      possibly lost: 0 bytes in 0 blocks
==17914==    still reachable: 0 bytes in 0 blocks
==17914==         suppressed: 0 bytes in 0 blocks
==17914== 
==17914== For counts of detected and suppressed errors, rerun with: -v
==17914== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

According to the [Mongoose api reference](https://github.com/cesanta/mongoose/blob/master/docs/API.md):
> `MG_CLOSE` is sent when the connection is closed. This event is used to cleanup per-connection state stored in connection_param if it was allocated. Event handler return value is ignored

So i thought that i should free `connection_param` on `MG_CLOSE` event. The problem is that now-a-days, most browsers send the `Connection: keep-alive` header and use the same connection for several request. e.g.: when you reload the webpage when it has already loaded.

This lead to loosing the pointer reference of `connection_param`, because, as the connection wasn't closed, no `MG_CLOSE` event was fired, but the `close_local_endpoint` function was called and this function set `connection_param` to `NULL`.

My quick solution was not to set `connection_param` pointer to `NULL` in `close_local_endpoint` function and leave the current value. I've run the tests and they passed. But, i'm not sure that with this change i'm breaking some other functionallity.

With this line change, if the above example is run with valgrind, i get this output:
```
[nickcis@myhost hello_world]$ valgrind --leak-check=full ./hello_world
==18515== Memcheck, a memory error detector
==18515== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==18515== Using Valgrind-3.10.1 and LibVEX; rerun with -h for copyright info
==18515== Command: ./hello_world
==18515== 
mg_set_option        listening_port [8080]
ns_add_sock          0x4243278 5
ns_bind              0x4243278 sock 5/1 ssl (nil) (nil)
Starting on port 8080
ns_add_sock          0x4243340 6
accept_conn          0x4243340 6 (nil) (nil)
allocating memory
poll
ns_read_from_socket  0x4243340 0 <- 425 bytes (PLAIN)
on_recv_data         0x42433d0 425 0 0
close_local_endpoint 0x42433d0 3 1 3145728
on_recv_data         0x42433d0 0 0 0
ns_add_sock          0x4244088 7
accept_conn          0x4244088 7 (nil) (nil)
allocating memory
poll
poll
ns_write_to_socket   0x4243340 0 -> 85 bytes
poll
poll
ns_read_from_socket  0x4243340 0 <- 425 bytes (PLAIN)
on_recv_data         0x42433d0 425 0 0
close_local_endpoint 0x42433d0 3 1 3145728
on_recv_data         0x42433d0 0 0 0
poll
poll
ns_write_to_socket   0x4243340 0 -> 85 bytes
poll
poll
poll
poll
poll
poll
ns_read_from_socket  0x4243340 0 <- 429 bytes (PLAIN)
on_recv_data         0x42433d0 429 0 0
close_local_endpoint 0x42433d0 3 1 3145728
on_recv_data         0x42433d0 0 0 0
ns_mgr_free          0x4243028
poll
poll
ns_write_to_socket   0x4243340 0 -> 89 bytes
ns_close_conn        0x4244088 0
mg_ev_handler        0x4244118 0x4244088 0 closing
freeing memory
close_local_endpoint 0x4244118 0 0 0
ns_close_conn        0x4243340 0
mg_ev_handler        0x42433d0 0x4243340 0 closing
freeing memory
close_local_endpoint 0x42433d0 0 0 0
ns_close_conn        0x4243278 128
==18515== 
==18515== HEAP SUMMARY:
==18515==     in use at exit: 0 bytes in 0 blocks
==18515==   total heap usage: 29 allocs, 29 frees, 6,436 bytes allocated
==18515== 
==18515== All heap blocks were freed -- no leaks are possible
==18515== 
==18515== For counts of detected and suppressed errors, rerun with: -v
==18515== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
Which shows that the `connection_param` pointer is freed correctly.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/541)
<!-- Reviewable:end -->
