### PR TITLE
web_server: allow space in configuration file

### DIFF
--- a/examples/web_server/web_server.c
+++ b/examples/web_server/web_server.c
@@ -212,7 +212,7 @@ static void process_command_line_arguments(char *argv[], char **options) {
         continue;
       }
 
-      if (sscanf(line, "%s %[^\r\n#]", opt, val) != 2) {
+      if (sscanf(line, "%s %[^\r\n# ]", opt, val) != 2) {
         printf("%s: line %d is invalid, ignoring it:\n %s",
                s_config_file, (int) line_no, line);
       } else {


### PR DESCRIPTION
This patch fixes an issue when using a configuration file with comments in it.  It stops reading after the second word and doesn't keep on reading until the comment sign or the end of line.

According to https://github.com/cesanta/mongoose/blob/master/docs/SSL.md you can add a comment after a configuration line and this fix makes the parsing work correctly.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/553)
<!-- Reviewable:end -->
