### PR TITLE
add a sock option for disable Nagle algorithm

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3746,7 +3746,7 @@ static int mg_accept_conn(struct mg_connection *lc) {
     int flag = 1;
     int ret = setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (char *)&flag, sizeof(flag));
     if (ret == -1) {
-      DBG("setsockopt: TCP_NODELAY failed.");
+      DBG(("setsockopt: TCP_NODELAY failed."));
     }
   }  
   nc = mg_if_accept_new_conn(lc);
@@ -14243,7 +14243,7 @@ static int mg_accept_conn(struct mg_connection *lc) {
     int flag = 1;
     int ret = setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (char *)&flag, sizeof(flag));
     if (ret == -1) {
-      DBG("setsockopt: TCP_NODELAY failed.");
+      DBG(("setsockopt: TCP_NODELAY failed."));
     }
   }  
   nc = mg_if_accept_new_conn(lc);

--- a/mongoose.h
+++ b/mongoose.h
@@ -3932,6 +3932,7 @@ struct mg_connection {
 #define MG_F_WEBSOCKET_NO_DEFRAG (1 << 12) /* Websocket specific */
 #define MG_F_DELETE_CHUNK (1 << 13)        /* HTTP specific */
 #define MG_F_ENABLE_BROADCAST (1 << 14)    /* Allow broadcast address usage */
+#define MG_F_TCP_NODELAY (1 << 15)        /* Disable Nagle's algorithm */
 
 #define MG_F_USER_1 (1 << 20) /* Flags left for application */
 #define MG_F_USER_2 (1 << 21)


### PR DESCRIPTION
In a realtime game or application. Disable Nagle's algorithm is important.