### PR TITLE
Fixed issue #711 - mg_match_prefix fails to match single asterisk

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -7900,7 +7900,7 @@ int mg_match_prefix_n(const struct mg_str pattern, const struct mg_str str) {
         len = str.len - j;
       } else {
         len = 0;
-        while (j + len != str.len && str.p[len] != '/') {
+        while (j + len != str.len && str.p[j + len] != '/') {
           len++;
         }
       }


### PR DESCRIPTION
The change in this branch fixes the problem where mg_match_prefix fails to properly match a glob pattern with a single asterisk. I tested it with the following code:

```
#include "mongoose.h"

int main()
{
    const char *str = "/api/user/192/friends";
    const char *pattern = "/api/user/*/friends";

    int numBytes = mg_match_prefix(pattern, strlen(pattern), str);
    if (numBytes < 0) {
        printf("No match found\n");
    } else {
        printf("Match found: %d bytes\n", numBytes);
    } 
}
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/712)

<!-- Reviewable:end -->
