### PR TITLE
Makefile: change curly brackets to round brackets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,12 +109,12 @@ linux-libs: mongoose.o
 	$(AR) rcs libmongoose.a mongoose.o
 
 install: linux-libs
-	install -Dm644 libmongoose.a libmongoose.so.$(SOVERSION) $(DESTDIR)${PREFIX}/lib
-	ln -s libmongoose.so.$(SOVERSION) $(DESTDIR)${PREFIX}/lib/libmongoose.so 
-	install -Dm644 mongoose.h $(DESTDIR)${PREFIX}/include/mongoose.h
+	install -Dm644 libmongoose.a libmongoose.so.$(SOVERSION) $(DESTDIR)$(PREFIX)/lib
+	ln -s libmongoose.so.$(SOVERSION) $(DESTDIR)$(PREFIX)/lib/libmongoose.so
+	install -Dm644 mongoose.h $(DESTDIR)$(PREFIX)/include/mongoose.h
 
 uninstall:
-	rm -rf $(DESTDIR)${PREFIX}/lib/libmongoose.a $(DESTDIR)${PREFIX}/lib/libmongoose.so.$(SOVERSION) $(DESTDIR)${PREFIX}/include/mongoose.h $(DESTDIR)${PREFIX}/lib/libmongoose.so
+	rm -rf $(DESTDIR)$(PREFIX)/lib/libmongoose.a $(DESTDIR)$(PREFIX)/lib/libmongoose.so.$(SOVERSION) $(DESTDIR)$(PREFIX)/include/mongoose.h $(DESTDIR)$(PREFIX)/lib/libmongoose.so
 
 arm: Makefile mongoose.c mongoose.h test/unit_test.c
 	$(ARM) arm-none-eabi-gcc mongoose.c -c -Itest -DMG_ARCH=MG_ARCH_CUSTOM $(OPTS) $(WARN) $(INCS) -DMG_MAX_HTTP_HEADERS=5 -DMG_ENABLE_LINES -DMG_ENABLE_DIRECTORY_LISTING=0 -DMG_ENABLE_SSI=1


### PR DESCRIPTION
Esthetic change which replaces the curly brackets introduced by me in
commit b6ee9e637bbb885c29291f3fcc632b05375f6b28 with round brackets.
Because consistency.