### PR TITLE
Add tls configuration callback

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1838,6 +1838,7 @@ struct mg_tls_opts {
   const char *certkey;   // Certificate key
   const char *ciphers;   // Cipher list
   struct mg_str srvname; // If not empty, enables server name verification
+  void (*cfn)(void *);   // Configuration-specific callback function
 };
 ```
 
@@ -1855,6 +1856,13 @@ TLS initialisation structure:
   `certkey` could be the same
 - `ciphers` - A list of allowed ciphers
 - `srvname` - Enable server name verification
+- `cfn` - Function to modify the default TLS configuration. 
+  If NULL, the default configuration of the TLS library will be used.
+  If set, `cfn` will be invoked after the default configuration has been set
+  and before the TLS handshake. In case of mbedTLS, the argument of `cfn`
+  will be a pointer to the coresponding `mbedtls_ssl_config` configuration.
+  In case of OpenSSL the argument of `cfn` will be a pointer to the coresponding
+  `SSL` object.
 
 
 NOTE: if both `ca` and `cert` are set, then so-called two-way TLS is enabled,

--- a/mongoose.c
+++ b/mongoose.c
@@ -3880,6 +3880,9 @@ void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
       goto fail;
     }
   }
+  if (opts->cfn != NULL) {
+      opts->cfn(&tls->conf);
+  }
   if ((rc = mbedtls_ssl_setup(&tls->ssl, &tls->conf)) != 0) {
     mg_error(c, "setup err %#x", -rc);
     goto fail;
@@ -4025,6 +4028,9 @@ void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
                 opts->srvname.ptr);
     SSL_set_tlsext_host_name(tls->ssl, buf);
     if (buf != mem) free(buf);
+  }
+  if (opts->cfn != NULL) {
+      opts->cfn(tls->ssl);
   }
   c->tls = tls;
   c->is_tls = 1;

--- a/mongoose.h
+++ b/mongoose.h
@@ -911,6 +911,7 @@ struct mg_tls_opts {
   const char *certkey;    // Certificate key
   const char *ciphers;    // Cipher list
   struct mg_str srvname;  // If not empty, enables server name verification
+  void (*cfn)(void *);    // Configuration-specific callback function
 };
 
 void mg_tls_init(struct mg_connection *, struct mg_tls_opts *);

--- a/src/tls.c
+++ b/src/tls.c
@@ -182,6 +182,9 @@ void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
       goto fail;
     }
   }
+  if (opts->cfn != NULL) {
+      opts->cfn(&tls->conf);
+  }
   if ((rc = mbedtls_ssl_setup(&tls->ssl, &tls->conf)) != 0) {
     mg_error(c, "setup err %#x", -rc);
     goto fail;
@@ -327,6 +330,9 @@ void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
                 opts->srvname.ptr);
     SSL_set_tlsext_host_name(tls->ssl, buf);
     if (buf != mem) free(buf);
+  }
+  if (opts->cfn != NULL) {
+      opts->cfn(tls->ssl);
   }
   c->tls = tls;
   c->is_tls = 1;

--- a/src/tls.h
+++ b/src/tls.h
@@ -8,6 +8,7 @@ struct mg_tls_opts {
   const char *certkey;    // Certificate key
   const char *ciphers;    // Cipher list
   struct mg_str srvname;  // If not empty, enables server name verification
+  void (*cfn)(void *);    // Configuration-specific callback function
 };
 
 void mg_tls_init(struct mg_connection *, struct mg_tls_opts *);


### PR DESCRIPTION
Currently there is no way for the user application to use a custom security configuration.
Only the standard configuration hard-coded in `mg_tls_init `can be used.

This pull request allows the user to define a callback, with which he can modify the tls security configuration at will.