### PR TITLE
Chen

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "cerrno": "c"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "cerrno": "c"
-    }
-}

--- a/mongoose.c
+++ b/mongoose.c
@@ -3084,7 +3084,7 @@ bool mg_socketpair(int *s1, int *s2) {
   // For some reason, native socketpair() call fails on Macos
   // Enable this codepath only when MG_ENABLE_NATIVE_SOCKETPAIR is defined
   int sp[2], ret = 0;
-  if (socketpair(AF_INET, SOCK_DGRAM, IPPROTO_UDP, sp) == 0) {
+  if (socketpair(AF_UNIX, SOCK_STREAM, IPPROTO_UDP, sp) == 0) {
     *s1 = sp[0], *s2 = sp[1], ret = 1;
   }
   LOG(LL_INFO, ("errno %d", errno));

--- a/src/sock.c
+++ b/src/sock.c
@@ -428,7 +428,7 @@ bool mg_socketpair(int *s1, int *s2) {
   // For some reason, native socketpair() call fails on Macos
   // Enable this codepath only when MG_ENABLE_NATIVE_SOCKETPAIR is defined
   int sp[2], ret = 0;
-  if (socketpair(AF_INET, SOCK_DGRAM, IPPROTO_UDP, sp) == 0) {
+  if (socketpair(AF_UNIX, SOCK_STREAM IPPROTO_UDP, sp) == 0) {
     *s1 = sp[0], *s2 = sp[1], ret = 1;
   }
   LOG(LL_INFO, ("errno %d", errno));


### PR DESCRIPTION
Change : in mg_socketpair, change the operation macro from AF_INET to AF_UNIX, and socket type from SOCK_DGRAM to SOCK_STREAM

Reason:  socketpair() can only use in AF_UNIX domain, and we usually use text msg (which use to communicate with other modules in our code) rather than streaming media. so, we should use SOCK_STREAM to make sure the msg is reachable