### PR TITLE
Set session id context to allow session reuse on two-way ssl (openssl)

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -4454,6 +4454,8 @@ const struct mg_iface_vtable mg_tun_iface_vtable = MG_TUN_IFACE_VTABLE;
 
 #include <openssl/ssl.h>
 
+static const int default_session_id_context = 1;
+
 struct mg_ssl_if_ctx {
   SSL *ssl;
   SSL_CTX *ssl_ctx;
@@ -4515,6 +4517,8 @@ enum mg_ssl_if_result mg_ssl_if_conn_init(
   SSL_CTX_set_options(ctx->ssl_ctx, SSL_OP_NO_SSLv2);
   SSL_CTX_set_options(ctx->ssl_ctx, SSL_OP_NO_SSLv3);
   SSL_CTX_set_options(ctx->ssl_ctx, SSL_OP_NO_TLSv1);
+  SSL_CTX_set_session_id_context(ctx->ssl_ctx, (void *)&default_session_id_context,
+   sizeof(default_session_id_context));
 #ifdef MG_SSL_OPENSSL_NO_COMPRESSION
   SSL_CTX_set_options(ctx->ssl_ctx, SSL_OP_NO_COMPRESSION);
 #endif


### PR DESCRIPTION
Two way SSL currently can't reuse tls session when using openssl. This can be verified using s_client tool from openssl as follows:

`$> openssl s_client -connect localhost:8443 -CAfile ca-chain.cert.pem -cert bob@example.com.cert.pem -key bob@example.com.key.pem -reconnect`

given proper CA and client cert files we should see that session can't be reused (it works fine on one-way ssl).

Reference: https://wiki.openssl.org/index.php/Manual:SSL_CTX_set_session_id_context(3)
> If the session id context is not set on an SSL/TLS server and client certificates are used, stored sessions will not be reused but a fatal error will be flagged and the handshake will fail.

I'm not 100% sure about setting such id to a default value, although as a SSL_CTX is created per server, I'm assuming sessions are not shared and therefore same session id should not point to same data on different servers.
