### PR TITLE
Fix SSDP example for second and subsequent responses

### DIFF
--- a/examples/udp-ssdp-search/main.c
+++ b/examples/udp-ssdp-search/main.c
@@ -33,6 +33,9 @@ static void fn(struct mg_connection *c, int ev, void *ev_data, void *fn_data) {
     // But in our case, we should restore the multicast address in order
     // to have next search to go to the multicast address
     memcpy(&c->rem, c->label, sizeof(c->rem));
+    // Discard the content of this response as we expect each SSDP response
+    // to generate at most one MG_EV_READ event.
+    c->recv.len = 0UL;
   }
 }
 


### PR DESCRIPTION
This fixes a bug in the `udp-ssdp-search` example which causes all responses to be reported with the contents of the first response.

Note that in most cases the bug will probably be masked by the choice of search target (`urn:schemas-upnp-org:device:MediaRenderer:1`). Changing the target to `ssdp:all` makes the difference in behaviour easier to observe. 

Example output before change:

```
andrew in mongoose/examples/udp-ssdp-search > ./example
4be84767 2 main.c:45:tfn                Sending M-SEARCH
4be8476b 2 main.c:16:fn                 Got a response
	SERVER -> Synology/DSM/192.168.0.3
	LOCATION -> http://192.168.0.3:5000/ssdp/desc-DSM-eth0.xml

4be8478e 2 main.c:16:fn                 Got a response
	SERVER -> Synology/DSM/192.168.0.3
	LOCATION -> http://192.168.0.3:5000/ssdp/desc-DSM-eth0.xml

4be8478f 2 main.c:16:fn                 Got a response
	SERVER -> Synology/DSM/192.168.0.3
	LOCATION -> http://192.168.0.3:5000/ssdp/desc-DSM-eth0.xml
...
```

Example output after change:

```
andrew in mongoose/examples/udp-ssdp-search > ./example
4be5edb8 2 main.c:45:tfn                Sending M-SEARCH
4be5edbd 2 main.c:16:fn                 Got a response
	SERVER -> Synology/DSM/192.168.0.3
	LOCATION -> http://192.168.0.3:5000/ssdp/desc-DSM-eth0.xml

4be5edf0 2 main.c:16:fn                 Got a response
	SERVER -> AsusWRT/2.6.36.4brcmarm UPnP/1.1 MiniUPnPd/2.2.3
	LOCATION -> http://192.168.0.1:60919/rootDesc.xml

4be5ee76 2 main.c:16:fn                 Got a response
	LOCATION -> http://192.168.0.181:8860/rootdesc.xml
	SERVER -> Cellvision UPnP/1.0
...
```