### PR TITLE
Fix TI-RTOS port

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -4157,14 +4157,12 @@ static void mg_set_non_blocking_mode(SOCKET fd) {
   fcntl(fd, F_SETFL, O_NONBLOCK);
 #elif MG_ARCH == MG_ARCH_TIRTOS
   int val = 0;
-  setsockopt(fd, 0, SO_BLOCKING, &val, sizeof(val));
-  int status = 0;
-  int res = SockStatus(fd, FDSTATUS_SEND, &status);
-  if (res == 0 && status > 0) {
-    val = status / 2;
-    int val_size = sizeof(val);
-    res = SockSet(fd, SOL_SOCKET, SO_SNDLOWAT, &val, val_size);
-  }
+  setsockopt(fd, SOL_SOCKET, SO_BLOCKING, &val, sizeof(val));
+  // SPRU524J section 3.3.3 page 63, SO_SNDLOWAT
+  int sz = sizeof(val);
+  getsockopt(fd, SOL_SOCKET, SO_SNDBUF, &val, &sz);
+  val /= 2;  // set send low-water mark at half send buffer size
+  setsockopt(fd, SOL_SOCKET, SO_SNDLOWAT, &val, sizeof(val));
 #else
   fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK);  // Non-blocking mode
   fcntl(fd, F_SETFD, FD_CLOEXEC);                          // Set close-on-exec
@@ -4328,6 +4326,11 @@ void mg_connect_resolved(struct mg_connection *c) {
     mg_error(c, "socket(): %d", MG_SOCK_ERRNO);
   } else if (c->is_udp) {
     MG_EPOLL_ADD(c);
+#if MG_ARCH == MG_ARCH_TIRTOS
+    union usa usa;  // TI-RTOS NDK requires binding to receive on UDP sockets
+    socklen_t slen = tousa(&c->loc, &usa);
+    if (bind(c->fd, &usa.sa, slen) != 0) MG_ERROR(("bind: %d", MG_SOCK_ERRNO));
+#endif
     mg_call(c, MG_EV_RESOLVE, NULL);
     mg_call(c, MG_EV_CONNECT, NULL);
   } else {
@@ -4347,6 +4350,7 @@ void mg_connect_resolved(struct mg_connection *c) {
       mg_error(c, "connect: %d", MG_SOCK_ERRNO);
     }
   }
+  (void) rc;
 }
 
 static SOCKET raccept(SOCKET sock, union usa *usa, socklen_t len) {

--- a/mongoose.h
+++ b/mongoose.h
@@ -420,15 +420,11 @@ struct timeval {
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
-#include <time.h>
-#include <errno.h>
 
+#include <serrno.h>
 #include <sys/socket.h>
 
 #include <ti/sysbios/knl/Clock.h>
-
-extern int SockStatus(SOCKET hSock, int request, int *results );
-extern int SockSet(SOCKET hSock, int Type, int Prop, void *pbuf, int size);
 
 #endif
 

--- a/src/arch_tirtos.h
+++ b/src/arch_tirtos.h
@@ -10,14 +10,10 @@
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
-#include <time.h>
-#include <errno.h>
 
+#include <serrno.h>
 #include <sys/socket.h>
 
 #include <ti/sysbios/knl/Clock.h>
-
-extern int SockStatus(SOCKET hSock, int request, int *results );
-extern int SockSet(SOCKET hSock, int Type, int Prop, void *pbuf, int size);
 
 #endif


### PR DESCRIPTION
- Sockets were not being put in non-blocking mode as the setsockopt() call wasn't using SOL_SOCKET
- Do not include errno.h but serrno.h, otherwise error codes are mangled... NDK functions use serrno, errno belongs to the compiler
- UDP sockets require binding to receive responses
- select() does not return write-ready on connect if the amount of bytes that can be written is below the "low-water mark". This parameter defaults to 2048, there was some code apparently setting this otherwise, with no success. Reworked the code to set this water mark at half the buffer size by just using plain getsockopt/setsockopt calls; otherwise TCP never connects if the TCP tx buffer size is set below 2048 (the example set it to 1024).

For the record:
	TI typedef's void * SOCKET for internal use, INVALID_SOCKET is cast to (void *). Their BSD compatible socket interface expects and returns int; while Mongoose uses SOCKET... this generates lots of warnings 169 and 515, disabled in the examples