### PR TITLE
Fix for new mg_iobuf API

### DIFF
--- a/examples/esp32/uart-bridge/Makefile
+++ b/examples/esp32/uart-bridge/Makefile
@@ -16,7 +16,7 @@ flash: CMD = flash
 flash: DA = --device $(PORT)
 flash: build
 
-.PHONY: flash
+.PHONY: build
 
 bridge.hex: build
 	esputil mkhex \

--- a/examples/esp32/uart-bridge/main/cli.c
+++ b/examples/esp32/uart-bridge/main/cli.c
@@ -44,12 +44,12 @@ static void cli_rm(const char *fname) {
   remove(path);
 }
 
-void cli(uint8_t input_byte) {
-  static struct mg_iobuf in;
+static struct mg_iobuf in;
 
+void cli(uint8_t input_byte) {
   if (input_byte == 0 || input_byte == 0xff) return;
   if (in.len >= 128) in.len = 0;
-  mg_iobuf_add(&in, in.len, &input_byte, sizeof(input_byte), 32);
+  mg_iobuf_add(&in, in.len, &input_byte, sizeof(input_byte));
 
   if (input_byte == '\n') {
     const char *arrow = "---";
@@ -86,4 +86,8 @@ void cli(uint8_t input_byte) {
     printf("%s %s\n", arrow, "CLI output end");
     in.len = 0;
   }
+}
+
+void cli_init(void) {
+  mg_iobuf_init(&in, 0, 32);
 }

--- a/examples/esp32/uart-bridge/main/main.c
+++ b/examples/esp32/uart-bridge/main/main.c
@@ -32,6 +32,7 @@ void app_main(void) {
   } else {
     // If WiFi is not configured, run CLI until configured
     MG_INFO(("WiFi is not configured, running CLI. Press enter"));
+    cli_init();
     for (;;) {
       uint8_t ch = getchar();
       cli(ch);

--- a/examples/esp32/uart-bridge/main/main.h
+++ b/examples/esp32/uart-bridge/main/main.h
@@ -15,3 +15,4 @@ void uart_bridge_fn(struct mg_connection *, int, void *, void *);
 int uart_read(void *buf, size_t len);
 bool wifi_init(const char *ssid, const char *pass);
 void cli(uint8_t ch);
+void cli_init(void);


### PR DESCRIPTION
The iobuf wasn't being explicitly initialized, it defaulted to 0 size and the _add() call was used to set a 32-byte alignment (from first call). Added a cli_init() function to be able to initialize alignment at 32 bytes; and called this function before entering the infinite loop.
Makefile: I think the phony target should be build, since there is a 'build' directory