### PR TITLE
Print mqtt buffer on error in tests

### DIFF
--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -365,11 +365,14 @@ static void test_mqtt(void) {
   // Connect with empty client ID
   c = mg_mqtt_connect(&mgr, url, NULL, mqtt_cb, buf);
   for (i = 0; i < 200 && buf[0] == 0; i++) mg_mgr_poll(&mgr, 10);
+  if (buf[0] != 'X')
+    MG_INFO(("[%s]", buf));
   ASSERT(buf[0] == 'X');
   mg_mqtt_sub(c, topic, 1);
   mg_mqtt_pub(c, topic, data, 1, false);
   for (i = 0; i < 300 && buf[1] == 0; i++) mg_mgr_poll(&mgr, 10);
-  // MG_INFO(("[%s]", buf));
+  if (strcmp(buf, "Xx/f12/hi") != 0)
+    MG_INFO(("[%s]", buf));
   ASSERT(strcmp(buf, "Xx/f12/hi") == 0);
 
   // Set params
@@ -384,10 +387,14 @@ static void test_mqtt(void) {
   opts.will_message = mg_str("mg_will_messsage");
   c = mg_mqtt_connect(&mgr, url, &opts, mqtt_cb, buf);
   for (i = 0; i < 300 && buf[0] == 0; i++) mg_mgr_poll(&mgr, 10);
+  if (buf[0] != 'X')
+    MG_INFO(("[%s]", buf));
   ASSERT(buf[0] == 'X');
   mg_mqtt_sub(c, topic, 1);
   mg_mqtt_pub(c, topic, data, 1, false);
   for (i = 0; i < 500 && buf[1] == 0; i++) mg_mgr_poll(&mgr, 10);
+  if (strcmp(buf, "Xx/f12/hi") != 0)
+    MG_INFO(("[%s]", buf));
   ASSERT(strcmp(buf, "Xx/f12/hi") == 0);
 
   mg_mgr_free(&mgr);


### PR DESCRIPTION
This test seems to fail randomly a lot, print the buffer on error to make it easier to isolate issues.