### PR TITLE
Fixed compilation with MG_DISABLE_SOCKETPAIR

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3785,6 +3785,12 @@ int mg_socketpair(sock_t sp[2], int sock_type) {
 
   return ret;
 }
+#else
+int mg_socketpair(sock_t sp[2], int sock_type) {
+    (void)sp;
+    (void)sock_type;
+    return -1;
+}
 #endif /* MG_DISABLE_SOCKETPAIR */
 
 #ifndef MG_SOCKET_SIMPLELINK
@@ -7338,9 +7344,11 @@ static void mg_handle_cgi(struct mg_connection *nc, const char *prog,
    * can be interrupted by a signal and fail.
    * TODO(lsm): use sigaction to restart interrupted syscall
    */
+#ifndef MG_DISABLE_SOCKETPAIR
   do {
     mg_socketpair(fds, SOCK_STREAM);
   } while (fds[0] == INVALID_SOCKET);
+#endif
 
   if (mg_start_process(opts->cgi_interpreter, prog, blk.buf, blk.vars, dir,
                        fds[1]) != 0) {


### PR DESCRIPTION
When MG_DISABLE_SOCKETPAIR is selected, not all calls to `mg_socketpair` are compiled out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/652)
<!-- Reviewable:end -->
