### PR TITLE
Use explicit struct sizeof in calloc in mg_alloc_conn()

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3407,7 +3407,8 @@ bool mg_aton(struct mg_str str, struct mg_addr *addr) {
 
 struct mg_connection *mg_alloc_conn(struct mg_mgr *mgr) {
   struct mg_connection *c =
-      (struct mg_connection *) calloc(1, sizeof(*c) + mgr->extraconnsize);
+      (struct mg_connection *) calloc(1, sizeof(struct mg_connection) +
+        mgr->extraconnsize);
   if (c != NULL) {
     c->mgr = mgr;
     c->send.align = c->recv.align = MG_IO_SIZE;

--- a/src/net.c
+++ b/src/net.c
@@ -138,7 +138,8 @@ bool mg_aton(struct mg_str str, struct mg_addr *addr) {
 
 struct mg_connection *mg_alloc_conn(struct mg_mgr *mgr) {
   struct mg_connection *c =
-      (struct mg_connection *) calloc(1, sizeof(*c) + mgr->extraconnsize);
+      (struct mg_connection *) calloc(1, sizeof(struct mg_connection) +
+        mgr->extraconnsize);
   if (c != NULL) {
     c->mgr = mgr;
     c->send.align = c->recv.align = MG_IO_SIZE;


### PR DESCRIPTION
This style appears to less likely to trip up static analysis tools.