### PR TITLE
Update GPL license identifier

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -15,7 +15,7 @@
 // Alternatively, you can license this software under a commercial
 // license, as set out in https://www.mongoose.ws/licensing/
 //
-// SPDX-License-Identifier: GPL-2.0 or commercial
+// SPDX-License-Identifier: GPL-2.0-only or commercial
 
 #include "mongoose.h"
 

--- a/mongoose.h
+++ b/mongoose.h
@@ -15,7 +15,7 @@
 // Alternatively, you can license this software under a commercial
 // license, as set out in https://www.mongoose.ws/licensing/
 //
-// SPDX-License-Identifier: GPL-2.0 or commercial
+// SPDX-License-Identifier: GPL-2.0-only or commercial
 
 #ifndef MONGOOSE_H
 #define MONGOOSE_H

--- a/src/license.h
+++ b/src/license.h
@@ -15,4 +15,4 @@
 // Alternatively, you can license this software under a commercial
 // license, as set out in https://www.mongoose.ws/licensing/
 //
-// SPDX-License-Identifier: GPL-2.0 or commercial
+// SPDX-License-Identifier: GPL-2.0-only or commercial


### PR DESCRIPTION
`GPL-2.0` was deprecated in favor of `GPL-2.0-only`.

`GPL-2.0+` was deprecated in favor of `GPL-2.0-or-later`.

See: https://spdx.org/licenses/