### PR TITLE
Add SPDX Identifier.

### DIFF
--- a/LICENSES/LicenseRef-Cesanta.txt
+++ b/LICENSES/LicenseRef-Cesanta.txt
@@ -1,0 +1,11 @@
+Copyright (c) 2004-2013 Sergey Lyubka
+Copyright (c) 2013-2021 Cesanta Software Limited
+All rights reserved
+
+This software is dual-licensed: you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 2 as
+published by the Free Software Foundation. For the terms of this
+license, see <http://www.gnu.org/licenses/>.
+
+You can license this software under a commercial license, as set out
+in <https://mongoose.ws/licensing/>.

--- a/mongoose.c
+++ b/mongoose.c
@@ -2,6 +2,8 @@
 // Copyright (c) 2013-2021 Cesanta Software Limited
 // All rights reserved
 //
+// SPDX-License-Identifier: GPL-2.0-only OR LicenseRef-Cesanta
+//
 // This software is dual-licensed: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as
 // published by the Free Software Foundation. For the terms of this

--- a/mongoose.h
+++ b/mongoose.h
@@ -2,6 +2,8 @@
 // Copyright (c) 2013-2021 Cesanta Software Limited
 // All rights reserved
 //
+// SPDX-License-Identifier: GPL-2.0-only OR LicenseRef-Cesanta
+//
 // This software is dual-licensed: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as
 // published by the Free Software Foundation. For the terms of this

--- a/src/license.h
+++ b/src/license.h
@@ -2,6 +2,8 @@
 // Copyright (c) 2013-2021 Cesanta Software Limited
 // All rights reserved
 //
+// SPDX-License-Identifier: GPL-2.0-only OR LicenseRef-Cesanta
+//
 // This software is dual-licensed: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as
 // published by the Free Software Foundation. For the terms of this


### PR DESCRIPTION
This makes it easier for projects using mongoose to audit license compliance.