### PR TITLE
Check for return of EAGAIN/EWOULDBLOCK when sending

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3314,6 +3314,10 @@ static void mg_write_to_socket(struct mg_connection *nc) {
     n = (int) MG_SEND_FUNC(nc->sock, io->buf, io->len, 0);
     DBG(("%p %d bytes -> %d", nc, n, nc->sock));
   }
+  
+  if(n < 0 && !mg_is_error(n)) {
+      return;
+  }
 
   if (n > 0) {
     mbuf_remove(io, n);


### PR DESCRIPTION
This issue is still present in Mongoose 6.4 on Cygwin.  To reproduce, build the simplest_web_server example and serve from a directory with an HTML file that references a few other files (in my case, serving a packed .js of ~750KB).  Issue occurs intermittently but with great frequency.

#438

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/650)
<!-- Reviewable:end -->
