### PR TITLE
fixed msvc errors around VLAs when using TLS

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3593,9 +3593,10 @@ int mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
     mbedtls_ssl_conf_ca_chain(&tls->conf, &tls->ca, NULL);
 #endif
     if (opts->srvname.len > 0) {
-      char buf[opts->srvname.len + 1];
-      sprintf(buf, "%.*s", (int) opts->srvname.len, opts->srvname.ptr);
+      char mem[128], *buf = mem;
+      mg_asprintf(&buf, sizeof(mem), "%.*s", (int) opts->srvname.len, opts->srvname.ptr);
       mbedtls_ssl_set_hostname(&tls->ssl, buf);
+      if (buf != mem) free(buf);
     }
     mbedtls_ssl_conf_authmode(&tls->conf, MBEDTLS_SSL_VERIFY_REQUIRED);
   }
@@ -3768,9 +3769,10 @@ int mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
   }
   if (opts->ciphers != NULL) SSL_set_cipher_list(tls->ssl, opts->ciphers);
   if (opts->srvname.len > 0) {
-    char buf[opts->srvname.len + 1];
-    sprintf(buf, "%.*s", (int) opts->srvname.len, opts->srvname.ptr);
+    char mem[128], *buf = mem;
+    mg_asprintf(&buf, sizeof(mem), "%.*s", (int) opts->srvname.len, opts->srvname.ptr);
     SSL_set_tlsext_host_name(tls->ssl, buf);
+    if (buf != mem) free(buf);
   }
   c->tls = tls;
   c->is_tls = 1;

--- a/src/tls.c
+++ b/src/tls.c
@@ -117,9 +117,10 @@ int mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
     mbedtls_ssl_conf_ca_chain(&tls->conf, &tls->ca, NULL);
 #endif
     if (opts->srvname.len > 0) {
-      char buf[opts->srvname.len + 1];
-      sprintf(buf, "%.*s", (int) opts->srvname.len, opts->srvname.ptr);
+      char mem[128], *buf = mem;
+      mg_asprintf(&buf, sizeof(mem), "%.*s", (int) opts->srvname.len, opts->srvname.ptr);
       mbedtls_ssl_set_hostname(&tls->ssl, buf);
+      if (buf != mem) free(buf);
     }
     mbedtls_ssl_conf_authmode(&tls->conf, MBEDTLS_SSL_VERIFY_REQUIRED);
   }
@@ -292,9 +293,10 @@ int mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
   }
   if (opts->ciphers != NULL) SSL_set_cipher_list(tls->ssl, opts->ciphers);
   if (opts->srvname.len > 0) {
-    char buf[opts->srvname.len + 1];
-    sprintf(buf, "%.*s", (int) opts->srvname.len, opts->srvname.ptr);
+    char mem[128], *buf = mem;
+    mg_asprintf(&buf, sizeof(mem), "%.*s", (int) opts->srvname.len, opts->srvname.ptr);
     SSL_set_tlsext_host_name(tls->ssl, buf);
+    if (buf != mem) free(buf);
   }
   c->tls = tls;
   c->is_tls = 1;


### PR DESCRIPTION
MSVC doesn't like VLAs (e.g. https://gcc.godbolt.org/z/Kn6n4TzaP), which means mongoose won't compile with MSVC if using mbedtls or openssl. This resolves it by using a dynamic allocation.

Original errors from mongoose compile with VS2019:
```
mongoose.c(3671,35): error C2057: expected constant expression
mongoose.c(3671,35): error C2466: cannot allocate an array of constant size 0
mongoose.c(3671,36): error C2133: 'buf': unknown size
```