### PR TITLE
Exported MQTT result codes

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3004,8 +3004,6 @@ void mg_md5_final(mg_md5_ctx *ctx, unsigned char digest[16]) {
 #define MQTT_HAS_PASSWORD 0x40
 #define MQTT_HAS_USER_NAME 0x80
 
-enum { MQTT_OK, MQTT_INCOMPLETE, MQTT_MALFORMED };
-
 void mg_mqtt_send_header(struct mg_connection *c, uint8_t cmd, uint8_t flags,
                          uint32_t len) {
   uint8_t buf[1 + sizeof(len)], *vlen = &buf[1];

--- a/mongoose.h
+++ b/mongoose.h
@@ -1230,6 +1230,8 @@ int64_t mg_sntp_parse(const unsigned char *buf, size_t len);
 #define MQTT_CMD_DISCONNECT 14
 #define MQTT_CMD_AUTH 15
 
+enum { MQTT_OK, MQTT_INCOMPLETE, MQTT_MALFORMED };
+
 struct mg_mqtt_opts {
   struct mg_str user;          // Username, can be empty
   struct mg_str pass;          // Password, can be empty

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -12,8 +12,6 @@
 #define MQTT_HAS_PASSWORD 0x40
 #define MQTT_HAS_USER_NAME 0x80
 
-enum { MQTT_OK, MQTT_INCOMPLETE, MQTT_MALFORMED };
-
 void mg_mqtt_send_header(struct mg_connection *c, uint8_t cmd, uint8_t flags,
                          uint32_t len) {
   uint8_t buf[1 + sizeof(len)], *vlen = &buf[1];

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -19,6 +19,8 @@
 #define MQTT_CMD_DISCONNECT 14
 #define MQTT_CMD_AUTH 15
 
+enum { MQTT_OK, MQTT_INCOMPLETE, MQTT_MALFORMED };
+
 struct mg_mqtt_opts {
   struct mg_str user;          // Username, can be empty
   struct mg_str pass;          // Password, can be empty


### PR DESCRIPTION
Since already exported MQTT_CMD_* are also not prefixed with MG_, I left them as they are.
Let me know if you want to prefix something.
