### PR TITLE
Add static and dynamic lib targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ IPV6 ?= 1
 ASAN_OPTIONS ?=
 EXAMPLES := $(wildcard examples/*)
 EXAMPLE_TARGET ?= example
+PREFIX ?= /usr/local
+SOVERSION = 7.2
 .PHONY: ex test
 
 ifeq "$(SSL)" "MBEDTLS"
@@ -100,6 +102,19 @@ linux: Makefile mongoose.c mongoose.h test/unit_test.c
 linux++: CC = g++
 linux++: WARN += -Wno-shadow  # Ignore "hides constructor for 'struct mg_str'"
 linux++: linux
+
+linux-libs: CFLAGS += -fPIC
+linux-libs: mongoose.o
+	$(CC) mongoose.o $(LDFLAGS) -shared -o libmongoose.so.$(SOVERSION)
+	$(AR) rcs libmongoose.a mongoose.o
+
+install: linux-libs
+	install -Dm644 libmongoose.a libmongoose.so.$(SOVERSION) $(DESTDIR)${PREFIX}/lib
+	ln -s libmongoose.so.$(SOVERSION) $(DESTDIR)${PREFIX}/lib/libmongoose.so 
+	install -Dm644 mongoose.h $(DESTDIR)${PREFIX}/include/mongoose.h
+
+uninstall:
+	rm -rf $(DESTDIR)${PREFIX}/lib/libmongoose.a $(DESTDIR)${PREFIX}/lib/libmongoose.so.$(SOVERSION) $(DESTDIR)${PREFIX}/include/mongoose.h $(DESTDIR)${PREFIX}/lib/libmongoose.so
 
 arm: Makefile mongoose.c mongoose.h test/unit_test.c
 	$(ARM) arm-none-eabi-gcc mongoose.c -c -Itest -DMG_ARCH=MG_ARCH_CUSTOM $(OPTS) $(WARN) $(INCS) -DMG_MAX_HTTP_HEADERS=5 -DMG_ENABLE_LINES -DMG_ENABLE_DIRECTORY_LISTING=0 -DMG_ENABLE_SSI=1


### PR DESCRIPTION
I know that the topic has come up a few times already (e.g. https://github.com/cesanta/mongoose/issues/326) and I understand you, as the maintainers, understand mongoose source code to be simply added to an existing project.

However, I believe that packaging mongoose as a separate lib does have its advantages, e.g. when packaging it for a Linux distro, e.g. https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=mongoose or https://github.com/iris-GmbH/meta-iris-thirdparty/blob/feature/jaor/mongoose_recipe/recipes-core/mongoose/mongoose_7.2.bb. For the latter I extended the existing Makefile in what I believe to be a pretty unintrusive way.

I'd be happy if you would reconsider adding support for building mongoose as a library. If not, so be it. No hard feelings :slightly_smiling_face: