### PR TITLE
Handle Apple HAP using http websocket

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -6671,8 +6671,12 @@ void mg_http_handler(struct mg_connection *nc, int ev,
     /* TODO(alashkin): refactor this ifelseifelseifelseifelse */
     if ((req_len < 0 ||
          (req_len == 0 && io->len >= MG_MAX_HTTP_REQUEST_SIZE))) {
+#if MG_ENABLE_HTTP_IGNORE_INVALID
+      mbuf_remove(io, io->len);
+#else
       DBG(("invalid request"));
       nc->flags |= MG_F_CLOSE_IMMEDIATELY;
+#endif
     } else if (req_len == 0) {
       /* Do nothing, request is not yet fully buffered */
     }

--- a/src/mg_http.c
+++ b/src/mg_http.c
@@ -837,8 +837,12 @@ void mg_http_handler(struct mg_connection *nc, int ev,
     /* TODO(alashkin): refactor this ifelseifelseifelseifelse */
     if ((req_len < 0 ||
          (req_len == 0 && io->len >= MG_MAX_HTTP_REQUEST_SIZE))) {
+#if MG_ENABLE_HTTP_IGNORE_INVALID
+      mbuf_remove(io, io->len);
+#else
       DBG(("invalid request"));
       nc->flags |= MG_F_CLOSE_IMMEDIATELY;
+#endif
     } else if (req_len == 0) {
       /* Do nothing, request is not yet fully buffered */
     }

--- a/src/mg_http.c
+++ b/src/mg_http.c
@@ -837,7 +837,7 @@ void mg_http_handler(struct mg_connection *nc, int ev,
     /* TODO(alashkin): refactor this ifelseifelseifelseifelse */
     if ((req_len < 0 ||
          (req_len == 0 && io->len >= MG_MAX_HTTP_REQUEST_SIZE))) {
-#if MG_ENABLE_HTTP_IGNORE_INVALID
+#if MG_ENABLE_HTTP_IGNORE_INVALID_REQUESTS
       mbuf_remove(io, io->len);
 #else
       DBG(("invalid request"));


### PR DESCRIPTION
Define MG_ENABLE_HTTP_IGNORE_INVALID_REQUESTS to ignore nonprintable responses for Apple HomeKit Accessory Protocol