### PR TITLE
<bug>: avoid realloc(xx, 0)

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -1431,6 +1431,11 @@ void mbuf_free(struct mbuf *mbuf) {
 
 void mbuf_resize(struct mbuf *a, size_t new_size) WEAK;
 void mbuf_resize(struct mbuf *a, size_t new_size) {
+  /*
+   * Some compiler treat realloc(xx, 0) as free(), then get double freed.
+   */
+  if(!new_size)
+    return;
   if (new_size > a->size || (new_size < a->size && new_size >= a->len)) {
     char *buf = (char *) MBUF_REALLOC(a->buf, new_size);
     /*


### PR DESCRIPTION
Call resize(buf, 0) by chance and get double freed....