### PR TITLE
Expose tls config

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1886,6 +1886,26 @@ struct mg_tls_opts opts = {.cert = "ca.pem"};
 mg_tls_init(c, &opts);
 ```
 
+### mg\_tls\_set\_config\_cb()
+
+```c
+void mg_tls_set_config_cb(void (*fn)(void *data))
+```
+
+By default, `mg_tls_init` initialises TLS for a given connection with a standard security
+configuration depending on the crypto library used. `mg_tl_set_config_cb` can be used
+to define a custom callback that can modify the security configuration.
+This callback will be called before starting the TLS handshake.
+
+If mbedTLS library is used, `data` will point to the corresponding mbedtls
+config and will be of type `mbedtls_ssl_config *`.
+
+If OpenSSl library is used, `data` will point ot the corresponding SSL object
+and will be of type `SSL *`.
+
+Parameters:
+- `fn` - callback function, will be called before starting the TLS handshake
+
 ## Timer
 
 ### struct mg\_timer

--- a/docs/README.md
+++ b/docs/README.md
@@ -1893,7 +1893,7 @@ void mg_tls_set_config_cb(void (*fn)(void *data))
 ```
 
 By default, `mg_tls_init` initialises TLS for a given connection with a standard security
-configuration depending on the crypto library used. `mg_tl_set_config_cb` can be used
+configuration depending on the crypto library used. `mg_tls_set_config_cb` can be used
 to define a custom callback that can modify the security configuration.
 This callback will be called before starting the TLS handshake.
 

--- a/mongoose.c
+++ b/mongoose.c
@@ -4103,7 +4103,6 @@ void mg_tls_handshake(struct mg_connection *c) {
 }
 void mg_tls_set_config_cb(void (*fn)(void *)) {
     (void) fn;
-    mg_error(c, "TLS is not enabled");
 }
 void mg_tls_free(struct mg_connection *c) {
   (void) c;

--- a/mongoose.h
+++ b/mongoose.h
@@ -914,6 +914,7 @@ struct mg_tls_opts {
 };
 
 void mg_tls_init(struct mg_connection *, struct mg_tls_opts *);
+void mg_tls_set_config_cb(void (*fn)(void *data));
 void mg_tls_free(struct mg_connection *);
 long mg_tls_send(struct mg_connection *, const void *buf, size_t len);
 long mg_tls_recv(struct mg_connection *, void *buf, size_t len);

--- a/src/tls.c
+++ b/src/tls.c
@@ -36,6 +36,8 @@ struct mg_tls {
   mbedtls_pk_context pk;    // Private key context
 };
 
+static void (*s_config_cb)(void *) = NULL;
+
 void mg_tls_handshake(struct mg_connection *c) {
   struct mg_tls *tls = (struct mg_tls *) c->tls;
   int rc;
@@ -182,6 +184,9 @@ void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
       goto fail;
     }
   }
+  if (s_config_cb != NULL) {
+      s_config_cb(&tls->conf);
+  }
   if ((rc = mbedtls_ssl_setup(&tls->ssl, &tls->conf)) != 0) {
     mg_error(c, "setup err %#x", -rc);
     goto fail;
@@ -196,6 +201,10 @@ void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
 fail:
   c->is_closing = 1;
   free(tls);
+}
+
+void mg_tls_set_config_cb(void (*fn)(void *)) {
+    s_config_cb = fn;
 }
 
 long mg_tls_recv(struct mg_connection *c, void *buf, size_t len) {
@@ -232,6 +241,8 @@ struct mg_tls {
   SSL_CTX *ctx;
   SSL *ssl;
 };
+
+static void (*s_config_cb)(void *) = NULL;
 
 static int mg_tls_err(struct mg_tls *tls, int res) {
   int err = SSL_get_error(tls->ssl, res);
@@ -328,6 +339,9 @@ void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
     SSL_set_tlsext_host_name(tls->ssl, buf);
     if (buf != mem) free(buf);
   }
+  if (s_config_cb != NULL) {
+      s_config_cb(tls->ssl);
+  }
   c->tls = tls;
   c->is_tls = 1;
   c->is_tls_hs = 1;
@@ -340,6 +354,10 @@ void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
 fail:
   c->is_closing = 1;
   free(tls);
+}
+
+void mg_tls_set_config_cb(void (*fn)(void *)) {
+    s_config_cb = fn;
 }
 
 void mg_tls_handshake(struct mg_connection *c) {
@@ -382,6 +400,10 @@ long mg_tls_send(struct mg_connection *c, const void *buf, size_t len) {
 void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
   (void) opts;
   mg_error(c, "TLS is not enabled");
+}
+void mg_tls_set_config_cb(void (*fn)(void *)) {
+    (void) fn;
+    mg_error(c, "TLS is not enabled");
 }
 void mg_tls_handshake(struct mg_connection *c) {
   (void) c;

--- a/src/tls.c
+++ b/src/tls.c
@@ -403,7 +403,6 @@ void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
 }
 void mg_tls_set_config_cb(void (*fn)(void *)) {
     (void) fn;
-    mg_error(c, "TLS is not enabled");
 }
 void mg_tls_handshake(struct mg_connection *c) {
   (void) c;

--- a/src/tls.h
+++ b/src/tls.h
@@ -11,6 +11,7 @@ struct mg_tls_opts {
 };
 
 void mg_tls_init(struct mg_connection *, struct mg_tls_opts *);
+void mg_tls_set_config_cb(void (*fn)(void *data));
 void mg_tls_free(struct mg_connection *);
 long mg_tls_send(struct mg_connection *, const void *buf, size_t len);
 long mg_tls_recv(struct mg_connection *, void *buf, size_t len);


### PR DESCRIPTION
Currently there is  no way for the user application to use a custom security configuration.
Only the standard configuration  hard-coded in `mg_tls_init` can be used.

This pull request adds a new mg_tls API function allowing the user to set a callback, with which he can modify the tls security configuration at will.