### PR TITLE
Fix crash in mg_stat on MinGW-w64

### DIFF
--- a/mongoose.h
+++ b/mongoose.h
@@ -209,7 +209,7 @@ typedef uint32_t in_addr_t;
 #define INT64_FMT "I64d"
 #define INT64_X_FMT "I64x"
 #define SIZE_T_FMT "Iu"
-#ifdef __MINGW32__
+#if defined __MINGW32__ && !defined __MINGW64_VERSION_MAJOR
 typedef struct stat cs_stat_t;
 #else
 typedef struct _stati64 cs_stat_t;


### PR DESCRIPTION
Fixing a crash in mg_stat when compiling with MinGW-w64 on 32bit Windows. MinGW-w64's definition of stat can not be converted to _stati64, but _stati64 is always defined, so _stati64 should be used on MinGW-w64.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/644)
<!-- Reviewable:end -->
