### PR TITLE
Accept zero-length payload messages

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3195,7 +3195,7 @@ int mg_mqtt_parse(const uint8_t *buf, size_t len, uint8_t version,
         m->id = (uint16_t) ((((uint16_t) p[0]) << 8) | p[1]);
         p += 2;
       }
-      if (p >= end) return MQTT_MALFORMED;
+      if (p > end) return MQTT_MALFORMED;
       if (version == 5) p += 1 + p[0];  // Skip options
       if (p > end) return MQTT_MALFORMED;
       m->data.ptr = (char *) p;

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -172,7 +172,7 @@ int mg_mqtt_parse(const uint8_t *buf, size_t len, uint8_t version,
         m->id = (uint16_t) ((((uint16_t) p[0]) << 8) | p[1]);
         p += 2;
       }
-      if (p >= end) return MQTT_MALFORMED;
+      if (p > end) return MQTT_MALFORMED;
       if (version == 5) p += 1 + p[0];  // Skip options
       if (p > end) return MQTT_MALFORMED;
       m->data.ptr = (char *) p;


### PR DESCRIPTION
Zero-length payload messages are valid messages, they can be sent with regular clients (mosquitto_pub -m "" or -n) and are fond to occur when a producer "deletes" a retained message and the consumer does not start with a clean session.

resolves #1827 