### PR TITLE
Fix #1340: Long HTTP Chunks

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -1401,7 +1401,7 @@ static void walkchunks(struct mg_connection *c, struct mg_http_message *hm,
         char *buf2 = (char *) &c->recv.buf[reqlen];
         size_t memo2 = c->recv.len;
         size_t cl2 = get_chunk_length(&buf2[off], memo2 - reqlen - off, &ll);
-        size_t n = cl < ll + 2 ? 0 : cl2 - ll - 2;
+        size_t n = cl2 < ll + 2 ? 0 : cl2 - ll - 2;
         memmove(buf2 + bl, buf2 + off + ll, n);
         bl += n;
         off += cl2;

--- a/src/http.c
+++ b/src/http.c
@@ -990,7 +990,7 @@ static void walkchunks(struct mg_connection *c, struct mg_http_message *hm,
         char *buf2 = (char *) &c->recv.buf[reqlen];
         size_t memo2 = c->recv.len;
         size_t cl2 = get_chunk_length(&buf2[off], memo2 - reqlen - off, &ll);
-        size_t n = cl < ll + 2 ? 0 : cl2 - ll - 2;
+        size_t n = cl2 < ll + 2 ? 0 : cl2 - ll - 2;
         memmove(buf2 + bl, buf2 + off + ll, n);
         bl += n;
         off += cl2;


### PR DESCRIPTION
Fix a copy/paste error, which resulted in only short (<0x10) chunks being handled as expected.

Fixes #1340 .

Out of curiosity I cut out the relevant parts of the code to godbolt.org and enabled PVS Studio to see whether their (excellent) copy-paste detector would throw a warning: https://godbolt.org/z/bP1P93faE

But it didn't :( 
Anyway, it would be interesting to register this project to their Open Source free service, in other projects I have seen wonders from this tool:
https://pvs-studio.com/en/blog/posts/0614/