### PR TITLE
Fix version number

### DIFF
--- a/mongoose.h
+++ b/mongoose.h
@@ -23,7 +23,7 @@
 #ifndef CS_MONGOOSE_SRC_COMMON_H_
 #define CS_MONGOOSE_SRC_COMMON_H_
 
-#define MG_VERSION "6.7"
+#define MG_VERSION "6.8"
 
 /* Local tweaks, applied before any of Mongoose's own headers. */
 #ifdef MG_LOCALS


### PR DESCRIPTION
Although it is not a big deal, as I downloaded version 6.8 and used it, 
the MG_VERSION macro still remains 6.7.
So I fixed it to 6.8.

Thank you so much.