### PR TITLE
fix compile error

### DIFF
--- a/examples/mqtt-server/main.c
+++ b/examples/mqtt-server/main.c
@@ -78,7 +78,7 @@ static void fn(struct mg_connection *c, int ev, void *ev_data, void *fn_data) {
         for (struct sub *sub = s_subs; sub != NULL; sub = sub->next) {
           if (mg_globmatch(sub->topic.ptr, sub->topic.len, mm->topic.ptr,
                            mm->topic.len)) {
-            mg_mqtt_pub(sub->c, &mm->topic, &mm->data, 1, false);
+            mg_mqtt_pub(sub->c, mm->topic, mm->data, 1, false);
           }
         }
         break;


### PR DESCRIPTION
[ray@vr8 mqtt-server]$ make
cc ../../mongoose.c -I../.. -W -Wall -DMG_ENABLE_LINES=1  -o example main.c
main.c: In function ‘fn’:
main.c:81:33: error：The 2nd argument type of 'mg_mqtt_pub 'is incompatible
             mg_mqtt_pub(sub->c, &mm->topic, &mm->data, 1, false);
                                 ^~~~~~~~~~
In file included from main.c:10:
../../mongoose.h:1105:57: Note: Type 'struct mg_str' is required, but the type of actual parameter is' struct mg_str *'
 void mg_mqtt_pub(struct mg_connection *c, struct mg_str topic,
                                           ~~~~~~~~~~~~~~^~~~~
main.c:81:45: error：The 3rd argument type of' mg_mqtt_pub 'is incompatible
             mg_mqtt_pub(sub->c, &mm->topic, &mm->data, 1, false);
                                             ^~~~~~~~~
In file included from main.c:10:
../../mongoose.h:1106:32: Note: Type 'struct mg_str' is required, but the type of actual parameter is' struct mg_str *'
                  struct mg_str data, int qos, bool retain);
                  ~~~~~~~~~~~~~~^~~~
make: *** [Makefile:7：example] error 1
[ray@vr8 mqtt-server]$ gcc --version
gcc (GCC) 8.5.0 20210514 (Red Hat 8.5.0-4)
Copyright © 2018 Free Software Foundation, Inc.
