### PR TITLE
Propose an issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,22 @@
+### Issue
+
+_please add your issue description_
+
+MongoDB: please do not mistake this project with the [mongoosejs project](https://mongoosejs.com/)
+
+### Meta-Info
+
+- mongoose version: _X.Y_
+  - prebuilt?: _y/n_
+    - if not, built with: _toolchain_
+  - custom changes?: _y/n_ (if yes, what is the latest mainline commit?)
+- architecture: _?_
+- OS: _if any_
+- duplicate?
+  - Please have a look at the issues on the [cesanta support forum](https://forum.cesanta.com/c/mongoose-web-server/).
+  - Please check the (closed) [GitHub issues](https://github.com/cesanta/mongoose/issues?q=is%3Aissue+).   
+    You can also search the issues with Google in your favorite browser, e.g. for the IPv6 related issues:    
+    `site:https://github.com/cesanta/mongoose/issues?q=is%3Aissue+ IPv6`
+- if you have a question, did you first try to find an answer in:
+  - the [official documentation](https://cesanta.com/docs/)?
+  - the working [examples](https://github.com/cesanta/mongoose/tree/master/examples)?


### PR DESCRIPTION
As it is in the discussion of raised issues to have some extra iteration because of architecture, library version, and other meta information, an issue template could save these extra rounds and possibly reduce the number of duplicates by highlighting where one can check for answers.

This is just a sketch based on what notifications I got from mongoose in the past months. Feel free to change it.