### PR TITLE
Add mg_tls_init_modify_conf()

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1886,6 +1886,27 @@ struct mg_tls_opts opts = {.cert = "ca.pem"};
 mg_tls_init(c, &opts);
 ```
 
+### mg\_tls\_init\_modify\_conf()
+
+```c
+void mg_tls_init_modify_conf(struct mg_connection *c, struct mg_tls_opts *opts, void (*fn)(void *));
+```
+
+Same as `mg_tls_init()` but with the possibility to modify the default configuration of the TLS library.
+
+Parameters:
+- `c` - Connection, for which TLS should be initialized
+- `opts` - TLS initialization parameters
+- `fn` - Function to modify the default configuration of the TLS library. 
+  If NULL, the default configuration of the TLS library will be used as in `mg_tls_init()`.
+  If set, `fn` will be invoked after the default configuration has been applied
+  and before the TLS handshake. In case of mbedTLS, the argument of `fn`
+  will be a pointer to the coresponding `mbedtls_ssl_config` configuration.
+  In case of OpenSSL the argument of `fn` will be a pointer to the coresponding
+  `SSL` object.
+
+Return value: None
+
 ## Timer
 
 ### struct mg\_timer

--- a/mongoose.c
+++ b/mongoose.c
@@ -3773,7 +3773,8 @@ static int rng_get(void *p_rng, unsigned char *buf, size_t len) {
 }
 #endif
 
-void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
+static void mg_tls_init_core(struct mg_connection *c, struct mg_tls_opts *opts,
+                             void (*fn)(void *)) {
   struct mg_tls *tls = (struct mg_tls *) calloc(1, sizeof(*tls));
   int rc = 0;
   const char *ca = opts->ca == NULL     ? "-"
@@ -3880,6 +3881,9 @@ void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
       goto fail;
     }
   }
+  if (fn != NULL) {
+    fn(&tls->conf);
+  }
   if ((rc = mbedtls_ssl_setup(&tls->ssl, &tls->conf)) != 0) {
     mg_error(c, "setup err %#x", -rc);
     goto fail;
@@ -3894,6 +3898,15 @@ void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
 fail:
   c->is_closing = 1;
   free(tls);
+}
+
+void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
+  return mg_tls_init_core(c, opts, NULL);
+}
+
+void mg_tls_init_modify_conf(struct mg_connection *c, struct mg_tls_opts *opts,
+                             void (*fn)(void *)) {
+  return mg_tls_init_core(c, opts, fn);
 }
 
 long mg_tls_recv(struct mg_connection *c, void *buf, size_t len) {
@@ -3949,7 +3962,8 @@ static int mg_tls_err(struct mg_tls *tls, int res) {
   return err;
 }
 
-void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
+static void mg_tls_init_core(struct mg_connection *c, struct mg_tls_opts *opts,
+                             void (*fn)(void *)) {
   struct mg_tls *tls = (struct mg_tls *) calloc(1, sizeof(*tls));
   const char *id = "mongoose";
   static unsigned char s_initialised = 0;
@@ -4026,6 +4040,9 @@ void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
     SSL_set_tlsext_host_name(tls->ssl, buf);
     if (buf != mem) free(buf);
   }
+  if (fn != NULL) {
+    fn(tls->ssl);
+  }
   c->tls = tls;
   c->is_tls = 1;
   c->is_tls_hs = 1;
@@ -4038,6 +4055,15 @@ void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
 fail:
   c->is_closing = 1;
   free(tls);
+}
+
+void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
+  return mg_tls_init_core(c, opts, NULL);
+}
+
+void mg_tls_init_modify_conf(struct mg_connection *c, struct mg_tls_opts *opts,
+                             void (*fn)(void *)) {
+  return mg_tls_init_core(c, opts, fn);
 }
 
 void mg_tls_handshake(struct mg_connection *c) {
@@ -4080,6 +4106,12 @@ long mg_tls_send(struct mg_connection *c, const void *buf, size_t len) {
 void mg_tls_init(struct mg_connection *c, struct mg_tls_opts *opts) {
   (void) opts;
   mg_error(c, "TLS is not enabled");
+}
+void mg_tls_init_modify_conf(struct mg_connection *c, struct mg_tls_opts *opts,
+                             void (*fn)(void *)) {
+    (void) opts;
+    (void) fn;
+    mg_error(c, "TLS is not enabled");
 }
 void mg_tls_handshake(struct mg_connection *c) {
   (void) c;

--- a/mongoose.h
+++ b/mongoose.h
@@ -914,6 +914,8 @@ struct mg_tls_opts {
 };
 
 void mg_tls_init(struct mg_connection *, struct mg_tls_opts *);
+void mg_tls_init_modify_conf(struct mg_connection *, struct mg_tls_opts *,
+                             void (*fn)(void *));
 void mg_tls_free(struct mg_connection *);
 long mg_tls_send(struct mg_connection *, const void *buf, size_t len);
 long mg_tls_recv(struct mg_connection *, void *buf, size_t len);

--- a/src/tls.h
+++ b/src/tls.h
@@ -11,6 +11,8 @@ struct mg_tls_opts {
 };
 
 void mg_tls_init(struct mg_connection *, struct mg_tls_opts *);
+void mg_tls_init_modify_conf(struct mg_connection *, struct mg_tls_opts *,
+                             void (*fn)(void *));
 void mg_tls_free(struct mg_connection *);
 long mg_tls_send(struct mg_connection *, const void *buf, size_t len);
 long mg_tls_recv(struct mg_connection *, void *buf, size_t len);


### PR DESCRIPTION
Adds possibility to modify the default configuration of the TLS library.

Currently there is no way for the user application to use a custom security configuration.
Only the standard configuration hard-coded in `mg_tls_init()` can be used.

This pull request adds a TLS API function similar to `mg_tls_init()`  with an extra callback as parameter. With this callback the user application can modify the TLS security configuration at will.