### PR TITLE
Pass user data to the handler in case of failed multipart upload

### DIFF
--- a/src/mg_http.c
+++ b/src/mg_http.c
@@ -746,6 +746,7 @@ void mg_http_handler(struct mg_connection *nc, int ev,
       struct mg_http_multipart_part mp;
       memset(&mp, 0, sizeof(mp));
       mp.status = -1;
+      mp.user_data = pd->mp_stream.user_data;
       mp.var_name = pd->mp_stream.var_name;
       mp.file_name = pd->mp_stream.file_name;
       mg_call(nc, (pd->endpoint_handler ? pd->endpoint_handler : nc->handler),


### PR DESCRIPTION
In case of an error'd multipart upload handler is called with MG_EV_HTTP_MULTIPART_REQUEST_END and newly constructed mg_http_multipart_part. This structure is missing the user_data which was maybe stored there during normal operation (e.g. MG_EV_HTTP_PART_BEGIN).

Provide pointer to the used user_data so in a case of an error a user gets a chance to do the cleanup.