### PR TITLE
libFuzzer integration + bug report

### DIFF
--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -1,0 +1,17 @@
+# Copyright (c) 2014 Cesanta Software
+# All rights reserved
+
+# `wildcard ./*/` works in both linux and linux/wine, while `wildcard */` enumerates nothing under wine
+SUBDIRS = $(sort $(dir $(wildcard ./*/)))
+SUBDIRS:=$(filter-out ./ , $(SUBDIRS))
+
+
+.PHONY: $(SUBDIRS)
+
+all: $(SUBDIRS)
+
+$(SUBDIRS):
+	@$(MAKE) -C $@
+
+clean:
+	for d in $(SUBDIRS) ; do $(MAKE) -C $$d clean ; done

--- a/fuzz/fuzz.mk
+++ b/fuzz/fuzz.mk
@@ -1,0 +1,25 @@
+SOURCES = $(PROG).c ../../mongoose.c
+CFLAGS = -g -W -Wall -Werror -I../.. -Wno-unused-function $(CFLAGS_EXTRA) $(MODULE_CFLAGS)
+
+all: $(PROG)
+
+CFLAGS += -pthread
+
+ifeq ($(SSL_LIB),openssl)
+CFLAGS += -DMG_ENABLE_SSL -lssl -lcrypto
+endif
+ifeq ($(SSL_LIB), krypton)
+CFLAGS += -DMG_ENABLE_SSL ../../../krypton/krypton.c -I../../../krypton
+endif
+ifeq ($(SSL_LIB),mbedtls)
+CFLAGS += -DMG_ENABLE_SSL -DMG_SSL_IF=MG_SSL_IF_MBEDTLS -DMG_SSL_MBED_DUMMY_RANDOM -lmbedcrypto -lmbedtls -lmbedx509
+endif
+
+CC = clang
+CFLAGS += -fsanitize=fuzzer,address
+
+$(PROG): $(SOURCES)
+	$(CC) $(SOURCES) -o $@ $(CFLAGS)
+
+clean:
+	rm -rf *.gc* *.dSYM *.obj *.o a.out $(PROG)

--- a/fuzz/mg_parse_http/Makefile
+++ b/fuzz/mg_parse_http/Makefile
@@ -1,0 +1,3 @@
+PROG = mg_parse_http
+SSL_LIB=openssl
+include ../fuzz.mk

--- a/fuzz/mg_parse_http/mg_parse_http.c
+++ b/fuzz/mg_parse_http/mg_parse_http.c
@@ -1,0 +1,19 @@
+//
+// Created by fuzzit.dev inc.
+//
+
+//
+// Created by fuzzit.dev inc.
+//
+
+#include <stdint.h>
+
+#include "mongoose.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t * Data, size_t Size) {
+    struct http_message req;
+    mg_parse_http((const char *)Data, Size, &req, 0);
+    return 0;
+}
+
+

--- a/src/mg_http.c
+++ b/src/mg_http.c
@@ -455,7 +455,7 @@ int mg_parse_http(const char *s, int n, struct http_message *hm, int is_req) {
     }
   } else {
     s = mg_skip(s, end, " ", &hm->proto);
-    if (end - s < 4 || s[3] != ' ') return -1;
+    if (end - s < 4 || isspace(s[0]) || s[3] != ' ') return -1;
     hm->resp_code = atoi(s);
     if (hm->resp_code < 100 || hm->resp_code >= 600) return -1;
     s += 4;


### PR DESCRIPTION
This commit places the basics for libFuzzer integration with one
fuzzer which fuzzes the mg_parse_http function. The fuzzer is
located at fuzz/mg_parse_http.

To add more fuzzers please add them to ./fuzz directory.

Also a memory corruption bug is found using this fuzzer which
might lead to additional bugs after fix is pushed.