### PR TITLE
Add support for OpenSSL client SNI

### DIFF
--- a/src/mg_ssl_if_openssl.c
+++ b/src/mg_ssl_if_openssl.c
@@ -10,6 +10,7 @@
 #endif
 
 #include <openssl/ssl.h>
+#include <openssl/tls1.h>
 
 struct mg_ssl_if_ctx {
   SSL *ssl;
@@ -97,8 +98,6 @@ enum mg_ssl_if_result mg_ssl_if_conn_init(
   if (params->server_name != NULL) {
 #ifdef KR_VERSION
     SSL_CTX_kr_set_verify_name(ctx->ssl_ctx, params->server_name);
-#else
-/* TODO(rojer): Implement server name verification on OpenSSL. */
 #endif
   }
 
@@ -120,6 +119,10 @@ enum mg_ssl_if_result mg_ssl_if_conn_init(
     return MG_SSL_ERROR;
   }
 
+  if (params->server_name != NULL) {
+    SSL_set_tlsext_host_name(ctx->ssl, params->server_name);
+  }
+  
   nc->flags |= MG_F_SSL;
 
   return MG_SSL_OK;


### PR DESCRIPTION
Adds SNI extension to Client Hello which can be used by setting ``mg_connect_opts.ssl_server_name``.