### PR TITLE
Fix json's MG_EOO in nested objects

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -2494,12 +2494,12 @@ int mg_json_get(const char *s, int len, const char *path, int *toklen) {
 
 // In the ascii table, the distance between `[` and `]` is 2.
 // Ditto for `{` and `}`. Hence +2 in the code below.
-#define MG_EOO(x)                                            \
-  do {                                                       \
-    if (depth == ed && ci != ei) return MG_JSON_NOT_FOUND;   \
-    if (c != nesting[depth - 1] + 2) return MG_JSON_INVALID; \
-    depth--;                                                 \
-    MG_CHECKRET(x);                                          \
+#define MG_EOO(x)                                                      \
+  do {                                                                 \
+    if (depth == ed && (ci != ei || ci < 0)) return MG_JSON_NOT_FOUND; \
+    if (c != nesting[depth - 1] + 2) return MG_JSON_INVALID;           \
+    depth--;                                                           \
+    MG_CHECKRET(x);                                                    \
   } while (0)
 
   for (i = 0; i < len; i++) {

--- a/src/json.c
+++ b/src/json.c
@@ -58,12 +58,12 @@ int mg_json_get(const char *s, int len, const char *path, int *toklen) {
 
 // In the ascii table, the distance between `[` and `]` is 2.
 // Ditto for `{` and `}`. Hence +2 in the code below.
-#define MG_EOO(x)                                            \
-  do {                                                       \
-    if (depth == ed && ci != ei) return MG_JSON_NOT_FOUND;   \
-    if (c != nesting[depth - 1] + 2) return MG_JSON_INVALID; \
-    depth--;                                                 \
-    MG_CHECKRET(x);                                          \
+#define MG_EOO(x)                                                      \
+  do {                                                                 \
+    if (depth == ed && (ci != ei || ci < 0)) return MG_JSON_NOT_FOUND; \
+    if (c != nesting[depth - 1] + 2) return MG_JSON_INVALID;           \
+    depth--;                                                           \
+    MG_CHECKRET(x);                                                    \
   } while (0)
 
   for (i = 0; i < len; i++) {

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -2317,7 +2317,7 @@ static void test_get_header_var(void) {
 static void test_json(void) {
   const char *s;
   const char *s1 = "{\"a\":{},\"b\":7,\"c\":[[],2]}";
-  const char *s2 = "{\"a\":{\"b1\":{}},\"c\":7}";
+  const char *s2 = "{\"a\":{\"b1\":{}},\"c\":7,\"d\":{\"b2\":{}}}";
   int n, n1 = (int) strlen(s1), n2 = (int) strlen(s2);
 
   ASSERT(mg_json_get(" true ", 6, "", &n) == MG_JSON_INVALID);


### PR DESCRIPTION
A key present in a later nested object was being incorrectly accepted, e.g.:
searching for `$a.b2` in `{"a": {"b1": {}}, "c": 7, "d": {"b2": {}}}`  returned `d.b2`

Modified test string
`const char *s2 = "{\"a\":{\"b1\":{}},\"c\":7}";` to
`const char *s2 = "{\"a\":{\"b1\":{}},\"c\":7,\"d\":{\"b2\":{}}}";`,
in order to catch it with  `ASSERT(mg_json_get(s2, n2, "$.a.b2", &n) == MG_JSON_NOT_FOUND);` failing; and fixed so now it passes.