### PR TITLE
fixing offset of Content-Length value.

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -616,7 +616,7 @@ static void listdir(struct mg_connection *c, struct mg_http_message *hm,
             MG_VERSION);
   n = mg_snprintf(tmp, sizeof(tmp), "%lu", (unsigned long) (c->send.len - off));
   if (n > sizeof(tmp)) n = 0;
-  memcpy(c->send.buf + off - 10, tmp, n);  // Set content length
+  memcpy(c->send.buf + off - 12, tmp, n);  // Set content length
 }
 
 static void remove_double_dots(char *s) {


### PR DESCRIPTION
in very large HTTP response, this offset might cause a problem with HTTP header format.

![Screenshot_20220607_075521](https://user-images.githubusercontent.com/3690943/172290160-f3749ed7-f38b-4e0e-b523-ffb6bef38213.png)
