### PR TITLE
Copy remote peer's address to spawned thread's local connection

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3492,6 +3492,7 @@ static void spawn_handling_thread(struct mg_connection *nc) {
    */
   c[1]->listener = nc->listener;
   c[1]->proto_handler = nc->proto_handler;
+  c[1]->sa = nc->sa;
   c[1]->user_data = nc->user_data;
   c[1]->sa = nc->sa;
 


### PR DESCRIPTION
When threading is enabled, the sa field of connection created for spawned thread is not copied, therefore can't get real peer's address and port can be fixed by this patch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/688)
<!-- Reviewable:end -->
