### PR TITLE
Improve HTTP client example for TLS and SNI

### DIFF
--- a/examples/http-client/Makefile
+++ b/examples/http-client/Makefile
@@ -3,6 +3,7 @@ CFLAGS ?= -DMG_ENABLE_LINES $(CFLAGS_EXTRA)
 MBEDTLS_DIR ?=
 
 ifeq "$(MBEDTLS_DIR)" ""
+CFLAGS += -DMG_ENABLE_OPENSSL -lssl -lcrypto
 else
 CFLAGS += -DMG_ENABLE_MBEDTLS=1 -I$(MBEDTLS_DIR)/include -I/usr/include
 CFLAGS += -L$(MBEDTLS_DIR)/lib -lmbedtls -lmbedcrypto -lmbedx509

--- a/examples/http-client/main.c
+++ b/examples/http-client/main.c
@@ -9,12 +9,8 @@
 
 #include "mongoose.h"
 
-#if MG_ENABLE_OPENSSL
-static const char *s_url = "https://example.com";
-#else
 // The very first web page in history
 static const char *s_url = "http://info.cern.ch";
-#endif
 
 // Print HTTP response and signal that we're done
 static void fn(struct mg_connection *c, int ev, void *ev_data, void *fn_data) {


### PR DESCRIPTION
I don't find the documentation that describes how to handle SNI (Server Name Indication) as an HTTPS client. This PR adds some code which handles SNI into the example of HTTP client.