### PR TITLE
including winsock2.h if ipv6 enabled

### DIFF
--- a/mongoose.h
+++ b/mongoose.h
@@ -147,6 +147,10 @@
 #ifdef _MSC_VER
 #pragma comment(lib, "ws2_32.lib") /* Linking with winsock library */
 #endif
+#ifdef MG_ENABLE_IPV6
+#include <WinSock2.h>
+#include <Ws2ipdef.h>
+#endif
 #include <windows.h>
 #include <process.h>
 #ifndef EINPROGRESS


### PR DESCRIPTION
By default windows.h loads ```winsock.h```, not ```WinSock2.h```. The latter is required (plus ```Ws2ipdef.h```) for IPv6 support.

Also note that in the mongoose.h there is a pragma comment to link with Winsock2 lib, but mongoose actually uses the Winsock1 headers.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/626)
<!-- Reviewable:end -->
