### PR TITLE
MG_F_FINISHED_SENDING_DATA => MG_F_SEND_AND_CLOSE

### DIFF
--- a/docs/design-concept/conn-flags.md
+++ b/docs/design-concept/conn-flags.md
@@ -9,7 +9,7 @@ flags are meant to be set only by user event handler to tell Mongoose how to
 behave.  Below is a list of connection flags that are meant to be set by event
 handlers:
 
-* `MG_F_FINISHED_SENDING_DATA` tells Mongoose that all data has been appended
+* `MG_F_SEND_AND_CLOSE` tells Mongoose that all data has been appended
   to the `send_mbuf`. As soon as Mongoose sends it to the socket, the
   connection will be closed.
 * `MG_F_BUFFER_BUT_DONT_SEND` tells Mongoose to append data to the `send_mbuf`


### PR DESCRIPTION
the constant was changed but the name is the old one in the documentation, also I can't find the two following constants anywhere in the code about buffering, I don't use them but someone more familiar with the code might want to have a look :)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/667)

<!-- Reviewable:end -->
