### PR TITLE
Make private functions static and add missing prototypes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SRCS = mongoose.c test/unit_test.c test/packed_fs.c
 HDRS = $(wildcard src/*.h)
 DEFS ?= -DMG_MAX_HTTP_HEADERS=7 -DMG_ENABLE_LINES -DMG_ENABLE_PACKED_FS=1
-WARN ?= -W -Wall -Werror -Wshadow -Wdouble-promotion -fno-common -Wconversion
+WARN ?= -W -Wall -Werror -Wshadow -Wdouble-promotion -fno-common -Wconversion -Wmissing-prototypes
 OPTS ?= -O3 -g3
 INCS ?= -Isrc -I.
 CFLAGS ?= $(OPTS) $(WARN) $(INCS) $(DEFS) $(TFLAGS) $(EXTRA)

--- a/mongoose.c
+++ b/mongoose.c
@@ -177,7 +177,7 @@ static size_t mg_dns_parse_name_depth(const uint8_t *s, size_t len, size_t ofs,
   return i;
 }
 
-size_t mg_dns_parse_name(const uint8_t *s, size_t n, size_t ofs, char *dst,
+static size_t mg_dns_parse_name(const uint8_t *s, size_t n, size_t ofs, char *dst,
                          size_t dstlen) {
   return mg_dns_parse_name_depth(s, n, ofs, dst, dstlen, 0);
 }
@@ -303,7 +303,7 @@ static void dns_cb(struct mg_connection *c, int ev, void *ev_data,
   (void) fn_data;
 }
 
-void mg_dns_send(struct mg_connection *c, const struct mg_str *name,
+static void mg_dns_send(struct mg_connection *c, const struct mg_str *name,
                  uint16_t txnid, bool ipv6) {
   struct {
     struct mg_dns_header header;
@@ -922,7 +922,7 @@ struct mg_str *mg_http_get_header(struct mg_http_message *h, const char *name) {
   return NULL;
 }
 
-void mg_http_parse_headers(const char *s, const char *end,
+static void mg_http_parse_headers(const char *s, const char *end,
                            struct mg_http_header *h, int max_headers) {
   int i;
   for (i = 0; i < max_headers; i++) {
@@ -1122,6 +1122,7 @@ static void restore_http_cb(struct mg_connection *c) {
   c->pfn = http_cb;
 }
 
+char *mg_http_etag(char *buf, size_t len, size_t size, time_t mtime);
 char *mg_http_etag(char *buf, size_t len, size_t size, time_t mtime) {
   snprintf(buf, len, "\"%lx." MG_INT64_FMT "\"", (unsigned long) mtime,
            (int64_t) size);
@@ -2575,7 +2576,7 @@ static uint32_t blk0(union char64long16 *block, int i) {
   z += (w ^ x ^ y) + blk(i) + 0xCA62C1D6 + rol(v, 5); \
   w = rol(w, 30);
 
-void mg_sha1_transform(uint32_t state[5], const unsigned char buffer[64]) {
+static void mg_sha1_transform(uint32_t state[5], const unsigned char buffer[64]) {
   uint32_t a, b, c, d, e;
   union char64long16 block[1];
 
@@ -2973,7 +2974,7 @@ static void mg_set_non_blocking_mode(SOCKET fd) {
 #endif
 }
 
-SOCKET mg_open_listener(const char *url, struct mg_addr *addr) {
+static SOCKET mg_open_listener(const char *url, struct mg_addr *addr) {
   SOCKET fd = INVALID_SOCKET;
   int s_err = 0;  // Memoized socket error, in case closesocket() overrides it
   memset(addr, 0, sizeof(*addr));

--- a/src/base64.c
+++ b/src/base64.c
@@ -1,3 +1,4 @@
+#include "base64.h"
 #include <string.h>
 
 static int mg_b64idx(int c) {

--- a/src/dns.c
+++ b/src/dns.c
@@ -63,7 +63,7 @@ static size_t mg_dns_parse_name_depth(const uint8_t *s, size_t len, size_t ofs,
   return i;
 }
 
-size_t mg_dns_parse_name(const uint8_t *s, size_t n, size_t ofs, char *dst,
+static size_t mg_dns_parse_name(const uint8_t *s, size_t n, size_t ofs, char *dst,
                          size_t dstlen) {
   return mg_dns_parse_name_depth(s, n, ofs, dst, dstlen, 0);
 }
@@ -189,7 +189,7 @@ static void dns_cb(struct mg_connection *c, int ev, void *ev_data,
   (void) fn_data;
 }
 
-void mg_dns_send(struct mg_connection *c, const struct mg_str *name,
+static void mg_dns_send(struct mg_connection *c, const struct mg_str *name,
                  uint16_t txnid, bool ipv6) {
   struct {
     struct mg_dns_header header;

--- a/src/http.c
+++ b/src/http.c
@@ -172,7 +172,7 @@ struct mg_str *mg_http_get_header(struct mg_http_message *h, const char *name) {
   return NULL;
 }
 
-void mg_http_parse_headers(const char *s, const char *end,
+static void mg_http_parse_headers(const char *s, const char *end,
                            struct mg_http_header *h, int max_headers) {
   int i;
   for (i = 0; i < max_headers; i++) {
@@ -372,6 +372,7 @@ static void restore_http_cb(struct mg_connection *c) {
   c->pfn = http_cb;
 }
 
+char *mg_http_etag(char *buf, size_t len, size_t size, time_t mtime);
 char *mg_http_etag(char *buf, size_t len, size_t size, time_t mtime) {
   snprintf(buf, len, "\"%lx." MG_INT64_FMT "\"", (unsigned long) mtime,
            (int64_t) size);

--- a/src/sha1.c
+++ b/src/sha1.c
@@ -62,7 +62,7 @@ static uint32_t blk0(union char64long16 *block, int i) {
   z += (w ^ x ^ y) + blk(i) + 0xCA62C1D6 + rol(v, 5); \
   w = rol(w, 30);
 
-void mg_sha1_transform(uint32_t state[5], const unsigned char buffer[64]) {
+static void mg_sha1_transform(uint32_t state[5], const unsigned char buffer[64]) {
   uint32_t a, b, c, d, e;
   union char64long16 block[1];
 

--- a/src/sock.c
+++ b/src/sock.c
@@ -127,7 +127,7 @@ static void mg_set_non_blocking_mode(SOCKET fd) {
 #endif
 }
 
-SOCKET mg_open_listener(const char *url, struct mg_addr *addr) {
+static SOCKET mg_open_listener(const char *url, struct mg_addr *addr) {
   SOCKET fd = INVALID_SOCKET;
   int s_err = 0;  // Memoized socket error, in case closesocket() overrides it
   memset(addr, 0, sizeof(*addr));

--- a/test/mongoose_custom.c
+++ b/test/mongoose_custom.c
@@ -23,6 +23,7 @@ struct mg_connection *mg_connect(struct mg_mgr *mgr, const char *url,
   return NULL;
 }
 
+void mg_connect_resolved(struct mg_connection *c);
 void mg_connect_resolved(struct mg_connection *c) {
   (void) c;
 }
@@ -52,5 +53,6 @@ struct mg_connection *mg_mkpipe(struct mg_mgr *mgr, mg_event_handler_t fn,
   return NULL;
 }
 
+void _fini(void);
 void _fini(void) {
 }

--- a/test/pack.c
+++ b/test/pack.c
@@ -23,9 +23,11 @@
 #include <sys/stat.h>
 
 static const char *code =
+    "const char *mg_unlist(size_t no);\n"
     "const char *mg_unlist(size_t no) {\n"
     "  return packed_files[no].name;\n"
     "}\n"
+    "const char *mg_unpack(const char *name, size_t *size, time_t *mtime);\n"
     "const char *mg_unpack(const char *name, size_t *size, time_t *mtime) {\n"
     "  const struct packed_file *p;\n"
     "  for (p = packed_files; p->name != NULL; p++) {\n"


### PR DESCRIPTION
Fixes:
```c
mongoose/mongoose.c:180:8: warning: no previous prototype for ‘mg_dns_parse_name’ [-Wmissing-prototypes]
  180 | size_t mg_dns_parse_name(const uint8_t *s, size_t n, size_t ofs, char *dst,
      |        ^~~~~~~~~~~~~~~~~
mongoose/mongoose.c:306:6: warning: no previous prototype for ‘mg_dns_send’ [-Wmissing-prototypes]
  306 | void mg_dns_send(struct mg_connection *c, const struct mg_str *name,
      |      ^~~~~~~~~~~
mongoose/mongoose.c:925:6: warning: no previous prototype for ‘mg_http_parse_headers’ [-Wmissing-prototypes]
  925 | void mg_http_parse_headers(const char *s, const char *end,
      |      ^~~~~~~~~~~~~~~~~~~~~
mongoose/mongoose.c:1125:7: warning: no previous prototype for ‘mg_http_etag’ [-Wmissing-prototypes]
 1125 | char *mg_http_etag(char *buf, size_t len, size_t size, time_t mtime) {
      |       ^~~~~~~~~~~~
mongoose/mongoose.c:2578:6: warning: no previous prototype for ‘mg_sha1_transform’ [-Wmissing-prototypes]
 2578 | void mg_sha1_transform(uint32_t state[5], const unsigned char buffer[64]) {
      |      ^~~~~~~~~~~~~~~~~
mongoose/mongoose.c:2976:8: warning: no previous prototype for ‘mg_open_listener’ [-Wmissing-prototypes]
 2976 | SOCKET mg_open_listener(const char *url, struct mg_addr *addr) {
      |        ^~~~~~~~~~~~~~~~
```