### PR TITLE
Run valgrind tests with appropriate compiler optimizations.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,20 +3,25 @@ on: [push, pull_request]
 jobs:
   linux:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cc: [gcc, clang]
+        target: [test, test++, valgrind]
+        ssl: [MBEDTLS, OPENSSL]
+    name: linux ${{ matrix.target }} CC=${{ matrix.cc }} SSL=${{ matrix.ssl }}
+    env:
+      IPV6: 0
+      CC: ${{ matrix.cc }}
+      SSL: ${{ matrix.ssl }}
     steps:
     - uses: actions/checkout@v3
     - name: Install packages
       run: sudo apt-get update ; sudo apt-get install libmbedtls-dev valgrind
-    - name: gcc
-      run: make test test++ IPV6=0 CC=gcc
-    - name: clang
-      run: make test test++ IPV6=0 CC=clang
-    - name: openssl
-      run: make test SSL=OPENSSL IPV6=0
+    - name: test
+      run: make ${{ matrix.target }}
     - name: unamalgamated
       run: make unamalgamated
-    - name: valgrind
-      run: make valgrind IPV6=0
   examples:
     runs-on: ubuntu-latest
     steps:
@@ -55,165 +60,66 @@ jobs:
     - uses: actions/checkout@v3
     - name: arm
       run: make arm
-  esp32:
+  matrix_examples:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        example:
+          - name: esp32
+            path: esp32
+          - name: esp8266
+            path: esp8266
+          - name: stm32-freertos-tcp
+            path: stm32/stm32-freertos-tcp
+          - name: stm32-nucleo-f746z
+            path: stm32/stm32-nucleo-f746z
+          - name: stm32-nucleo-f429z
+            path: stm32/stm32-nucleo-f429z
+          - name: stm32-nucleo-h743z
+            path: stm32/stm32-nucleo-h743z
+          - name: nxp-mimxrt1020-azurertos
+            path: nxp/nxp-mimxrt1020-azurertos
+          - name: nxp-frdmk66f-freertos
+            path: nxp/nxp-frdmk66f-freertos
+          - name: nxp-lpcxpresso54s018m-freertos
+            path: nxp/nxp-lpcxpresso54s018m-freertos
+          - name: nxp-mimxrt1020-freertos
+            path: nxp/nxp-mimxrt1020-freertos
+          - name: nxp-evkbimxrt1050-lwip-freertos
+            path: nxp/nxp-evkbimxrt1050-lwip-freertos
+          - name: nxp-evkmimxrt1020-lwip-freertos
+            path: nxp/nxp-evkmimxrt1020-lwip-freertos
+          - name: nxp-evkmimxrt1024-lwip-freertos
+            path: nxp/nxp-evkmimxrt1024-lwip-freertos
+          - name: nxp-evkmimxrt1060-lwip-freertos
+            path: nxp/nxp-evkmimxrt1060-lwip-freertos
+          - name: nxp-evkmimxrt1064-lwip-freertos
+            path: nxp/nxp-evkmimxrt1064-lwip-freertos
+          - name: nxp-evkmimxrt1160-cm7-lwip-freertos
+            path: nxp/nxp-evkmimxrt1160-cm7-lwip-freertos
+          - name: nxp-evkmimxrt1170-cm7-lwip-freertos
+            path: nxp/nxp-evkmimxrt1170-cm7-lwip-freertos
+          - name: nxp-frdmk64f-lwip-freertos
+            path: nxp/nxp-frdmk64f-lwip-freertos
+          - name: nxp-frdmk66f-lwip-freertos
+            path: nxp/nxp-frdmk66f-lwip-freertos
+          - name: nxp-lpcxpresso54018-lwip-freertos
+            path: nxp/nxp-lpcxpresso54018-lwip-freertos
+          - name: nxp-lpcxpresso54608-lwip-freertos
+            path: nxp/nxp-lpcxpresso54608-lwip-freertos
+          - name: nxp-lpcxpresso54618-lwip-freertos
+            path: nxp/nxp-lpcxpresso54618-lwip-freertos
+          - name: nxp-lpcxpresso54628-lwip-freertos
+            path: nxp/nxp-lpcxpresso54628-lwip-freertos
+          - name: nxp-twrk65f180m-lwip-freertos
+            path: nxp/nxp-twrk65f180m-lwip-freertos
+          - name: nxp-twrkv58f220m-lwip-freertos
+            path: nxp/nxp-twrkv58f220m-lwip-freertos
+          - name: infineon-xmc4700_4800-lwip-rtx-rtos
+            path: infineon/infineon-xmc4700_4800-lwip-rtx-rtos
+    name: ${{ matrix.example.name }}
     steps:
