### PR TITLE
Fix ASAN build for examples/cookie_auth

### DIFF
--- a/examples/cookie_auth/cookie_auth.c
+++ b/examples/cookie_auth/cookie_auth.c
@@ -58,11 +58,11 @@ static int check_pass(const char *user, const char *pass) {
  * or NULL if not found.
  */
 static struct session *get_session(struct http_message *hm) {
-  struct mg_str *cookie_header = mg_get_http_header(hm, "cookie");
-  if (cookie_header == NULL) goto clean;
   char ssid_buf[21];
   char *ssid = ssid_buf;
   struct session *ret = NULL;
+  struct mg_str *cookie_header = mg_get_http_header(hm, "cookie");
+  if (cookie_header == NULL) goto clean;
   if (!mg_http_parse_header2(cookie_header, SESSION_COOKIE_NAME, &ssid,
                              sizeof(ssid_buf))) {
     goto clean;


### PR DESCRIPTION
The ASAN build fails for examples/cookie_auth with
```
cookie_auth.c:62:7: error: variable 'ret' is used uninitialized whenever 'if' condition is true [-Werror,-Wsometimes-uninitialized]
  if (cookie_header == NULL) goto clean;
      ^~~~~~~~~~~~~~~~~~~~~
cookie_auth.c:84:10: note: uninitialized use occurs here
  return ret;
         ^~~
cookie_auth.c:62:3: note: remove the 'if' if its condition is always false
  if (cookie_header == NULL) goto clean;
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cookie_auth.c:65:3: note: variable 'ret' is declared here
  struct session *ret = NULL;
  ^
cookie_auth.c:62:7: error: variable 'ssid' is used uninitialized whenever 'if' condition is true [-Werror,-Wsometimes-uninitialized]
  if (cookie_header == NULL) goto clean;
      ^~~~~~~~~~~~~~~~~~~~~
cookie_auth.c:81:7: note: uninitialized use occurs here
  if (ssid != ssid_buf) {
      ^~~~
cookie_auth.c:62:3: note: remove the 'if' if its condition is always false
  if (cookie_header == NULL) goto clean;
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cookie_auth.c:64:3: note: variable 'ssid' is declared here
  char *ssid = ssid_buf;
  ^
2 errors generated.
```