### PR TITLE
Prevent conflict with openssl

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -867,7 +867,7 @@ static void byteReverse(unsigned char *buf, unsigned longs) {
  * Start MD5 accumulation.  Set bit count to 0 and buffer to mysterious
  * initialization constants.
  */
-void MD5_Init(MD5_CTX *ctx) {
+void mg_md5_init(MD5_CTX *ctx) {
   ctx->buf[0] = 0x67452301;
   ctx->buf[1] = 0xefcdab89;
   ctx->buf[2] = 0x98badcfe;
@@ -959,7 +959,7 @@ static void MD5Transform(uint32_t buf[4], uint32_t const in[16]) {
   buf[3] += d;
 }
 
-void MD5_Update(MD5_CTX *ctx, const unsigned char *buf, size_t len) {
+void mg_md5_update(MD5_CTX *ctx, const unsigned char *buf, size_t len) {
   uint32_t t;
 
   t = ctx->bits[0];
@@ -994,7 +994,7 @@ void MD5_Update(MD5_CTX *ctx, const unsigned char *buf, size_t len) {
   memcpy(ctx->in, buf, len);
 }
 
-void MD5_Final(unsigned char digest[16], MD5_CTX *ctx) {
+void mg_md5_final(unsigned char digest[16], MD5_CTX *ctx) {
   unsigned count;
   unsigned char *p;
   uint32_t *a;
@@ -1031,16 +1031,16 @@ char *cs_md5(char buf[33], ...) {
   va_list ap;
   MD5_CTX ctx;
 
-  MD5_Init(&ctx);
+  mg_md5_init(&ctx);
 
   va_start(ap, buf);
   while ((p = va_arg(ap, const unsigned char *) ) != NULL) {
     size_t len = va_arg(ap, size_t);
-    MD5_Update(&ctx, p, len);
+    mg_md5_update(&ctx, p, len);
   }
   va_end(ap);
 
-  MD5_Final(hash, &ctx);
+  mg_md5_final(hash, &ctx);
   cs_to_hex(buf, hash, sizeof(hash));
 
   return buf;


### PR DESCRIPTION
When linking openssl and mongoose in the same binary the MD5_Init, MD5_Update and MD5_Final symbols are defined twice. Renaming the ones in mongoose works around this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/757)
<!-- Reviewable:end -->
