### PR TITLE
Re-enable sending ACKs until proper mechanism is in place

### DIFF
--- a/mip/mip.c
+++ b/mip/mip.c
@@ -531,7 +531,7 @@ static struct mg_connection *accept_conn(struct mg_connection *lsn,
   return c;
 }
 
-static void read_conn(struct mg_connection *c, struct pkt *pkt) {
+static bool read_conn(struct mg_connection *c, struct pkt *pkt) {
   struct tcpstate *s = (struct tcpstate *) (c + 1);
   if (pkt->tcp->flags & TH_FIN) {
     s->ack = mg_htonl(pkt->tcp->seq) + 1, s->seq = mg_htonl(pkt->tcp->ack);
@@ -548,12 +548,9 @@ static void read_conn(struct mg_connection *c, struct pkt *pkt) {
     c->recv.len += pkt->pay.len;
     struct mg_str evd = mg_str_n((char *) pkt->pay.buf, pkt->pay.len);
     mg_call(c, MG_EV_READ, &evd);
-#if 0
-    // Send ACK immediately
-    tx_tcp(ifp, c->rem.ip, TH_ACK, c->loc.port, c->rem.port, mg_htonl(s->seq),
-           mg_htonl(s->ack), NULL, 0);
-#endif
+    return true;
   }
+  return false;
 }
 
 static void rx_tcp(struct mip_if *ifp, struct pkt *pkt) {
@@ -575,7 +572,14 @@ static void rx_tcp(struct mip_if *ifp, struct pkt *pkt) {
               mg_ntohl(pkt->ip->dst), mg_ntohs(pkt->tcp->dport)));
     mg_hexdump(pkt->pay.buf, pkt->pay.len);
 #endif
-    read_conn(c, pkt);
+    if(read_conn(c, pkt)) {
+      // Send ACK immediately, no piggyback yet
+      // TODO() Set a timer and send ACK if timer expires and no segment was sent ?
+      // (clear timer on segment sent)
+      struct tcpstate *s = (struct tcpstate *) (c + 1);
+      tx_tcp(ifp, c->rem.ip, TH_ACK, c->loc.port, c->rem.port, mg_htonl(s->seq),
+           mg_htonl(s->ack), NULL, 0);
+    }
   } else if ((c = getpeer(ifp->mgr, pkt, true)) == NULL) {
     tx_tcp_pkt(ifp, pkt, TH_RST | TH_ACK, pkt->tcp->ack, NULL, 0);
   } else if (pkt->tcp->flags & TH_SYN) {


### PR DESCRIPTION
Disabling sending immediate ACKs works as long as there is something to send.
When the device starts, it connects to the MQTT broker and then subscribes to a topic. The MQTT SUB carries the TCP ACK to the MQTT CONNACK, but there is no traffic to carry the TCP ACK to the MQTT SUBACK.
The TCP ACK to the MQTT SUBACK is not sent and 800ms later the broker retransmits the TCP segment. MIP logs an OOB error, closes the connection and retries. This happens forever.

I could not re-enable sending the ACKs so moved that part to the calling function and returned a flag to signal the need to send an ACK "later". Since there is no timer in place, it is sent immediately.
Unnecessary ACKs are sent, but at least the connections don't break when idle.