### PR TITLE
Setting SSL server state for already open socket

### DIFF
--- a/mongoose.h
+++ b/mongoose.h
@@ -796,6 +796,7 @@ struct mg_connection {
 #define MG_F_WANT_READ (1 << 5)          /* SSL specific */
 #define MG_F_WANT_WRITE (1 << 6)         /* SSL specific */
 #define MG_F_IS_WEBSOCKET (1 << 7)       /* Websocket specific */
+#define MG_F_SSL_SERVER_TRANSITION (1 << 8)   /* Transition from plain socket to server */
 
 /* Flags that are settable by user */
 #define MG_F_SEND_AND_CLOSE (1 << 10)      /* Push remaining data and close  */
@@ -1017,6 +1018,14 @@ struct mg_connection *mg_connect_opt(struct mg_mgr *, const char *,
  * Return: NULL on success, or error message on error.
  */
 const char *mg_set_ssl(struct mg_connection *nc, const char *cert,
+                       const char *ca_cert);
+
+/*
+ * Enable SSL for a given connection; make the connection an SSL server
+ * The meaning of certification parameters are the same as in mg_set_ssl.
+ * Return: NULL on success, or error message on error.
+ */
+const char *mg_set_ssl_server(struct mg_connection *nc, const char *cert,
                        const char *ca_cert);
 
 /*


### PR DESCRIPTION
The pull request superseeds request #606 and takes into account rojer's ideas how to avoid code duplication in a new function mg_set_ssl_server. 
The function itself is necessary when socket starts as in a plain mode and changed into SSL later, like in the HTTP SSL proxy with bumping.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/611)

<!-- Reviewable:end -->
