### PR TITLE
Fix mg_mgr_wakeup conflicting types error

### DIFF
--- a/test/mongoose_custom.c
+++ b/test/mongoose_custom.c
@@ -23,8 +23,9 @@ bool mg_send(struct mg_connection *c, const void *buf, size_t len) {
   return 0;
 }
 
-void mg_mgr_wakeup(struct mg_connection *c, const void *buf, size_t len) {
+bool mg_mgr_wakeup(struct mg_connection *c, const void *buf, size_t len) {
   (void) c, (void) buf, (void) len;
+  return 0;
 }
 
 struct mg_connection *mg_mkpipe(struct mg_mgr *mgr, mg_event_handler_t fn,


### PR DESCRIPTION
Fixes:
```c
test/mongoose_custom.c:26:6: error: conflicting types for 'mg_mgr_wakeup'
   26 | void mg_mgr_wakeup(struct mg_connection *c, const void *buf, size_t len) {
      |      ^~~~~~~~~~~~~
In file included from test/mongoose_custom.c:1:
./mongoose.h:956:6: note: previous declaration of 'mg_mgr_wakeup' was here
  956 | bool mg_mgr_wakeup(struct mg_connection *pipe, const void *buf, size_t len);
      |      ^~~~~~~~~~~~~
make: *** [Makefile:105: arm] Error 1
```