### PR TITLE
Fix mg_json_get for the array element result not as expected.

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -2602,6 +2602,7 @@ int mg_json_get(struct mg_str json, const char *path, int *toklen) {
         } else if (c == ',') {
           expecting = (nesting[depth - 1] == '{') ? S_KEY : S_VALUE;
         } else if (c == ']' || c == '}') {
+          if (depth == ed && ei >= 0) ci--; // Array ends, as ci is pre-added by 1, needs to be decremented before MG_EOO
           MG_EOO('O');
           if (depth == ed && ei >= 0) ci++;
         } else {

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -2508,6 +2508,10 @@ static void test_json(void) {
     ASSERT(mg_json_get_long(json, "$[1].b", -42) == 4);
     ASSERT(mg_json_get_long(json, "$[2].a", -42) == -42);
 
+    json = mg_str("{\"a\":[1],\"b\":[2,3]}");
+    ASSERT(mg_json_get_long(json, "$.a[0]", -42) == 1);
+    ASSERT(mg_json_get_long(json, "$.a[1]", -42) == -42);
+
   }
 }
 


### PR DESCRIPTION
Because **ci** is pre-added, when array ends, it needs to be decremented by 1  before  entering the macro **MG_EOO**.

Before this modification,  finding "$.a[1]"in {"a":[1],"b":[2,3]}" would got the result b[0] .