### PR TITLE
Remove logically dead code

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -6812,7 +6812,7 @@ static int mg_http_multipart_continue_wait_for_chunk(struct mg_connection *c) {
       mbuf_remove(io, consumed);
     }
     return 0;
-  } else if (boundary != NULL) {
+  } else {
     size_t data_len = ((size_t)(boundary - io->buf) - 4);
     size_t consumed = mg_http_multipart_call_handler(c, MG_EV_HTTP_PART_DATA,
                                                      io->buf, data_len);
@@ -6824,8 +6824,6 @@ static int mg_http_multipart_continue_wait_for_chunk(struct mg_connection *c) {
     } else {
       return 0;
     }
-  } else {
-    return 0;
   }
 }
 


### PR DESCRIPTION
The if- and else-if-clause already cover the complete value range of
'boundary'. Thus, the original else cannot be reached. Because the
original else-if-clause triggers on the negation of the if-clause it can
be replaced with a simple else.

Signed-off-by: Mark Jonas <toertel@gmail.com>
Acked-by: Stefano Babic <sbabic@denx.de>