### PR TITLE
fixed poll timeout being larger than timer period 

### DIFF
--- a/examples/mqtt-client/main.c
+++ b/examples/mqtt-client/main.c
@@ -47,7 +47,7 @@ static void fn(struct mg_connection *c, int ev, void *ev_data, void *fn_data) {
     MG_INFO(("SUBSCRIBED to %.*s", (int) subt.len, subt.ptr));
 
     mg_mqtt_pub(c, pubt, data, s_qos, false);
-    MG_INFO(("PUBSLISHED %.*s -> %.*s", (int) data.len, data.ptr,
+    MG_INFO(("PUBLISHED %.*s -> %.*s", (int) data.len, data.ptr,
              (int) pubt.len, pubt.ptr));
   } else if (ev == MG_EV_MQTT_MSG) {
     // When we get echo response, print it

--- a/examples/timers/main.c
+++ b/examples/timers/main.c
@@ -45,9 +45,9 @@ int main(void) {
   struct mg_mgr mgr;  // Event manager
   mg_mgr_init(&mgr);  // Initialise event manager
   mg_log_set("3");    // Set debug log level
-  mg_timer_add(&mgr, 300, MG_TIMER_REPEAT, timer_fn, &mgr);
+  mg_timer_add(&mgr, 1000, MG_TIMER_REPEAT, timer_fn, &mgr);
   mg_http_listen(&mgr, s_listen_on, fn, NULL);  // Create HTTP listener
-  for (;;) mg_mgr_poll(&mgr, 1000);             // Infinite event loop
+  for (;;) mg_mgr_poll(&mgr, 500);             // Infinite event loop
   mg_mgr_free(&mgr);                            // Free manager resources
   return 0;
 }


### PR DESCRIPTION
Timer time was 300ms but msgs came out at 1s 'cause mgr poll timeout was 1s
As 300ms looks too fast, I kept 1s for msg time and reduced poll time to 500ms