### PR TITLE
Add a fallback resource as new option for serving http.

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -7858,7 +7858,9 @@ void mg_serve_http(struct mg_connection *nc, struct http_message *hm,
     mg_http_send_error(nc, 404, NULL);
     return;
   }
-  if(opts.fallback_resource != NULL && mg_stat(path, &st)) {
+  if(opts.fallback_resource != NULL &&
+    ( mg_stat(path, &st) ||
+    ( S_ISDIR(st.st_mode) && strcmp(opts.enable_directory_listing, "yes") ) ) ) {
     pathlen_dr=strlen(opts.document_root);
     pathlen_fr=strlen(opts.fallback_resource);
     path = (char *) MG_REALLOC(path, pathlen_dr+pathlen_fr+2); /* save 1 char for optional / */

--- a/mongoose.h
+++ b/mongoose.h
@@ -4648,6 +4648,12 @@ struct mg_serve_http_opts {
   const char *index_files;
 
   /*
+   * Fallback resource for when a resource is not found
+   * Leave as NULL to disable the functionnality.
+   */
+  const char *fallback_resource;
+
+  /*
    * Leave as NULL to disable authentication.
    * To enable directory protection with authentication, set this to ".htpasswd"
    * Then, creating ".htpasswd" file in any directory automatically protects


### PR DESCRIPTION
Most web framework supporting routing request servers to support a fallback resource to be served when the uri does not match any actual file, so as to 'redirect' all requests to a single file (which in term uses the uri in the treatment to serve the actually requested resource).
This is what this does: an new field `fallback_resource` is added to the `mg_serve_http_opts` structure, and used in the `mg_serve_http` function in case the requested resource is not found.