### PR TITLE
Add optional poll() implementation under MG_ENABLE_POLL define

### DIFF
--- a/mongoose.h
+++ b/mongoose.h
@@ -436,7 +436,11 @@ extern int SockSet(SOCKET hSock, int Type, int Prop, void *pbuf, int size);
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#if defined(MG_ENABLE_POLL) && MG_ENABLE_POLL
+#include <poll.h>
+#else
 #include <sys/select.h>
+#endif
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -576,6 +580,10 @@ int sscanf(const char *, const char *, ...);
 
 #ifndef MG_ENABLE_MIP
 #define MG_ENABLE_MIP 0
+#endif
+
+#ifndef MG_ENABLE_POLL
+#define MG_ENABLE_POLL 0
 #endif
 
 #ifndef MG_ENABLE_FATFS

--- a/src/arch_unix.h
+++ b/src/arch_unix.h
@@ -22,7 +22,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#if defined(MG_ENABLE_POLL) && MG_ENABLE_POLL
+#include <poll.h>
+#else
 #include <sys/select.h>
+#endif
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/time.h>

--- a/src/config.h
+++ b/src/config.h
@@ -4,6 +4,10 @@
 #define MG_ENABLE_MIP 0
 #endif
 
+#ifndef MG_ENABLE_POLL
+#define MG_ENABLE_POLL 0
+#endif
+
 #ifndef MG_ENABLE_FATFS
 #define MG_ENABLE_FATFS 0
 #endif

--- a/src/sock.c
+++ b/src/sock.c
@@ -383,7 +383,7 @@ static void accept_conn(struct mg_mgr *mgr, struct mg_connection *lsn) {
 #endif
       MG_ERROR(("%lu accept failed, errno %d", lsn->id, MG_SOCK_ERRNO));
 #if (MG_ARCH != MG_ARCH_WIN32) && (MG_ARCH != MG_ARCH_FREERTOS_TCP) && \
-    (MG_ARCH != MG_ARCH_TIRTOS)
+    (MG_ARCH != MG_ARCH_TIRTOS) && !(MG_ENABLE_POLL)
   } else if ((long) fd >= FD_SETSIZE) {
     MG_ERROR(("%ld > %ld", (long) fd, (long) FD_SETSIZE));
     closesocket(fd);
@@ -474,6 +474,39 @@ static void mg_iotest(struct mg_mgr *mgr, int ms) {
     c->is_writable = bits & eSELECT_WRITE ? 1 : 0;
     FreeRTOS_FD_CLR(c->fd, mgr->ss,
                     eSELECT_READ | eSELECT_EXCEPT | eSELECT_WRITE);
+  }
+#elif MG_ENABLE_POLL
+  size_t i = 0, n = 0;
+  for (struct mg_connection *c = mgr->conns; c != NULL; c = c->next) n++;
+  struct pollfd fds[n == 0 ? 1 : n]; // Avoid zero-length VLA
+
+  memset(fds, 0, sizeof(fds));
+  for (struct mg_connection *c = mgr->conns; c != NULL; c = c->next, i++) {
+    if (c->is_closing || c->is_resolving || FD(c) == INVALID_SOCKET) {
+      // Socket not valid, ignore
+    } else {
+      fds[i].fd = FD(c);
+      fds[i].events |= POLLIN;
+      if (c->is_connecting || (c->send.len > 0 && c->is_tls_hs == 0)) {
+          fds[i].events |= POLLOUT;
+      }
+    }
+  }
+
+  if (poll(fds, n, ms) < 0) {
+    MG_ERROR(("poll failed, errno: %d", MG_SOCK_ERRNO));
+    return;
+  }
+
+  i = 0;
+  for (struct mg_connection *c = mgr->conns; c != NULL; c = c->next, i++) {
+    if (c->is_closing || c->is_resolving || FD(c) == INVALID_SOCKET) {
+      // Socket not valid, ignore
+    } else {
+      c->is_readable = (unsigned)(fds[i].revents & POLLIN ? true : false);
+      c->is_writable = (unsigned)(fds[i].revents & POLLOUT ? true : false);
+      fds[i].revents = 0;
+    }
   }
 #else
   struct timeval tv = {ms / 1000, (ms % 1000) * 1000}, tv_zero = {0, 0};


### PR DESCRIPTION
This adds the ability to substitute `select()` with `poll()` on supported
unix environments when `MG_ENABLE_POLL` is defined. A make flag called
`USE_POLL` is provided as well.
Using `poll()` removes the limitation of `FD_SETSIZE` concurrent sockets,
generally 1024 on Linux environments.

Tested with `make test IPV6=0 USE_POLL=1`
Marked as `draft` because I have not debugged a strange issue where substituting the call to `malloc()` in `mg_iotest()` with `alloca()` (as suggested by @cpq) results in the `test_http_client` and `test_dns_error` tests to fail.