### PR TITLE
device-dashboard: default to using packed fs, otherwise hw examples won't work

### DIFF
--- a/examples/device-dashboard/net.c
+++ b/examples/device-dashboard/net.c
@@ -169,7 +169,7 @@ void device_dashboard_fn(struct mg_connection *c, int ev, void *ev_data,
                     u->token);
     } else {
       struct mg_http_serve_opts opts = {0};
-#if 0
+#if 1
       opts.root_dir = "/web_root";
       opts.fs = &mg_fs_packed;
 #else


### PR DESCRIPTION
ESP32 example relies on packed_fs, it links to it and not to the web_root dir