### PR TITLE
Resolve the bug that repeatedly creates and overwrites existing sockets using mg_wrapfd().

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2004-2013 Sergey Lyubka
+﻿// Copyright (c) 2004-2013 Sergey Lyubka
 // Copyright (c) 2013-2022 Cesanta Software Limited
 // All rights reserved
 //
@@ -4299,11 +4299,15 @@ static void setsockopts(struct mg_connection *c) {
 }
 
 void mg_connect_resolved(struct mg_connection *c) {
+  c->is_client = true;
   // char buf[40];
   int type = c->is_udp ? SOCK_DGRAM : SOCK_STREAM;
   int rc, af = c->rem.is_ip6 ? AF_INET6 : AF_INET;
   // mg_straddr(&c->rem, buf, sizeof(buf));
-  c->fd = S2PTR(socket(af, type, 0));
+  if (!c->fd || INVALID_SOCKET == FD(c))
+  {
+    c->fd = S2PTR(socket(af, type, 0));
+  }
   c->is_resolving = 0;
   if (FD(c) == INVALID_SOCKET) {
     mg_error(c, "socket(): %d", MG_SOCK_ERRNO);


### PR DESCRIPTION
When acting as a TCP(SSL) client, such as the following example code, the existing socket is repeatedly created and overwritten.

```
// Defined MG_ENABLE_OPENSSL

#include <iostream>
#include <thread>
#include "mongoose.h"

using namespace std;

static void cfn(struct mg_connection* c, int ev, void* ev_data, void* fn_data) {

	if (ev == MG_EV_OPEN) {
		MG_INFO(("CLIENT has been initialized"));
	}
	else if (ev == MG_EV_CONNECT) {
		MG_INFO(("CLIENT connected"));
	}
	else if (ev == MG_EV_READ) {
		struct mg_iobuf* r = &c->recv;
		MG_INFO(("CLIENT got data: %.*s", r->len, r->buf));
	}
	else if (ev == MG_EV_CLOSE) {
		MG_INFO(("CLIENT disconnected"));
	}
	else if (ev == MG_EV_ERROR) {
		MG_INFO(("CLIENT error: %s", (char*)ev_data));
	}
}

void timer_fn(void* arg)
{
	struct mg_connection* conn = (struct mg_connection*)arg;
	const int len = 1024;
	char* msg = new char[len] {0};

	if (mg_send(conn, msg, len))
	{
		MG_INFO(("sent"));
	}
	else
	{
		MG_ERROR(("sent failed"));
	}

	delete[] msg;
}

int main()
{
	mg_mgr* mgr = new mg_mgr;
	mg_mgr_init(mgr);
	thread([&, mgr]
		{
			while (true)
			{
				mg_mgr_poll(mgr, 100);
			}

			mg_mgr_free(mgr);
		}).detach();

	SOCKADDR_IN localAddr;
	localAddr.sin_family = AF_INET;
	localAddr.sin_port = htons(23301);
	inet_pton(AF_INET, "127.0.0.1", &localAddr.sin_addr);

	SOCKET sockfd = socket(AF_INET, SOCK_STREAM, 0);
	if (0 != ::bind(sockfd, (sockaddr*)&localAddr, sizeof(sockaddr)))
	{
		MG_ERROR(("bind failed"));
		return 0;
	}

	struct mg_connection* conn = mg_wrapfd(mgr, sockfd, cfn, nullptr);
	mg_resolve(conn, "tcp://127.0.0.1:23300");

	mg_tls_opts tlsOpts;
	memset(&tlsOpts, 0, sizeof(mg_tls_opts));
	mg_tls_init(conn, &tlsOpts);

	mg_timer_add(mgr, 2000, MG_TIMER_ONCE, timer_fn, conn);

	cin.get();
}
```


