### PR TITLE
Don't redefine MONGOOSE_ENABLE_THREADS on Windows if already defined

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -63,7 +63,7 @@
 #pragma warning (disable : 4204)  // missing c99 support
 #endif
 
-#if defined(_WIN32) && !defined(MONGOOSE_NO_CGI)
+#if defined(_WIN32) && !defined(MONGOOSE_NO_CGI) && !defined(MONGOOSE_ENABLE_THREADS)
 #define MONGOOSE_ENABLE_THREADS   /* Windows uses stdio threads for CGI */
 #endif
 


### PR DESCRIPTION
This prevents MONGOOSE_ENABLE_THREADS from causing a GCC warning due to redefinition on Windows if the build system compiling mongoose.c defines MONGOOSE_ENABLE_THREADS globally (such as for cross-platform software packages).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/554)
<!-- Reviewable:end -->
