### PR TITLE
util: prefer monotonic clocks for mg_millis

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -5386,6 +5386,12 @@ struct mg_str mg_url_pass(const char *url) {
 #endif
 
 
+#if MG_ARCH == MG_ARCH_UNIX && defined(__APPLE__)
+#include <mach/mach_time.h>
+#elif MG_ARCH == MG_ARCH_UNIX
+#include <time.h>
+#endif
+
 #if MG_ENABLE_CUSTOM_RANDOM
 #else
 void mg_random(void *buf, size_t len) {
@@ -5473,9 +5479,30 @@ uint64_t mg_millis(void) {
   return xTaskGetTickCount() * portTICK_PERIOD_MS;
 #elif MG_ARCH == MG_ARCH_AZURERTOS
   return tx_time_get() * (1000 /* MS per SEC */ / TX_TIMER_TICKS_PER_SECOND);
+#elif MG_ARCH == MG_ARCH_UNIX && defined(__APPLE__)
+  // Value of a clock that increments monotonically in tick units
+  uint64_t ticks = mach_absolute_time();
+  static mach_timebase_info_data_t timebase;
+  if ( timebase.denom == 0 ) {
+    mach_timebase_info(&timebase);
+  }
+  uint64_t uptime_nanos = (uint64_t) ((ticks * timebase.numer) / timebase.denom);
+  return (uint64_t) (uptime_nanos / 1000000);
 #elif MG_ARCH == MG_ARCH_UNIX
   struct timespec ts = {0, 0};
+#ifdef _POSIX_MONOTONIC_CLOCK
+#ifdef CLOCK_MONOTONIC_RAW
+  // Raw hardware-based time that is not subject to NTP adjustments
+  clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+#else
+  // Affected by the incremental adjustments performed by adjtime and NTP
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+#endif
+#else
+  // Affected by discontinuous jumps in the system time and by the incremental adjustments performed by adjtime and NTP
   clock_gettime(CLOCK_REALTIME, &ts);
+#endif
+#include <inttypes.h>
   return ((uint64_t) ts.tv_sec * 1000 + (uint64_t) ts.tv_nsec / 1000000);
 #else
   return (uint64_t) (time(NULL) * 1000);

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -379,6 +379,7 @@ static void test_mqtt_ver(uint8_t mqtt_version) {
   struct mg_str topic = mg_str("x/f12"), data = mg_str("hi");
   struct mg_connection *c;
   struct mg_mqtt_opts opts;
+  char rnd[10], client_id[21], will_topic[21], will_message[21];
   const char *url = "mqtt://broker.hivemq.com:1883";
   int i;
   mg_mgr_init(&mgr);
@@ -410,9 +411,19 @@ static void test_mqtt_ver(uint8_t mqtt_version) {
   opts.will_retain = true;
   opts.keepalive = 20;
   opts.version = mqtt_version;
-  opts.will_topic = mg_str("mg_will_topic");
-  opts.will_message = mg_str("mg_will_messsage");
-  opts.client_id = mg_str("mg_unit_test");
+  mg_random(rnd, sizeof(rnd));
+  mg_hex(rnd, sizeof(rnd), will_topic);
+  client_id[sizeof(will_topic) - 1] = '\0';
+  mg_random(rnd, sizeof(rnd));
+  mg_hex(rnd, sizeof(rnd), will_message);
+  client_id[sizeof(will_message) - 1] = '\0';
+  mg_random(rnd, sizeof(rnd));
+  mg_hex(rnd, sizeof(rnd), client_id);
+  client_id[sizeof(client_id) - 1] = '\0';
+  // Must be randomized to prevent conflicts on same mqtt test server
+  opts.will_topic = mg_str(will_topic);
+  opts.will_message = mg_str(will_message);
+  opts.client_id = mg_str(client_id);
   c = mg_mqtt_connect(&mgr, url, &opts, mqtt_cb, &test_data);
   for (i = 0; i < 300 && buf[0] == 0; i++) mg_mgr_poll(&mgr, 10);
   if (buf[0] != 'X') MG_INFO(("[%s]", buf));


### PR DESCRIPTION
Using non-monotonic clocks for elapsed time calculations tends to break in horrible ways on systems without battery backed clocks due to NTP syncing on system startup(CLOCK_REALTIME will effectively jump far into the future so we should avoid it when possible).