### PR TITLE
sntp: Don't set Leap Indicator in client messages.

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -2826,7 +2826,7 @@ void mg_sntp_send(struct mg_connection *c, unsigned long utc) {
   } else if (utc > s_sntmp_next) {
     uint8_t buf[48] = {0};
     s_sntmp_next = utc + SNTP_INTERVAL_SEC;
-    buf[0] = (3 << 6) | (4 << 3) | 3;
+    buf[0] = (0 << 6) | (4 << 3) | 3;
     mg_send(c, buf, sizeof(buf));
     LOG(LL_DEBUG,
         ("%p request sent, ct %lu, next at %lu", c->fd, utc, s_sntmp_next));

--- a/src/sntp.c
+++ b/src/sntp.c
@@ -52,7 +52,7 @@ void mg_sntp_send(struct mg_connection *c, unsigned long utc) {
   } else if (utc > s_sntmp_next) {
     uint8_t buf[48] = {0};
     s_sntmp_next = utc + SNTP_INTERVAL_SEC;
-    buf[0] = (3 << 6) | (4 << 3) | 3;
+    buf[0] = (0 << 6) | (4 << 3) | 3;
     mg_send(c, buf, sizeof(buf));
     LOG(LL_DEBUG,
         ("%p request sent, ct %lu, next at %lu", c->fd, utc, s_sntmp_next));


### PR DESCRIPTION
Per RFC4330:
This field is significant only in server messages