### PR TITLE
Do not try to read from full connections.

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -4554,7 +4554,7 @@ void mg_mgr_poll(struct mg_mgr *mgr, int ms) {
     } else if (c->is_tls_hs) {
       if ((c->is_readable || c->is_writable)) mg_tls_handshake(c);
     } else {
-      if (c->is_readable) read_conn(c);
+      if (c->is_readable && can_read(c)) read_conn(c);
       if (c->is_writable) write_conn(c);
     }
 

--- a/src/sock.c
+++ b/src/sock.c
@@ -612,7 +612,7 @@ void mg_mgr_poll(struct mg_mgr *mgr, int ms) {
     } else if (c->is_tls_hs) {
       if ((c->is_readable || c->is_writable)) mg_tls_handshake(c);
     } else {
-      if (c->is_readable) read_conn(c);
+      if (c->is_readable && can_read(c)) read_conn(c);
       if (c->is_writable) write_conn(c);
     }
 


### PR DESCRIPTION
Fixes a bug where setting `c->is_full = true` wasn't stopping reads.