### PR TITLE
Use explicit struct sizeof in calloc in mg_tls_init()

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -5139,7 +5139,7 @@ static struct mg_str mg_loadfile(struct mg_fs *fs, const char *path) {
 
 void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
   struct mg_fs *fs = opts->fs == NULL ? &mg_fs_posix : opts->fs;
-  struct mg_tls *tls = (struct mg_tls *) calloc(1, sizeof(*tls));
+  struct mg_tls *tls = (struct mg_tls *) calloc(1, sizeof(struct mg_tls));
   int rc = 0;
   c->tls = tls;
   if (c->tls == NULL) {

--- a/src/tls_mbed.c
+++ b/src/tls_mbed.c
@@ -87,7 +87,7 @@ static struct mg_str mg_loadfile(struct mg_fs *fs, const char *path) {
 
 void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
   struct mg_fs *fs = opts->fs == NULL ? &mg_fs_posix : opts->fs;
-  struct mg_tls *tls = (struct mg_tls *) calloc(1, sizeof(*tls));
+  struct mg_tls *tls = (struct mg_tls *) calloc(1, sizeof(struct mg_tls));
   int rc = 0;
   c->tls = tls;
   if (c->tls == NULL) {


### PR DESCRIPTION
This style appears to less likely to trip up static analysis tools.