### PR TITLE
Fix a bug of server example code in the document

### DIFF
--- a/docs/http/server_example.md
+++ b/docs/http/server_example.md
@@ -30,8 +30,8 @@ static void ev_handler(struct mg_connection *c, int ev, void *p) {
 
     // We have received an HTTP request. Parsed request is contained in `hm`.
     // Send HTTP reply to the client which shows full original request.
-    mg_send_head(c, 200, hm.message.len, "Content-Type: text/plain");
-    mg_printf(c, "%.*s", hm.message.len, hm.message.p);
+    mg_send_head(c, 200, hm->message.len, "Content-Type: text/plain");
+    mg_printf(c, "%.*s", hm->message.len, hm->message.p);
   }
 }
 


### PR DESCRIPTION
Here is the origin code in the document.

``` c
#include "mongoose.h"

static const char *s_http_port = "8000";

static void ev_handler(struct mg_connection *c, int ev, void *p) {
  if (ev == MG_EV_HTTP_REQUEST) {
    struct http_message *hm = (struct http_message *) p;

    // We have received an HTTP request. Parsed request is contained in `hm`.
    // Send HTTP reply to the client which shows full original request.
    mg_send_head(c, 200, hm.message.len, "Content-Type: text/plain");
    mg_printf(c, "%.*s", hm.message.len, hm.message.p);
  }
}

int main(void) {
  struct mg_mgr mgr;
  struct mg_connection *c;

  mg_mgr_init(&mgr, NULL);
  c = mg_bind(&mgr, s_http_port, ev_handler);
  mg_set_protocol_http_websocket(c);

  for (;;) {
    mg_mgr_poll(&mgr, 1000);
  }
  mg_mgr_free(&mgr);

  return 0;
}
```

Let's see these two lines:

``` c
    mg_send_head(c, 200, hm.message.len, "Content-Type: text/plain");
    mg_printf(c, "%.*s", hm.message.len, hm.message.p);
```

The `hm` is a pointer to `struct http_message`, but you use `hm.message` to obtain the element `message` of `*hm`. I think that `hm->message` should be the correct way to represent.

please review 😄  @cpq @rojer . Thank you so much.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/700)

<!-- Reviewable:end -->