-    - uses: actions/checkout@v3
-    - name: esp32
-      run: make -C examples/esp32 build
-  esp8266:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: esp8266
-      run: make -C examples/esp8266 build
-  stm32-freertos-tcp:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: stm32-freertos-tcp
-      run: make -C examples/stm32/stm32-freertos-tcp build
-  stm32-nucleo-f746z:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: stm32-nucleo-f746z
-      run: make -C examples/stm32/stm32-nucleo-f746z build
-  stm32-nucleo-f429z:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: stm32-nucleo-f429z
-      run: make -C examples/stm32/stm32-nucleo-f429z build
-  stm32-nucleo-h743z:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: stm32-nucleo-h743z
-      run: make -C examples/stm32/stm32-nucleo-h743z build
-  nxp-mimxrt1020-azurertos:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: nxp-mimxrt1020-azurertos
-      run: make -C examples/nxp/nxp-mimxrt1020-azurertos build
-  nxp-frdmk66f-freertos:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: nxp-frdmk66f-freertos
-      run: make -C examples/nxp/nxp-frdmk66f-freertos build
-  nxp-lpcxpresso54s018m-freertos:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: nxp-lpcxpresso54s018m-freertos
-      run: make -C examples/nxp/nxp-lpcxpresso54s018m-freertos build
-  nxp-mimxrt1020-freertos:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: nxp-mimxrt1020-freertos
-      run: make -C examples/nxp/nxp-mimxrt1020-freertos build
-  nxp-evkbimxrt1050-lwip-freertos:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: nxp-evkbimxrt1050-lwip-freertos
-      run: make -C examples/nxp/nxp-evkbimxrt1050-lwip-freertos build
-  nxp-evkmimxrt1020-lwip-freertos:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: nxp-evkmimxrt1020-lwip-freertos
-      run: make -C examples/nxp/nxp-evkmimxrt1020-lwip-freertos build
-  nxp-evkmimxrt1024-lwip-freertos:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: nxp-evkmimxrt1024-lwip-freertos
-      run: make -C examples/nxp/nxp-evkmimxrt1024-lwip-freertos build
-  nxp-evkmimxrt1060-lwip-freertos:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: nxp-evkmimxrt1060-lwip-freertos
-      run: make -C examples/nxp/nxp-evkmimxrt1060-lwip-freertos build
-  nxp-evkmimxrt1064-lwip-freertos:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: nxp-evkmimxrt1064-lwip-freertos
-      run: make -C examples/nxp/nxp-evkmimxrt1064-lwip-freertos build
-  nxp-evkmimxrt1160-cm7-lwip-freertos:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: nxp-evkmimxrt1160-cm7-lwip-freertos
-      run: make -C examples/nxp/nxp-evkmimxrt1160-cm7-lwip-freertos build
-  nxp-evkmimxrt1170-cm4-lwip-freertos:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: nxp-evkmimxrt1170-cm4-lwip-freertos
-      run: make -C examples/nxp/nxp-evkmimxrt1170-cm4-lwip-freertos build
-  nxp-evkmimxrt1170-cm7-lwip-freertos:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: nxp-evkmimxrt1170-cm7-lwip-freertos
-      run: make -C examples/nxp/nxp-evkmimxrt1170-cm7-lwip-freertos build
-  nxp-frdmk64f-lwip-freertos:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: nxp-frdmk64f-lwip-freertos
-      run: make -C examples/nxp/nxp-frdmk64f-lwip-freertos build
-  nxp-frdmk66f-lwip-freertos:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: nxp-frdmk66f-lwip-freertos
-      run: make -C examples/nxp/nxp-frdmk66f-lwip-freertos build
-  nxp-lpcxpresso54018-lwip-freertos:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: nxp-lpcxpresso54018-lwip-freertos
-      run: make -C examples/nxp/nxp-lpcxpresso54018-lwip-freertos build
-  nxp-lpcxpresso54608-lwip-freertos:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: nxp-lpcxpresso54608-lwip-freertos
-      run: make -C examples/nxp/nxp-lpcxpresso54608-lwip-freertos build
-  nxp-lpcxpresso54618-lwip-freertos:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: nxp-lpcxpresso54618-lwip-freertos
-      run: make -C examples/nxp/nxp-lpcxpresso54618-lwip-freertos build
-  nxp-lpcxpresso54628-lwip-freertos:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: nxp-lpcxpresso54628-lwip-freertos
-      run: make -C examples/nxp/nxp-lpcxpresso54628-lwip-freertos build
-  nxp-twrk65f180m-lwip-freertos:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: nxp-twrk65f180m-lwip-freertos
-      run: make -C examples/nxp/nxp-twrk65f180m-lwip-freertos build
-  nxp-twrkv58f220m-lwip-freertos:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: nxp-twrkv58f220m-lwip-freertos
-      run: make -C examples/nxp/nxp-twrkv58f220m-lwip-freertos build
-  infineon-xmc4700_4800-lwip-rtx-rtos:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: infineon-xmc4700_4800-lwip-rtx-rtos
-      run: make -C examples/infineon/infineon-xmc4700_4800-lwip-rtx-rtos build
+      - uses: actions/checkout@v3
+      - name: ${{ matrix.example.name }}
+        run: make -C examples/${{ matrix.example.path }} build


### PR DESCRIPTION
Per valgrind docs:
> If you are planning to use Memcheck: On rare occasions, compiler optimisations (at -O2 and above, and sometimes -O1) have been observed to generate code which fools Memcheck into wrongly reporting uninitialised value errors, or missing uninitialised value errors.

> So the best solution is to turn off optimisation altogether.

Also cleaned up the tests(some weren't getting run properly like `test++`) using the test matrix feature.