### PR TITLE
Use platform native ntohl/ntohs/htons/htonl when available

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -5542,16 +5542,24 @@ char *mg_random_str(char *buf, size_t len) {
 }
 
 uint32_t mg_ntohl(uint32_t net) {
+#if MG_ARCH == MG_ARCH_WIN32 || MG_ARCH == MG_ARCH_UNIX
+  return ntohl(net);
+#else
   uint8_t data[4] = {0, 0, 0, 0};
   memcpy(&data, &net, sizeof(data));
   return (((uint32_t) data[3]) << 0) | (((uint32_t) data[2]) << 8) |
          (((uint32_t) data[1]) << 16) | (((uint32_t) data[0]) << 24);
+#endif
 }
 
 uint16_t mg_ntohs(uint16_t net) {
+#if MG_ARCH == MG_ARCH_WIN32 || MG_ARCH == MG_ARCH_UNIX
+  return ntohs(net);
+#else
   uint8_t data[2] = {0, 0};
   memcpy(&data, &net, sizeof(data));
   return (uint16_t) ((uint16_t) data[1] | (((uint16_t) data[0]) << 8));
+#endif
 }
 
 uint32_t mg_crc32(uint32_t crc, const char *buf, size_t len) {

--- a/mongoose.h
+++ b/mongoose.h
@@ -888,8 +888,13 @@ uint32_t mg_ntohl(uint32_t net);
 uint32_t mg_crc32(uint32_t crc, const char *buf, size_t len);
 uint64_t mg_millis(void);
 
+#if MG_ARCH == MG_ARCH_WIN32 || MG_ARCH == MG_ARCH_UNIX
+#define mg_htons(x) htons(x)
+#define mg_htonl(x) htonl(x)
+#else
 #define mg_htons(x) mg_ntohs(x)
 #define mg_htonl(x) mg_ntohl(x)
+#endif
 
 // Linked list management macros
 #define LIST_ADD_HEAD(type_, head_, elem_) \

--- a/src/util.c
+++ b/src/util.c
@@ -35,16 +35,24 @@ char *mg_random_str(char *buf, size_t len) {
 }
 
 uint32_t mg_ntohl(uint32_t net) {
+#if MG_ARCH == MG_ARCH_WIN32 || MG_ARCH == MG_ARCH_UNIX
+  return ntohl(net);
+#else
   uint8_t data[4] = {0, 0, 0, 0};
   memcpy(&data, &net, sizeof(data));
   return (((uint32_t) data[3]) << 0) | (((uint32_t) data[2]) << 8) |
          (((uint32_t) data[1]) << 16) | (((uint32_t) data[0]) << 24);
+#endif
 }
 
 uint16_t mg_ntohs(uint16_t net) {
+#if MG_ARCH == MG_ARCH_WIN32 || MG_ARCH == MG_ARCH_UNIX
+  return ntohs(net);
+#else
   uint8_t data[2] = {0, 0};
   memcpy(&data, &net, sizeof(data));
   return (uint16_t) ((uint16_t) data[1] | (((uint16_t) data[0]) << 8));
+#endif
 }
 
 uint32_t mg_crc32(uint32_t crc, const char *buf, size_t len) {

--- a/src/util.h
+++ b/src/util.h
@@ -11,8 +11,13 @@ uint32_t mg_ntohl(uint32_t net);
 uint32_t mg_crc32(uint32_t crc, const char *buf, size_t len);
 uint64_t mg_millis(void);
 
+#if MG_ARCH == MG_ARCH_WIN32 || MG_ARCH == MG_ARCH_UNIX
+#define mg_htons(x) htons(x)
+#define mg_htonl(x) htonl(x)
+#else
 #define mg_htons(x) mg_ntohs(x)
 #define mg_htonl(x) mg_ntohl(x)
+#endif
 
 // Linked list management macros
 #define LIST_ADD_HEAD(type_, head_, elem_) \


### PR DESCRIPTION
These functions need endian specific handling, lets use the platform native variants when available to ensure correct behavior.

Should fix #1738 on unix/win32 platforms, others may still have issues.