### PR TITLE
Add ifdef guards, fixes issue #1315

### DIFF
--- a/mongoose.h
+++ b/mongoose.h
@@ -14,7 +14,10 @@
 //
 // Alternatively, you can license this software under a commercial
 // license, as set out in <https://www.cesanta.com/license>.
+#ifndef MONGOOSE_H
+#define MONGOOSE_H
 #pragma once
+
 #define MG_VERSION "7.3"
 
 #ifdef __cplusplus
@@ -978,3 +981,5 @@ size_t mg_dns_decode_name(const uint8_t *, size_t, size_t, char *, size_t);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* MONGOOSE_H */


### PR DESCRIPTION
See https://stackoverflow.com/questions/1143936/pragma-once-vs-include-guards for other people rationale on this.
I followed a tip that an user suggested there, to use ifdef guards and pragma once this way:

```c
#ifndef BLAH_H
#define BLAH_H
#pragma once

// ...

#endif
```
