### PR TITLE
mg_poll_conn - sends message to a single connection

### DIFF
--- a/mongoose.h
+++ b/mongoose.h
@@ -1233,6 +1233,7 @@ time_t mg_mgr_poll(struct mg_mgr *, int milli);
  * by `MG_CTL_MSG_MESSAGE_SIZE` which is set to 8192 bytes.
  */
 void mg_broadcast(struct mg_mgr *, mg_event_handler_t func, void *, size_t);
+void mg_poll_conn(struct mg_connection *, mg_event_handler_t, void *, size_t);
 #endif
 
 /*


### PR DESCRIPTION
We wrote this simple mod so that we could send a message to a single connection without triggering a broadcast poll.

In our applications, we been passing the connection in the message.  The handler would then decide whether to accept or reject the message by comparing the 'nc' mg_connection argument to the connection passed in the message.  We wanted to avoid this broadcast kind of logic by targeting a specific connection.  By adding the connection to the ctl_msg, a very simple mod, the ctl_msg handler can easily determine dispatch to that connection immediately without polling every connection.

We figured that this mod is sufficiently non-intrusive to warrant asking that it be merged into the main release.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/639)

<!-- Reviewable:end -->
