### PR TITLE
Certificate revocation checking when using mbedtls

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1802,6 +1802,7 @@ while ((mg_mqtt_parse(buf, len, &mm)) == 0) {
 ```c
 struct mg_tls_opts {
   const char *ca;        // CA certificate file. For both listeners and clients
+  const char *crl;       // Certificate Revocation List. For clients
   const char *cert;      // Certificate
   const char *certkey;   // Certificate key
   const char *ciphers;   // Cipher list
@@ -1813,6 +1814,9 @@ TLS initialisation structure:
 - `ca` - Certificate Authority. Can be a filename or a string. Used to verify
   a certificate that the other end sends to us. If NULL, then certificate checking
   is disabled
+- `crl` - Certificate Revocation List. Can be a filename or a string. Used to
+  verify a certificate that the other end sends to us. If NULL, then certificate
+  revocation checking is disabled
 - `cert` - Our own certificate. Can be a filename, or a string. If NULL, then
   we don't authenticate with the other peer
 - `certkey` - A key for a `cert`. Sometimes, a certificate and its key are

--- a/mongoose.h
+++ b/mongoose.h
@@ -900,6 +900,7 @@ void mg_http_serve_ssi(struct mg_connection *c, const char *root,
 
 struct mg_tls_opts {
   const char *ca;         // CA certificate file. For both listeners and clients
+  const char *crl;        // Certificate Revocation List. For clients
   const char *cert;       // Certificate
   const char *certkey;    // Certificate key
   const char *ciphers;    // Cipher list

--- a/src/tls.c
+++ b/src/tls.c
@@ -29,6 +29,7 @@ EXTERN_C int mbedtls_net_send(void *, const unsigned char *, size_t);
 struct mg_tls {
   char *cafile;             // CA certificate path
   mbedtls_x509_crt ca;      // Parsed CA certificate
+  mbedtls_x509_crl crl;     // Parsed Certificate Revocation List
   mbedtls_x509_crt cert;    // Parsed certificate
   mbedtls_ssl_context ssl;  // SSL/TLS context
   mbedtls_ssl_config conf;  // SSL-TLS config
@@ -80,6 +81,9 @@ void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
   const char *ca = opts->ca == NULL     ? "-"
                    : opts->ca[0] == '-' ? "(emb)"
                                         : opts->ca;
+  const char *crl = opts->crl == NULL    ? "-"
+                   : opts->crl[0] == '-' ? "(emb)"
+                                         : opts->crl;
   const char *cert = opts->cert == NULL     ? "-"
                      : opts->cert[0] == '-' ? "(emb)"
                                             : opts->cert;
@@ -90,11 +94,12 @@ void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
     mg_error(c, "TLS OOM");
     goto fail;
   }
-  LOG(LL_DEBUG,
-      ("%lu Setting TLS, CA: %s, cert: %s, key: %s", c->id, ca, cert, certkey));
+  LOG(LL_DEBUG, ("%lu Setting TLS, CA: %s, CRL: %s, cert: %s, key: %s", c->id,
+                 ca, crl, cert, certkey));
   mbedtls_ssl_init(&tls->ssl);
   mbedtls_ssl_config_init(&tls->conf);
   mbedtls_x509_crt_init(&tls->ca);
+  mbedtls_x509_crl_init(&tls->crl);
   mbedtls_x509_crt_init(&tls->cert);
   mbedtls_pk_init(&tls->pk);
   mbedtls_ssl_conf_dbg(&tls->conf, debug_cb, c);
@@ -113,9 +118,19 @@ void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
     mbedtls_ssl_conf_authmode(&tls->conf, MBEDTLS_SSL_VERIFY_NONE);
   }
   if (opts->ca != NULL && opts->ca[0] != '\0') {
+    if (opts->crl != NULL && opts->crl[0] != '\0') {
+      rc = opts->crl[0] == '-'
+               ? mbedtls_x509_crl_parse(&tls->crl, (uint8_t *) opts->crl,
+                                        strlen(opts->crl) + 1)
+               : mbedtls_x509_crl_parse_file(&tls->crl, opts->crl);
+      if (rc != 0) {
+        mg_error(c, "parse(%s) err %#x", crl, -rc);
+        goto fail;
+      }
+    }
 #if defined(MBEDTLS_X509_CA_CHAIN_ON_DISK)
     tls->cafile = strdup(opts->ca);
-    rc = mbedtls_ssl_conf_ca_chain_file(&tls->conf, tls->cafile, NULL);
+    rc = mbedtls_ssl_conf_ca_chain_file(&tls->conf, tls->cafile, &tls->crl);
     if (rc != 0) {
       mg_error(c, "parse on-disk chain(%s) err %#x", ca, -rc);
       goto fail;
@@ -129,7 +144,7 @@ void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
       mg_error(c, "parse(%s) err %#x", ca, -rc);
       goto fail;
     }
-    mbedtls_ssl_conf_ca_chain(&tls->conf, &tls->ca, NULL);
+    mbedtls_ssl_conf_ca_chain(&tls->conf, &tls->ca, &tls->crl);
 #endif
     if (opts->srvname.len > 0) {
       char mem[128], *buf = mem;
@@ -202,6 +217,7 @@ void mg_tls_free(struct mg_connection *c) {
   mbedtls_ssl_free(&tls->ssl);
   mbedtls_pk_free(&tls->pk);
   mbedtls_x509_crt_free(&tls->ca);
+  mbedtls_x509_crl_free(&tls->crl);
   mbedtls_x509_crt_free(&tls->cert);
   mbedtls_ssl_config_free(&tls->conf);
   free(tls);

--- a/src/tls.h
+++ b/src/tls.h
@@ -3,6 +3,7 @@
 
 struct mg_tls_opts {
   const char *ca;         // CA certificate file. For both listeners and clients
+  const char *crl;        // Certificate Revocation List. For clients
   const char *cert;       // Certificate
   const char *certkey;    // Certificate key
   const char *ciphers;    // Cipher list


### PR DESCRIPTION
This commit expands mongoose API so that it is possible to use the Certificate Revocation List checking supported by mbedtls.