### PR TITLE
reassembled buffer should not be tested for WEBSOCKET_OP_CLOSE

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -8896,9 +8896,11 @@ static int mg_deliver_websocket_data(struct mg_connection *nc) {
       mbuf_remove(&nc->recv_mbuf, (size_t) frame_len); /* Cleanup frame */
     }
 
-    /* If client closes, close too */
-    if ((buf[0] & 0x0f) == WEBSOCKET_OP_CLOSE) {
-      nc->flags |= MG_F_SEND_AND_CLOSE;
+    if(!reass) {
+      /* If client closes, close too. Only valid when the frame is not reassembled */
+      if ((buf[0] & 0x0f) == WEBSOCKET_OP_CLOSE) {
+        nc->flags |= MG_F_SEND_AND_CLOSE;
+      }
     }
   }
 


### PR DESCRIPTION
if reass==1 then frames are appended to the reassembled buffer thus buf[0] will have whatever data wsm.data[0] had (see memmove in line #8882) so is possible that the 8-LSB will be WEBSOCKET_OP_CLOSE and the connection will be closed. In fact this was the reason for the issue https://github.com/cesanta/mongoose/issues/740

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/767)
<!-- Reviewable:end -->
