### PR TITLE
docs: fix simple typo, priorty -> priority

### DIFF
--- a/examples/stm32-freertos-tcp/stm32f7/core_cm7.h
+++ b/examples/stm32-freertos-tcp/stm32f7/core_cm7.h
@@ -1810,7 +1810,7 @@ __STATIC_INLINE void NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
   reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
   reg_value  =  (reg_value                                   |
                 ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
-                (PriorityGroupTmp << 8U)                      );              /* Insert write key and priorty group */
+                (PriorityGroupTmp << 8U)                      );              /* Insert write key and priority group */
   SCB->AIRCR =  reg_value;
 }
 


### PR DESCRIPTION
There is a small typo in examples/stm32-freertos-tcp/stm32f7/core_cm7.h.

Should read `priority` rather than `priorty`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md