### PR TITLE
Make MG_CTL_MSG_MESSAGE_SIZE overridable.

### DIFF
--- a/docs/c-api/mg_net.h/mg_broadcast.md
+++ b/docs/c-api/mg_net.h/mg_broadcast.md
@@ -16,5 +16,5 @@ that can be, and must be, called from a different (non-IO) thread.
 `func` callback function will be called by the IO thread for each
 connection. When called, the event will be `MG_EV_POLL`, and a message will
 be passed as the `ev_data` pointer. Maximum message size is capped
-by `MG_CTL_MSG_MESSAGE_SIZE` which is set to 8192 bytes. 
+by `MG_CTL_MSG_MESSAGE_SIZE` which is set to 8192 bytes by default.
 

--- a/mongoose.c
+++ b/mongoose.c
@@ -38,7 +38,9 @@
 /* Amalgamated: #include "mg_http.h" */
 /* Amalgamated: #include "mg_net.h" */
 
+#ifndef MG_CTL_MSG_MESSAGE_SIZE
 #define MG_CTL_MSG_MESSAGE_SIZE 8192
+#endif
 
 /* internals that need to be accessible in unit tests */
 MG_INTERNAL struct mg_connection *mg_do_connect(struct mg_connection *nc,

--- a/mongoose.h
+++ b/mongoose.h
@@ -4015,7 +4015,7 @@ int mg_mgr_poll(struct mg_mgr *mgr, int milli);
  * `func` callback function will be called by the IO thread for each
  * connection. When called, the event will be `MG_EV_POLL`, and a message will
  * be passed as the `ev_data` pointer. Maximum message size is capped
- * by `MG_CTL_MSG_MESSAGE_SIZE` which is set to 8192 bytes.
+ * by `MG_CTL_MSG_MESSAGE_SIZE` which is set to 8192 bytes by default.
  */
 void mg_broadcast(struct mg_mgr *mgr, mg_event_handler_t cb, void *data,
                   size_t len);

--- a/src/mg_internal.h
+++ b/src/mg_internal.h
@@ -34,7 +34,9 @@
 #include "mg_http.h"
 #include "mg_net.h"
 
+#ifndef MG_CTL_MSG_MESSAGE_SIZE
 #define MG_CTL_MSG_MESSAGE_SIZE 8192
+#endif
 
 /* internals that need to be accessible in unit tests */
 MG_INTERNAL struct mg_connection *mg_do_connect(struct mg_connection *nc,

--- a/src/mg_net.h
+++ b/src/mg_net.h
@@ -225,7 +225,7 @@ int mg_mgr_poll(struct mg_mgr *mgr, int milli);
  * `func` callback function will be called by the IO thread for each
  * connection. When called, the event will be `MG_EV_POLL`, and a message will
  * be passed as the `ev_data` pointer. Maximum message size is capped
- * by `MG_CTL_MSG_MESSAGE_SIZE` which is set to 8192 bytes.
+ * by `MG_CTL_MSG_MESSAGE_SIZE` which is set to 8192 bytes by default.
  */
 void mg_broadcast(struct mg_mgr *mgr, mg_event_handler_t cb, void *data,
                   size_t len);


### PR DESCRIPTION
The default buffer size of 8192 for control messages is too large on some
platforms such as the esp32. Allowing the size to be adjustable via
compile time flags allows for mongoose to be used on these platforms
without blowing up the stack.