### PR TITLE
Fix typedef bool for MSC

### DIFF
--- a/src/common/platforms/platform_windows.h
+++ b/src/common/platforms/platform_windows.h
@@ -50,7 +50,7 @@
 #include <windows.h>
 #include <process.h>
 
-#if _MSC_VER < 1700
+#if defined(_MSC_VER) && (_MSC_VER < 1700)
 typedef int bool;
 #else
 #include <stdbool.h>


### PR DESCRIPTION
When compiling for the `CS_P_WINDOWS` platform with Mingw-w64 (or MinGW) the `stdbool` header is available. The `typedef int bool` alternative should be limited to MSC.