### PR TITLE
Workaround for aliased weak symbol override issue

### DIFF
--- a/examples/stm32/nucleo-f746zg-baremetal/README.md
+++ b/examples/stm32/nucleo-f746zg-baremetal/README.md
@@ -9,7 +9,7 @@ which implements the following:
 - Interrupt-driven [mip_driver_stm32.h](../../../drivers/mip_driver_stm32.h) ethernet driver
 - Blue LED blinky, based on SysTick interrupt
 - User button handler, turns off/on green LED, based on EXTI, interrupt-driven 
-- Catch-all fault handler that blinks red LED
+- HardFault handler that blinks red LED
 - Debug log on UART3 (st-link)
 
 ## Requirements
@@ -24,13 +24,13 @@ Plugin your Nucleo board into USB, and attach an Ethernet cable.
 To build and flash:
 
 ```sh
-make clean flash
+$ make clean flash
 ```
 
-To see debug log, use any serial monitor program like `cu`:
+To see debug log, use any serial monitor program like `picocom` at 115200 bps and configure it to insert carriage returns after line feeds:
 
 ```sh
-cu -l /dev/ttyACM0 -s 115200
+$ picocom /dev/ttyACM0 -i -b 115200 --imap=lfcrlf
 ```
 
 ## Benchmark

--- a/examples/stm32/nucleo-f746zg-baremetal/boot.c
+++ b/examples/stm32/nucleo-f746zg-baremetal/boot.c
@@ -21,19 +21,7 @@ void __attribute__((weak)) DefaultIRQHandler(void) {
   for (;;) (void) 0;
 }
 
-void __attribute__((weak)) EXTI_IRQHandler(void) {
-  for (;;) (void) 0;
-}
-
 #define WEAK_ALIAS __attribute__((weak, alias("DefaultIRQHandler")))
-
-__attribute__((alias("EXTI_IRQHandler"))) void EXTI0_IRQHandler(void);
-__attribute__((alias("EXTI_IRQHandler"))) void EXTI1_IRQHandler(void);
-__attribute__((alias("EXTI_IRQHandler"))) void EXTI2_IRQHandler(void);
-__attribute__((alias("EXTI_IRQHandler"))) void EXTI3_IRQHandler(void);
-__attribute__((alias("EXTI_IRQHandler"))) void EXTI4_IRQHandler(void);
-__attribute__((alias("EXTI_IRQHandler"))) void EXTI9_5_IRQHandler(void);
-__attribute__((alias("EXTI_IRQHandler"))) void EXTI15_10_IRQHandler(void);
 
 WEAK_ALIAS void NMI_Handler(void);
 WEAK_ALIAS void HardFault_Handler(void);
@@ -51,6 +39,13 @@ WEAK_ALIAS void TAMP_STAMP_IRQHandler(void);
 WEAK_ALIAS void RTC_WKUP_IRQHandler(void);
 WEAK_ALIAS void FLASH_IRQHandler(void);
 WEAK_ALIAS void RCC_IRQHandler(void);
+WEAK_ALIAS void EXTI0_IRQHandler(void);
+WEAK_ALIAS void EXTI1_IRQHandler(void);
+WEAK_ALIAS void EXTI2_IRQHandler(void);
+WEAK_ALIAS void EXTI3_IRQHandler(void);
+WEAK_ALIAS void EXTI4_IRQHandler(void);
+WEAK_ALIAS void EXTI9_5_IRQHandler(void);
+WEAK_ALIAS void EXTI15_10_IRQHandler(void);
 WEAK_ALIAS void DMA1_Stream0_IRQHandler(void);
 WEAK_ALIAS void DMA1_Stream1_IRQHandler(void);
 WEAK_ALIAS void DMA1_Stream2_IRQHandler(void);

--- a/examples/stm32/nucleo-f746zg-baremetal/main.c
+++ b/examples/stm32/nucleo-f746zg-baremetal/main.c
@@ -21,7 +21,7 @@ uint64_t mg_millis(void) {  // Declare our own uptime function
   return s_ticks;           // Return number of milliseconds since boot
 }
 
-void DefaultIRQHandler(void) {                // Catch-all fault handler
+void HardFault_Handler(void) {                // Escalated fault handler
   gpio_output(LED3);                          // Setup red LED
   for (;;) spin(2999999), gpio_toggle(LED3);  // Blink LED infinitely
 }
@@ -30,7 +30,7 @@ void SysTick_Handler(void) {  // SyStick IRQ handler, triggered every 1ms
   s_ticks++;
 }
 
-void EXTI_IRQHandler(void) {
+void EXTI15_10_IRQHandler(void) {     // External interrupt handler
   s_exti++;
   if (EXTI->PR & BIT(PINNO(BTN1))) EXTI->PR = BIT(PINNO(BTN1));
   gpio_write(LED1, gpio_read(BTN1));  // No debounce. Turn LED if button pressed


### PR DESCRIPTION
Changed README to use picocom as cu is apparently not able to add carriage return after line feed