### PR TITLE
Dettach git clone and fix clean

### DIFF
--- a/examples/raspberry/raspberry-pi-pico-w/Makefile
+++ b/examples/raspberry/raspberry-pi-pico-w/Makefile
@@ -1,9 +1,12 @@
 NAME = raspberry-pi-pico-w
 
-build:
+$(NAME):
 	git clone --depth 1 https://github.com/mongoose-examples/$(NAME)
+
+build: | $(NAME)
 	cp ./../../../mongoose.[ch] $(NAME)
 	make -C $(NAME) build
 
 clean:
+	make -C $(NAME) clean
 	rm -rf $(NAME)


### PR DESCRIPTION
The user has to clone the repo, then edit the Makefile to change WiFi credentials. Running make build does both and the tests go flawlessly.
The user can run make to clone the repo, then change credentials and run make build, it will skip cloning if the repo is already there.

In some systems the compiled files are not owned by the user as Docker runs as root, so we first invoke clean in the cloned repo (which erases the compiled files), and then remove the cloned repo that the user owns and can rm.