### PR TITLE
Add irq and drop counters to qprofiler

### DIFF
--- a/mip/mip.c
+++ b/mip/mip.c
@@ -966,12 +966,22 @@ struct qpentry {
 
 static struct queue qp;
 
+// This is called from IRQ and main contexts; two producers, single consumer
+// TODO(scaprile): avoid concurrency issues (2 queues ?)
 void qp_mark(unsigned int type, int len) {
   static bool ovf = false;
-  struct qpentry e = {.timestamp = mg_millis(),
-                      .type = ovf ? (uint16_t) QP_QUEUEOVF : (uint16_t) type,
-                      .len = (uint16_t) len};
+  static uint16_t drop_ctr = 0, irq_ctr = 0;
+  struct qpentry e = {
+      .timestamp = mg_millis(), .type = (uint16_t) type, .len = (uint16_t) len};
 
+  if (type == QP_IRQTRIGGERED)
+    e.len = ++irq_ctr;  // only incremented on IRQ calls
+  else if (type == QP_FRAMEDROPPED)
+    ++drop_ctr;  // only incremented on IRQ calls
+  if (ovf) {
+    e.type = (uint16_t) QP_QUEUEOVF;
+    e.len = drop_ctr;
+  }
   ovf = !q_write(&qp, &e, sizeof(e));
 }
 

--- a/mip/mip.h
+++ b/mip/mip.h
@@ -32,9 +32,17 @@ struct mip_spi {
 };
 
 #ifdef MIP_QPROFILE
-enum {QP_IRQTRIGGERED=0, QP_FRAMEPUSHED, QP_FRAMEPOPPED, QP_FRAMEDONE, QP_FRAMEDROPPED, QP_QUEUEOVF};
+enum {                  // payload is frame length unless otherwise noted
+  QP_IRQTRIGGERED = 0,  // payload is number of interrupts so far
+  QP_FRAMEPUSHED,
+  QP_FRAMEPOPPED,
+  QP_FRAMEDONE,
+  QP_FRAMEDROPPED,
+  QP_QUEUEOVF  // profiling queue is full, payload is number of frame drops so
+               // far
+};
 
 void qp_mark(unsigned int type, int len);
-void qp_log(void);
+void qp_log(void);  // timestamp, type, payload
 void qp_init(void);
 #endif

--- a/mongoose.h
+++ b/mongoose.h
@@ -1456,10 +1456,18 @@ struct mip_spi {
 };
 
 #ifdef MIP_QPROFILE
-enum {QP_IRQTRIGGERED=0, QP_FRAMEPUSHED, QP_FRAMEPOPPED, QP_FRAMEDONE, QP_FRAMEDROPPED, QP_QUEUEOVF};
+enum {                  // payload is frame length unless otherwise noted
+  QP_IRQTRIGGERED = 0,  // payload is number of interrupts so far
+  QP_FRAMEPUSHED,
+  QP_FRAMEPOPPED,
+  QP_FRAMEDONE,
+  QP_FRAMEDROPPED,
+  QP_QUEUEOVF  // profiling queue is full, payload is number of frame drops so
+               // far
+};
 
 void qp_mark(unsigned int type, int len);
-void qp_log(void);
+void qp_log(void);  // timestamp, type, payload
 void qp_init(void);
 #endif
 


### PR DESCRIPTION
read access to drop_ctr should always be atomic except on some 8-bitters, which we don't support.