### PR TITLE
Non-SSL TCP read now gets all available data

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3547,14 +3547,14 @@ static void mg_handle_tcp_read(struct mg_connection *conn) {
   } else
 #endif
   {
-    n = (int) MG_RECV_FUNC(conn->sock, buf,
-                           recv_avail_size(conn, MG_TCP_RECV_BUFFER_SIZE), 0);
-    DBG(("%p %d bytes (PLAIN) <- %d", conn, n, conn->sock));
-    if (n > 0) {
+    while ((n = MG_RECV_FUNC(conn->sock, buf,
+                           recv_avail_size(conn, MG_TCP_RECV_BUFFER_SIZE), 0)) > 0) {
       mg_if_recv_tcp_cb(conn, buf, n, 1 /* own */);
-    } else {
-      MG_FREE(buf);
+      /* buf has been freed, we need a new one. */
+      buf = (char *) MG_MALLOC(MG_TCP_RECV_BUFFER_SIZE);
+      if (buf == NULL) break;
     }
+    MG_FREE(buf);
     if (n == 0) {
       /* Orderly shutdown of the socket, try flushing output. */
       conn->flags |= MG_F_SEND_AND_CLOSE;

--- a/mongoose.c
+++ b/mongoose.c
@@ -3549,6 +3549,7 @@ static void mg_handle_tcp_read(struct mg_connection *conn) {
   {
     while ((n = MG_RECV_FUNC(conn->sock, buf,
                            recv_avail_size(conn, MG_TCP_RECV_BUFFER_SIZE), 0)) > 0) {
+      DBG(("%p %d bytes (PLAIN) <- %d", conn, n, conn->sock));
       mg_if_recv_tcp_cb(conn, buf, n, 1 /* own */);
       /* buf has been freed, we need a new one. */
       buf = (char *) MG_MALLOC(MG_TCP_RECV_BUFFER_SIZE);


### PR DESCRIPTION
Instead of just reading one data block per mg_poll, this patch now reads all available data and calls the callback per block (as per SSL functionality).