### PR TITLE
Close dummy mg_mgr sockets when MG_ENABLE_BROADCAST is set (Issue 607)

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -4731,6 +4731,12 @@ static void spawn_handling_thread(struct mg_connection *nc) {
   c[0] = mg_add_sock(&dummy, sp[0], forwarder_ev_handler);
   c[1] = mg_add_sock(&dummy, sp[1], nc->listener->priv_1.f);
 
+#if MG_ENABLE_BROADCAST
+  if (dummy.ctl[0] != INVALID_SOCKET) closesocket(dummy.ctl[0]);
+  if (dummy.ctl[1] != INVALID_SOCKET) closesocket(dummy.ctl[1]);
+  dummy.ctl[0] = dummy.ctl[1] = INVALID_SOCKET;
+#endif
+
   /* link_conns replaces priv_2, storing its value */
   poll_timeout = (intptr_t) nc->priv_2;
 


### PR DESCRIPTION
When MG_ENABLE_BROADCAST is set, the dummy mg_mgr struct in `spawn_handling_thread()` creates its own socket pair, which never gets closed.  This pull requests closes the pair once we're done with `dummy`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/761)
<!-- Reviewable:end -->
