### PR TITLE
bug: response line and headers are not removed from recv_mbuf after MG_EV_HTTP_REPLY

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -6450,7 +6450,7 @@ void mg_http_handler(struct mg_connection *nc, int ev,
       deliver_chunk(nc, hm, req_len);
       /* Whole HTTP message is fully buffered, call event handler */
       mg_http_call_endpoint_handler(nc, trigger_ev, hm);
-      mbuf_remove(io, hm->message.len);
+      mbuf_remove(io, nc->recv_mbuf.len);
       pd->rcvd = 0;
     }
   }


### PR DESCRIPTION
bug: When using HTTP1.1 keep-alive, the response line and headers are still in nc->recv_mbuf after MG_EV_HTTP_REPLY.

fix: mongoose.c mg_http_handler mbuf_remove(io, hm->message.len) -> mbuf_remove(io, nc->recv_mbuf.len)