### PR TITLE
Rework timer_expired()

### DIFF
--- a/mongoose.h
+++ b/mongoose.h
@@ -828,7 +828,7 @@ void mg_log_set_fn(mg_pfn_t fn, void *param);
 struct mg_timer {
   unsigned long id;         // Timer ID
   uint64_t period_ms;       // Timer period in milliseconds
-  uint64_t expire;          // Expiration timestamp in milliseconds
+  uint64_t start;           // Latest start timestamp in milliseconds
   unsigned flags;           // Possible flags values below
 #define MG_TIMER_ONCE 0     // Call function once
 #define MG_TIMER_REPEAT 1   // Call function periodically

--- a/src/timer.c
+++ b/src/timer.c
@@ -5,7 +5,7 @@
 
 void mg_timer_init(struct mg_timer **head, struct mg_timer *t, uint64_t ms,
                    unsigned flags, void (*fn)(void *), void *arg) {
-  t->id = 0, t->period_ms = ms, t->expire = 0;
+  t->id = 0, t->period_ms = ms, t->start = 0;
   t->flags = flags, t->fn = fn, t->arg = arg, t->next = *head;
   *head = t;
 }
@@ -15,21 +15,22 @@ void mg_timer_free(struct mg_timer **head, struct mg_timer *t) {
   if (*head) *head = t->next;
 }
 
-// t: expiration time, prd: period, now: current time. Return true if expired
+// t: start time, prd: period, now: current time. Return true if expired
 bool mg_timer_expired(uint64_t *t, uint64_t prd, uint64_t now) {
-  if (now + prd < *t) *t = 0;                    // Time wrapped? Reset timer
-  if (*t == 0) *t = now + prd;                   // Firt poll? Set expiration
-  if (*t > now) return false;                    // Not expired yet, return
-  *t = (now - *t) > prd ? now + prd : *t + prd;  // Next expiration time
-  return true;                                   // Expired, return true
+  if (*t == 0) *t = now;             // First poll? Setup
+  if (now < *t)
+    *t = now;  // Handle non-monotonic time (misses 1 fire on wraparound)
+  if (now - *t < prd) return false;  // Not expired yet, return
+  *t = *t + prd;                     // Calculate next time, keep period
+  return true;                       // Expired, return true
 }
 
 void mg_timer_poll(struct mg_timer **head, uint64_t now_ms) {
   struct mg_timer *t, *tmp;
   for (t = *head; t != NULL; t = tmp) {
-    bool once = t->expire == 0 && (t->flags & MG_TIMER_RUN_NOW) &&
-                !(t->flags & MG_TIMER_CALLED);  // Handle MG_TIMER_NOW only once
-    bool expired = mg_timer_expired(&t->expire, t->period_ms, now_ms);
+    bool once = t->start == 0 && (t->flags & MG_TIMER_RUN_NOW) &&
+                !(t->flags & MG_TIMER_CALLED);  // Handle MG_TIMER_RUN_NOW only once
+    bool expired = mg_timer_expired(&t->start, t->period_ms, now_ms);
     tmp = t->next;
     if (!once && !expired) continue;
     if ((t->flags & MG_TIMER_REPEAT) || !(t->flags & MG_TIMER_CALLED)) {

--- a/src/timer.h
+++ b/src/timer.h
@@ -5,7 +5,7 @@
 struct mg_timer {
   unsigned long id;         // Timer ID
   uint64_t period_ms;       // Timer period in milliseconds
-  uint64_t expire;          // Expiration timestamp in milliseconds
+  uint64_t start;           // Latest start timestamp in milliseconds
   unsigned flags;           // Possible flags values below
 #define MG_TIMER_ONCE 0     // Call function once
 #define MG_TIMER_REPEAT 1   // Call function periodically


### PR DESCRIPTION
The single-line comments PR did not include mongoose.{c,h}, so that crept into this one.
Hope changing 'expire' to 'start' doesn't cause trouble.