### PR TITLE
Fix epoll() accept bug.

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -2616,7 +2616,6 @@ struct mg_connection *mg_if_accept_new_conn(struct mg_connection *lc) {
   nc->proto_handler = lc->proto_handler;
   nc->user_data = lc->user_data;
   nc->recv_mbuf_limit = lc->recv_mbuf_limit;
-  mg_add_conn(nc->mgr, nc);
   DBG(("%p %p %d %d, %p %p", lc, nc, nc->sock, (int) nc->flags, lc->ssl_ctx,
        nc->ssl));
   return nc;
@@ -3204,6 +3203,7 @@ static void mg_accept_conn(struct mg_connection *lc) {
     return;
   }
   mg_sock_set(nc, sock);
+  mg_add_conn(nc->mgr, nc);
 #ifdef MG_ENABLE_SSL
   if (lc->ssl_ctx != NULL) {
     nc->ssl = SSL_new(lc->ssl_ctx);


### PR DESCRIPTION
The `mg_ev_mgr_epoll_ctl()` function calls `abort()` after encountering the following error when a client TCP connection is accepted:

`epoll_ctl(5, EPOLL_CTL_MOD, 7, {EPOLLIN, {u32=20605408, u64=749695152056800}}) = -1 ENOENT (No such file or directory)`

N.B. `-DMG_MGR_EV_MGR=1` is used to enable `epoll()` on Linux.

The problem is that `mg_add_conn()` is called in `mg_if_accept_new_conn()` before `mg_sock_set()` has set the socket descriptor for the new connection:

`mg_ev_mgr_epoll_ctl  0x144c9e0 -1 1`
`mg_if_accept_new_conn 0x144fa68 0x144c9e0 -1 0, (nil) (nil)`
`mg_sock_set          0x144c9e0 7`

Caveat: the extent of my testing has been limited to plain TCP sockets, so similar problems may exist elsewhere (such as SSL).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/637)
<!-- Reviewable:end -->
