### PR TITLE
Modify the flag of NON-BLOCKING for fusion stack

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3924,7 +3924,13 @@ static int mg_socket_if_udp_send(struct mg_connection *nc, const void *buf,
 
 static int mg_socket_if_tcp_recv(struct mg_connection *nc, void *buf,
                                  size_t len) {
-  int n = (int) MG_RECV_FUNC(nc->sock, buf, len, 0);
+  int n = (int) MG_RECV_FUNC(nc->sock, buf, len, 
+    #ifdef FUSION_NEW
+    MSG_NONBLOCKING
+    #else
+    0
+    #endif
+  	);
   if (n == 0) {
     /* Orderly shutdown of the socket, try flushing output. */
     nc->flags |= MG_F_SEND_AND_CLOSE;


### PR DESCRIPTION
MG uses fcntl(sock, F_SETFL, flags | O_NONBLOCK) to set nbio mode but fusion says: 
#define O_NONBLOCK      0x2000  /* Non-blocking (not supported in Fusion) */

Actually, #define MSG_NONBLOCKING 0x4000  /* override any blocking state */
is used for non-blocking mode.