### PR TITLE
Suppress error: cast from ‘void*’ to ‘int’ loses precision [-fpermissive] in MG_ENABLE_OPENSSL build.

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3506,7 +3506,7 @@ fail:
 int mg_tls_handshake(struct mg_connection *c) {
   struct mg_tls *tls = (struct mg_tls *) c->tls;
   int rc;
-  SSL_set_fd(tls->ssl, (int) c->fd);
+  SSL_set_fd(tls->ssl, (ssize_t) c->fd);
   rc = c->is_client ? SSL_connect(tls->ssl) : SSL_accept(tls->ssl);
   if (rc == 1) {
     LOG(LL_DEBUG, ("%lu success", c->id));

--- a/src/tls.c
+++ b/src/tls.c
@@ -272,7 +272,7 @@ fail:
 int mg_tls_handshake(struct mg_connection *c) {
   struct mg_tls *tls = (struct mg_tls *) c->tls;
   int rc;
-  SSL_set_fd(tls->ssl, (int) c->fd);
+  SSL_set_fd(tls->ssl, (ssize_t) c->fd);
   rc = c->is_client ? SSL_connect(tls->ssl) : SSL_accept(tls->ssl);
   if (rc == 1) {
     LOG(LL_DEBUG, ("%lu success", c->id));


### PR DESCRIPTION
This PR suppresses the error `cast from ‘void*’ to ‘int’ loses precision [-fpermissive]` in the MG_ENABLE_OPENSSL build.

The cast from `void *` to `int` is illegal in some modern compilers (GCC, Clang). Casting to `ssize_t` is still legal.