### PR TITLE
Update web_server.c

### DIFF
--- a/examples/web_server/web_server.c
+++ b/examples/web_server/web_server.c
@@ -151,6 +151,18 @@ static char *sdup(const char *str) {
   return p;
 }
 
+static char *sdup_append(const char *str, const char * str2, const char sep) {
+  char *p;
+  char strsep[2] = { 0, 0 };
+  strsep[0] = sep;
+  if ((p = (char *) malloc(strlen(str) + strlen(strsep) + strlen(str2) + 1)) != NULL) {
+    strcpy(p, str);
+    strcat(p, strsep);
+    strcat(p, str2);
+  }
+  return p;
+}
+
 static void set_option(char **options, const char *name, const char *value) {
   int i;
 
@@ -161,8 +173,21 @@ static void set_option(char **options, const char *name, const char *value) {
       options[i + 2] = NULL;
       break;
     } else if (!strcmp(options[i], name)) {
-      free(options[i + 1]);
-      options[i + 1] = sdup(value);
+      char append_sep = 0;
+      if (!strcmp(options[i], "url_rewrites") || !strcmp(options[i], "index_files")
+        || !strcmp(options[i],"access_control_list") || !strcmp(options[i], "extra_mime_types")) {
+        if (value[0] == '^') value++;
+        else append_sep = ',';
+      }
+      if (!append_sep) {
+        free(options[i + 1]);
+        options[i + 1] = sdup(value);
+      } else {
+        char * newval = sdup_append( options[i + 1], value, append_sep );
+        free(options[i + 1]);
+        options[i + 1] = newval;
+        fprintf(stderr, "%s %s\n", options[i], options[i + 1]);
+      }
       break;
     }
   }


### PR DESCRIPTION
This patch adds to mongoose webserver the possibility to specify multiple times some of the options which require comma separated values.
url_rewrites is the most useful of these, and having comma separated url in a single row can be quite difficult to admin.
Prepending a value with '^' char will not append the value, but will set it as it would normally do.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/542)
<!-- Reviewable:end -->
