### PR TITLE
Fix wrong reference to prescaler

### DIFF
--- a/examples/stm32/nucleo-f429zi-baremetal/mcu.h
+++ b/examples/stm32/nucleo-f429zi-baremetal/mcu.h
@@ -175,10 +175,9 @@ static inline void uart_init(struct uart *uart, unsigned long baud) {
 
   gpio_init(tx, GPIO_MODE_AF, GPIO_OTYPE_PUSH_PULL, GPIO_SPEED_HIGH, 0, af);
   gpio_init(rx, GPIO_MODE_AF, GPIO_OTYPE_PUSH_PULL, GPIO_SPEED_HIGH, 0, af);
-  uart->CR1 = 0;                       // Disable this UART
-  uart->BRR = FREQ / APB2_PRE / baud;  // Baud rate x16 (with 4dp), "4" is APBx
-                                       // prescaler, different from APBx_PRE
-                                       // TODO(): make this configurable ?
+  uart->CR1 = 0;                    // Disable this UART
+  uart->BRR = FREQ / 4 / baud;      // Baud rate, "4" is APBx prescaler, different from APBx_PRE
+                                    // TODO(): make this configurable ?
   uart->CR1 |= BIT(13) | BIT(2) | BIT(3);  // Set UE, RE, TE
 }
 static inline void uart_write_byte(struct uart *uart, uint8_t byte) {


### PR DESCRIPTION
We've already been there with the F7 (see #1694)
APB1_PRE and APB2_PRE are just index values 
https://github.com/cesanta/mongoose/blob/e580d4e637a65c354a8def8ece8aaa48a7572782/examples/stm32/nucleo-f746zg-baremetal/mcu.h#L19-L22
These index values represent a divisor, for example the index 5 is a /4 and the index 4 is a /2
Each UART can take the clock from APB1 or APB2, which can be /4 or /2.
This example uses UART3, which uses APB1 (not APB2), which is /4, and coincides with the index 4 that is the value of APB2_PRE. So, the fact that '4' and APB2_PRE are igual is just a coincidence.
https://github.com/cesanta/mongoose/blob/e580d4e637a65c354a8def8ece8aaa48a7572782/examples/stm32/nucleo-f746zg-baremetal/mcu.h#L180-L181
So, we either leave this as a hardcoded value or write code to turn index into divisor value as a function of the UART being used.
Pseudocode:
```
getclk(idx)
  if idx < 4 error
  idx -= 4
  clk = [FREQ/2, FREQ/4, FREQ/8, FREQ/16]
  return clk

if uart == UART1 clk = clk(APB2_PRE)
if uart == UART2 clk = clk(APB1_PRE)
if uart == UART3 clk = clk(APB1_PRE)
```
Bear in mind that there is another register over there that can make the UART clock be taken from another master clock... and there are (IIRC) three more UARTs, so we are not covering all bases and I think the hardcoded '4' is a great option, at least for now.