### PR TITLE
fix typo in tools/README.md

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -2,7 +2,7 @@
 
 Mongoose is distributed as two files, `mongoose.c` and `mongoose.h` for ease of integration.
 However, when developing Mongoose itself, it can be quite difficult to work with them.
-Internally, these files are an _amalgamation_ of source an header modules.
+Internally, these files are an _amalgamation_ of source and header modules.
 This directory contains utilities to split and re-constitute amalgamated files.
 
 Here's how `mongoose.c` can be split into its consituent parts:


### PR DESCRIPTION
Hey,

my previous pull request #982 was closed. The main issue (the broken preview image) was fixed, but the typo still exists in `tools/README.md`. This PR fixes just that typo.