### PR TITLE
Ensure io->buf is not null in mg_iobuf_del

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CWD ?= $(realpath $(CURDIR))
 DOCKER ?= docker run --rm -e Tmp=. -e WINEDEBUG=-all -v $(CWD):$(CWD) -w $(CWD)
 VCFLAGS = /nologo /W3 /O2 /I. $(DEFS) $(TFLAGS)
 IPV6 ?= 1
-ASAN ?= -fsanitize=address,undefined
+ASAN ?= -fsanitize=address,undefined -fno-sanitize-recover
 ASAN_OPTIONS ?= detect_leaks=1
 EXAMPLES := $(wildcard examples/*)
 PREFIX ?= /usr/local

--- a/mongoose.c
+++ b/mongoose.c
@@ -2030,6 +2030,7 @@ size_t mg_iobuf_add(struct mg_iobuf *io, size_t ofs, const void *buf,
 }
 
 size_t mg_iobuf_del(struct mg_iobuf *io, size_t ofs, size_t len) {
+  if (io->buf == NULL) return 0;
   if (ofs > io->len) ofs = io->len;
   if (ofs + len > io->len) len = io->len - ofs;
   memmove(io->buf + ofs, io->buf + ofs + len, io->len - ofs - len);

--- a/src/iobuf.c
+++ b/src/iobuf.c
@@ -58,6 +58,7 @@ size_t mg_iobuf_add(struct mg_iobuf *io, size_t ofs, const void *buf,
 }
 
 size_t mg_iobuf_del(struct mg_iobuf *io, size_t ofs, size_t len) {
+  if (io->buf == NULL) return 0;
   if (ofs > io->len) ofs = io->len;
   if (ofs + len > io->len) len = io->len - ofs;
   memmove(io->buf + ofs, io->buf + ofs + len, io->len - ofs - len);


### PR DESCRIPTION
Fixes:
```
runtime error: null pointer passed as argument
```