### PR TITLE
Regenerate pack file when dependencies are changed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ all: mg_prefix unamalgamated unpacked test test++ arm examples vc98 vc2017 mingw
 examples:
 	@for X in $(EXAMPLES); do test -f $$X/Makefile || continue; $(MAKE) -C $$X example || exit 1; done
 
-test/packed_fs.c:
+test/packed_fs.c: Makefile src/ssi.h test/fuzz.c test/data/a.txt
 	$(CC) $(CFLAGS) test/pack.c -o pack
 	./pack Makefile src/ssi.h test/fuzz.c test/data/a.txt -z 'gzip -c' test/data/range.txt > $@
 


### PR DESCRIPTION
Should help prevent some spurious test failures due to stale `test/packed_fs.c` file.