### PR TITLE
Update DISABLE_MD5 flag

### DIFF
--- a/docs/overview/build-options/disabling-flags.md
+++ b/docs/overview/build-options/disabling-flags.md
@@ -3,6 +3,6 @@ title: Disabling flags
 ---
 
 - `MG_DISABLE_HTTP_DIGEST_AUTH` disable HTTP Digest (MD5) authorisation support
-- `MG_DISABLE_SHA1` disable SHA1 support (used by WebSocket)
-- `MG_DISABLE_MD5` disable MD5 support (used by HTTP auth)
+- `DISABLE_SHA1` disable SHA1 support (used by WebSocket)
+- `DISABLE_MD5` disable MD5 support (used by HTTP auth)
 - `MG_DISABLE_HTTP_KEEP_ALIVE` useful for embedded systems to save resources

--- a/mongoose.c
+++ b/mongoose.c
@@ -977,7 +977,6 @@ void MD5_Final(unsigned char digest[16], MD5_CTX *ctx) {
   memcpy(digest, ctx->buf, 16);
   memset((char *) ctx, 0, sizeof(*ctx));
 }
-#endif /* DISABLE_MD5 */
 
 char *cs_md5(char buf[33], ...) {
   unsigned char hash[16];
@@ -999,6 +998,7 @@ char *cs_md5(char buf[33], ...) {
 
   return buf;
 }
+#endif /* DISABLE_MD5 */
 
 #endif /* EXCLUDE_COMMON */
 #ifdef MG_MODULE_LINES


### PR DESCRIPTION
Hello,

This PR updates the closing `DISABLE_MD5` flag which was not correctly set, leading to these errors :
```
Undefined symbols for architecture x86_64:
  "_MD5_Final", referenced from:
      _cs_md5 in mongoose.o
  "_MD5_Init", referenced from:
      _cs_md5 in mongoose.o
  "_MD5_Update", referenced from:
      _cs_md5 in mongoose.o
ld: symbol(s) not found for architecture x86_64
```

It also updates the doc with the correct flag names.

Thx 👍 

Ben

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/mongoose/796)
<!-- Reviewable:end -->
