### PR TITLE
Solve leak when releasing SSL resources.

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -1839,6 +1839,9 @@ static void mg_destroy_conn(struct mg_connection *conn) {
   if (conn->ssl_ctx != NULL) {
     SSL_CTX_free(conn->ssl_ctx);
   }
+  sk_SSL_COMP_free(SSL_COMP_get_compression_methods());
+  EVP_cleanup();
+  CRYPTO_cleanup_all_ex_data();
 #endif
   MG_FREE(conn);
 }


### PR DESCRIPTION
Solve memory leak at function 'mg_destroy_conn()' when compiling with SSL (defining 'MG_ENABLE_SSL').
Refer to issue #579.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/580)
<!-- Reviewable:end -->
