### PR TITLE
Fix a possibly forgot dereferencing

### DIFF
--- a/src/mg_http.c
+++ b/src/mg_http.c
@@ -236,7 +236,7 @@ static void mg_http_free_proto_data_endpoints(struct mg_http_endpoint **ep) {
     current = tmp;
   }
 
-  ep = NULL;
+  *ep = NULL;
 }
 
 static void mg_http_free_reverse_proxy_data(struct mg_reverse_proxy_data *rpd) {


### PR DESCRIPTION
Suggested by *cppcheck*, and does not look like a false positive, as 
- setting the pointer-pointer argument to NULL would not have any effect at the end of the function.
- On the contrary, setting the referenced pointer to NULL is a good idea in a destructor like `*free()` function.

(Signed CLA)