### PR TITLE
Use explicit struct sizeof in calloc in mg_fs_open()

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -759,7 +759,7 @@ size_t mg_vxprintf(void (*out)(char, void *), void *param, const char *fmt,
 
 
 struct mg_fd *mg_fs_open(struct mg_fs *fs, const char *path, int flags) {
-  struct mg_fd *fd = (struct mg_fd *) calloc(1, sizeof(*fd));
+  struct mg_fd *fd = (struct mg_fd *) calloc(1, sizeof(struct mg_fd));
   if (fd != NULL) {
     fd->fd = fs->op(path, flags);
     fd->fs = fs;

--- a/src/fs.c
+++ b/src/fs.c
@@ -2,7 +2,7 @@
 #include "fmt.h"
 
 struct mg_fd *mg_fs_open(struct mg_fs *fs, const char *path, int flags) {
-  struct mg_fd *fd = (struct mg_fd *) calloc(1, sizeof(*fd));
+  struct mg_fd *fd = (struct mg_fd *) calloc(1, sizeof(struct mg_fd));
   if (fd != NULL) {
     fd->fd = fs->op(path, flags);
     fd->fs = fs;


### PR DESCRIPTION
This style appears to less likely to trip up static analysis tools.