### PR TITLE
Added a script that get mongoose version.

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -20,3 +20,11 @@ $ tools/amalgam.py --prefix=MG --public-header=mongoose.h $(cat mongoose.c.manif
 ```
 
 The same applies to `mongoose.h`, except `--public-header` should be omitted during amalgamation.
+
+## Version
+This produce the mongoose version from the mongoose header file.
+```
+$ tools/version.py
+=> 6.15
+...
+```

--- a/tools/version.py
+++ b/tools/version.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+#
+# This script extracts the mongoose version from mongoose.h, which is the master
+# location for this information.
+#
+
+import argparse
+import re
+import sys
+import os
+version_re = re.compile(r'#define MG_VERSION \"(.*)\"')
+
+parser = argparse.ArgumentParser(description='Extract the mongoose version')
+parser.add_argument('file', default='mongoose.h',
+                    nargs='?', help='mongoose header file')
+parser.add_argument('--src_dir', type=str, default="src",
+                    help='mongoose src dir')
+parser.add_argument('--use_src', action='store_true',
+                    help='get version from src dir')
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+
+    version_file = args.file
+    if args.use_src:
+        source_dir = args.src_dir
+        version_file = os.path.join(source_dir, "mg_common.h")
+
+    with open(version_file) as f:
+        for l in f:
+            m = version_re.match(l)
+            if m:
+                sys.stdout.write(m.group(1))


### PR DESCRIPTION
hi,
I have created a script that get mongoose version (for my own usage),  and thought you might want it.
It was inspired from zmq [version.sh](https://github.com/zeromq/libzmq/blob/master/version.sh).

I tried to use the same conventions you used in the other python scripts except for using `sys.stdout.write` since we need a print without spaces when printing version number.


