### PR TITLE
Fix compiler warnings when CS_ENABLE_STDIO is not defined.

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -623,12 +623,12 @@ enum cs_log_level cs_log_threshold WEAK =
     LL_ERROR;
 #endif
 
-static char *s_filter_pattern = NULL;
-static size_t s_filter_pattern_len;
-
 void cs_log_set_filter(const char *pattern) WEAK;
 
 #if CS_ENABLE_STDIO
+
+static char *s_filter_pattern = NULL;
+static size_t s_filter_pattern_len;
 
 FILE *cs_log_file WEAK = NULL;
 
@@ -3729,7 +3729,9 @@ static int mg_accept_conn(struct mg_connection *lc) {
   /* NOTE(lsm): on Windows, sock is always > FD_SETSIZE */
   sock_t sock = accept(lc->sock, &sa.sa, &sa_len);
   if (sock == INVALID_SOCKET) {
-    if (mg_is_error()) DBG(("%p: failed to accept: %d", lc, mg_get_errno()));
+    if (mg_is_error()) {
+        DBG(("%p: failed to accept: %d", lc, mg_get_errno()));
+    }
     return 0;
   }
   nc = mg_if_accept_new_conn(lc);

--- a/src/common/cs_dbg.c
+++ b/src/common/cs_dbg.c
@@ -31,12 +31,12 @@ enum cs_log_level cs_log_threshold WEAK =
     LL_ERROR;
 #endif
 
-static char *s_filter_pattern = NULL;
-static size_t s_filter_pattern_len;
-
 void cs_log_set_filter(const char *pattern) WEAK;
 
 #if CS_ENABLE_STDIO
+
+static char *s_filter_pattern = NULL;
+static size_t s_filter_pattern_len;
 
 FILE *cs_log_file WEAK = NULL;
 

--- a/src/mg_net_if_socket.c
+++ b/src/mg_net_if_socket.c
@@ -146,7 +146,9 @@ static int mg_accept_conn(struct mg_connection *lc) {
   /* NOTE(lsm): on Windows, sock is always > FD_SETSIZE */
   sock_t sock = accept(lc->sock, &sa.sa, &sa_len);
   if (sock == INVALID_SOCKET) {
-    if (mg_is_error()) DBG(("%p: failed to accept: %d", lc, mg_get_errno()));
+    if (mg_is_error()) {
+        DBG(("%p: failed to accept: %d", lc, mg_get_errno()));
+    }
     return 0;
   }
   nc = mg_if_accept_new_conn(lc);


### PR DESCRIPTION
Fix -Werror=empty-body when CS_ENABLE_STDIO is not defined