### PR TITLE
src/arch.h: fix endian macro and set default endian

### DIFF
--- a/mongoose.h
+++ b/mongoose.h
@@ -72,8 +72,12 @@ extern "C" {
 #define LITTLE_ENDIAN __LITTLE_ENDIAN
 #endif /* LITTLE_ENDIAN */
 #ifndef BIG_ENDIAN
-#define BIG_ENDIAN __LITTLE_ENDIAN
+#define BIG_ENDIAN __BIG_ENDIAN
 #endif /* BIG_ENDIAN */
+#elif !defined(BYTE_ORDER)
+#define BYTE_ORDER 1234
+#define LITTLE_ENDIAN 1234
+#define BIG_ENDIAN 4321
 #endif /* BYTE_ORDER */
 
 #if !defined(MG_ARCH)

--- a/src/arch.h
+++ b/src/arch.h
@@ -45,8 +45,12 @@
 #define LITTLE_ENDIAN __LITTLE_ENDIAN
 #endif /* LITTLE_ENDIAN */
 #ifndef BIG_ENDIAN
-#define BIG_ENDIAN __LITTLE_ENDIAN
+#define BIG_ENDIAN __BIG_ENDIAN
 #endif /* BIG_ENDIAN */
+#elif !defined(BYTE_ORDER)
+#define BYTE_ORDER 1234
+#define LITTLE_ENDIAN 1234
+#define BIG_ENDIAN 4321
 #endif /* BYTE_ORDER */
 
 #if !defined(MG_ARCH)


### PR DESCRIPTION
This macro which was moved from md5.c/sha1.c doesn't work correctly as it was defining `BIG_ENDIAN` as `__LITTLE_ENDIAN` in some cases.

We should also set the default endian to `LITTLE_ENDIAN` so that any comparisions against `BYTE_ORDER` don't fail in unexpected ways.