### PR TITLE
Relax sccmp test(output differs in valgrind for some tests) and test under valgrind.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,14 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install packages
-      run: sudo apt-get install libmbedtls-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install libmbedtls-dev valgrind
+    - name: valgrind
+      run: make test test++ IPV6=0 CC=gcc ASAN= ASAN_OPTIONS= RUN="valgrind
+        --tool=memcheck --gen-suppressions=all --leak-check=full
+        --show-leak-kinds=all --leak-resolution=high --track-origins=yes
+        --error-exitcode=1 --exit-on-first-error=yes"
     - name: gcc
       run: make test test++ IPV6=0 CC=gcc
     - name: clang

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -1212,7 +1212,7 @@ static bool sn(const char *fmt, ...) {
   return result;
 }
 
-static bool sccmp(const char *s1, const char *s2) {
+static bool sccmp(const char *s1, const char *s2, bool strict) {
   int n1 = mg_casecmp(s1, s2);
 #if MG_ARCH == MG_ARCH_UNIX
   int n2 = strcasecmp(s1, s2);
@@ -1220,6 +1220,8 @@ static bool sccmp(const char *s1, const char *s2) {
   int n2 = mg_casecmp(s1, s2);  // On MSVC98, _stricmp() is buggy
 #endif
   MG_INFO(("[%s] [%s] %d %d", s1, s2, n1, n2));
+  if (!strict && n1 && n2)
+    return true;
   return n1 == n2;
 }
 
@@ -1234,11 +1236,11 @@ static void test_str(void) {
   ASSERT(mg_strstr(mg_str("abc"), mg_str("b")) != NULL);
   ASSERT(mg_strcmp(mg_str("hi"), mg_strstrip(mg_str(" \thi\r\n"))) == 0);
 
-  ASSERT(sccmp("", ""));
-  ASSERT(sccmp("", "1"));
-  ASSERT(sccmp("a", "A"));
-  ASSERT(sccmp("a1", "A"));
-  ASSERT(sccmp("a", "A1"));
+  ASSERT(sccmp("", "", true));
+  ASSERT(sccmp("", "1", false));
+  ASSERT(sccmp("a", "A", true));
+  ASSERT(sccmp("a1", "A", false));
+  ASSERT(sccmp("a", "A1", false));
 
   ASSERT(sn("%d", 0));
   ASSERT(sn("%d", 1));


### PR DESCRIPTION
Output under valgrind:
```
3af51 2 unit_test.c:1222:sccmp          [] [] 0 0
3af62 2 unit_test.c:1222:sccmp          [] [1] -49 -1
3af64 2 unit_test.c:1222:sccmp          [a] [A] 0 0
3af64 2 unit_test.c:1222:sccmp          [a1] [A] 49 1
3af65 2 unit_test.c:1222:sccmp          [a] [A1] -49 -1
```