### PR TITLE
Use alloca instead of VLA

### DIFF
--- a/src/sock.c
+++ b/src/sock.c
@@ -503,9 +503,11 @@ static void mg_iotest(struct mg_mgr *mgr, int ms) {
 #elif MG_ENABLE_POLL
   nfds_t n = 0;
   for (struct mg_connection *c = mgr->conns; c != NULL; c = c->next) n++;
-  struct pollfd fds[n == 0 ? 1 : n];  // Avoid zero-length VLA
+  int pollCount = n == 0 ? 1 : 1; // Avoid zero-length VLA
+  int pollSize = pollSize * sizeof(struct pollfd);
+  struct pollfd *fds = alloca(pollSize);
 
-  memset(fds, 0, sizeof(fds));
+  memset(fds, 0, pollSize);
   n = 0;
   for (struct mg_connection *c = mgr->conns; c != NULL; c = c->next) {
     c->is_readable = c->is_writable = 0;

--- a/src/sock.c
+++ b/src/sock.c
@@ -504,7 +504,7 @@ static void mg_iotest(struct mg_mgr *mgr, int ms) {
   nfds_t n = 0;
   for (struct mg_connection *c = mgr->conns; c != NULL; c = c->next) n++;
   int pollCount = n == 0 ? 1 : 1; // Avoid zero-length VLA
-  int pollSize = pollSize * sizeof(struct pollfd);
+  int pollSize = pollSize * (int) sizeof(struct pollfd);
   struct pollfd *fds = alloca(pollSize);
 
   memset(fds, 0, pollSize);

--- a/src/sock.c
+++ b/src/sock.c
@@ -504,7 +504,7 @@ static void mg_iotest(struct mg_mgr *mgr, int ms) {
   nfds_t n = 0;
   for (struct mg_connection *c = mgr->conns; c != NULL; c = c->next) n++;
   int pollCount = n == 0 ? 1 : 1; // Avoid zero-length VLA
-  int pollSize = pollSize * (int) sizeof(struct pollfd);
+  int pollSize = pollCount * (int) sizeof(struct pollfd);
   struct pollfd *fds = alloca(pollSize);
 
   memset(fds, 0, pollSize);

--- a/src/sock.c
+++ b/src/sock.c
@@ -503,8 +503,8 @@ static void mg_iotest(struct mg_mgr *mgr, int ms) {
 #elif MG_ENABLE_POLL
   nfds_t n = 0;
   for (struct mg_connection *c = mgr->conns; c != NULL; c = c->next) n++;
-  int pollCount = n == 0 ? 1 : 1; // Avoid zero-length VLA
-  int pollSize = pollCount * (int) sizeof(struct pollfd);
+  size_t pollCount = n == 0 ? 1 : 1; // Avoid zero-length VLA
+  size_t pollSize = pollCount * sizeof(struct pollfd);
   struct pollfd *fds = alloca(pollSize);
 
   memset(fds, 0, pollSize);


### PR DESCRIPTION
Some compilers have problem dealing with VLAs ex: https://issues.dlang.org/show_bug.cgi?id=23213

Ideally a macro to check the feature should be used: https://port70.net/~nsz/c/c11/n1570.html#6.10.8.3

But i think one way of doing it is better for readability