### PR TITLE
Fix MIP Q

### DIFF
--- a/mip/mip.c
+++ b/mip/mip.c
@@ -180,7 +180,7 @@ static void q_copyout(struct queue *q, uint8_t *buf, size_t len, size_t tail) {
 
 static bool q_write(struct queue *q, const void *buf, size_t len) {
   bool success = false;
-  size_t left = q->len - q->head + q->tail;
+  size_t left = (q->len - q->head + q->tail -1) % q->len;
   if (len + sizeof(size_t) <= left) {
     q_copyin(q, (uint8_t *) &len, sizeof(len), q->head);
     q_copyin(q, (uint8_t *) buf, len, (q->head + sizeof(size_t)) % q->len);

--- a/mongoose.c
+++ b/mongoose.c
@@ -6469,7 +6469,7 @@ static void q_copyout(struct queue *q, uint8_t *buf, size_t len, size_t tail) {
 
 static bool q_write(struct queue *q, const void *buf, size_t len) {
   bool success = false;
-  size_t left = q->len - q->head + q->tail;
+  size_t left = (q->len - q->head + q->tail -1) % q->len;
   if (len + sizeof(size_t) <= left) {
     q_copyin(q, (uint8_t *) &len, sizeof(len), q->head);
     q_copyin(q, (uint8_t *) buf, len, (q->head + sizeof(size_t)) % q->len);


### PR DESCRIPTION
Available room calculation in `q_write()` was faulty, it would brake as soon as pointers wrapped around and yield a room larger than the queue size. This caused that new incoming frames would overwrite those already in queue, and so `q_read()` would pop gazillion bytes, stepping over the stack and into no-memory land, causing a HardFault.

I used the easiest of the conventional approaches for lock-free ring buffers: wasting one byte

Note: prior pushes not updating mongoose.c sneaked into this commit