### PR TITLE
Group clock setup dependencies

### DIFF
--- a/examples/stm32/nucleo-f746zg-baremetal/mcu.h
+++ b/examples/stm32/nucleo-f746zg-baremetal/mcu.h
@@ -15,11 +15,15 @@
 #define PINNO(pin) (pin & 255)
 #define PINBANK(pin) (pin >> 8)
 
-// System clock
-enum { APB1_PRE = 5 /* AHB clock / 4*/, APB2_PRE = 4 /* AHB clock / 2 */ };
+/* System clock
+5.3.3: APB1 clock <= 54MHz; APB2 clock <= 108MHz
+3.3.2, Table 5: configure flash latency (WS) in accordance to clock freq
+38.4: The AHB clock frequency must be at least 25 MHz when the Ethernet controller is used */
+enum { APB1_PRE = 5 /* AHB clock / 4 */, APB2_PRE = 4 /* AHB clock / 2 */ };
 enum { PLL_HSI = 16, PLL_M = 8, PLL_N = 216, PLL_P = 2 };  // Run at 216 Mhz
 //#define PLL_FREQ PLL_HSI
 #define PLL_FREQ (PLL_HSI * PLL_N / PLL_M / PLL_P)
+#define FLASH_LATENCY 7 
 #define FREQ (PLL_FREQ * 1000000)
 
 static inline void spin(volatile uint32_t count) {
@@ -173,7 +177,8 @@ static inline void uart_init(struct uart *uart, unsigned long baud) {
   gpio_init(tx, GPIO_MODE_AF, GPIO_OTYPE_PUSH_PULL, GPIO_SPEED_HIGH, 0, af);
   gpio_init(rx, GPIO_MODE_AF, GPIO_OTYPE_PUSH_PULL, GPIO_SPEED_HIGH, 0, af);
   uart->CR1 = 0;                          // Disable this UART
-  uart->BRR = FREQ / APB2_PRE / baud;     // Baud rate. /4 is a PLL prescaler
+  uart->BRR = FREQ / 4 / baud;      // Baud rate, "4" is APBx prescaler, different from APBx_PRE
+                                    // TODO(): make this configurable ?
   uart->CR1 |= BIT(0) | BIT(2) | BIT(3);  // Set UE, RE, TE
 }
 static inline void uart_write_byte(struct uart *uart, uint8_t byte) {
@@ -190,7 +195,7 @@ static inline uint8_t uart_read_byte(struct uart *uart) {
   return (uint8_t) (uart->RDR & 255);
 }
 
-static inline void clock_init(void) {  // Set clock to 216Mhz
+static inline void clock_init(void) {  // Set clock frequency
 #if 0
   RCC->APB1ENR |= BIT(28);                     // Power enable
   PWR->CR1 |= 3UL << 14;                       // Voltage regulator scale 3
@@ -200,7 +205,7 @@ static inline void clock_init(void) {  // Set clock to 216Mhz
   while ((PWR->CSR1 & BIT(17)) == 0) spin(1);  // Wait until done
   SCB->CPACR |= ((3UL << 10 * 2) | (3UL << 11 * 2));  // Enable FPU
 #endif
-  FLASH->ACR |= 7 | BIT(8) | BIT(9);                // Flash latency 7, prefetch
+  FLASH->ACR |= FLASH_LATENCY | BIT(8) | BIT(9);    // Flash latency, prefetch
   RCC->PLLCFGR &= ~((BIT(17) - 1));                 // Clear PLL multipliers
   RCC->PLLCFGR |= (((PLL_P - 2) / 2) & 3) << 16;    // Set PLL_P
   RCC->PLLCFGR |= PLL_M | (PLL_N << 6);             // Set PLL_M and PLL_N


### PR DESCRIPTION
Rolled back the UART baud rate config:
APB2_PRE is 4 and that means APB2 clock will be /2
APB1_PRE is 5 and that means APB1 clock will be /4
We are using UART3, which uses APB1. The value of APB2_PRE was just a coincidence and changing it won't change the UART3 clock so our calculations would be wrong.
Proper setup would require a table lookup.