### PR TITLE
Zephyr tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,19 +121,18 @@ jobs:
       - uses: actions/checkout@v3
       - name: ${{ matrix.example.path }}
         run: make -C examples/${{ matrix.example.path }} build
-  matrix_zephyr_examples:
+  zephyr_examples:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        zephyrexample:
-          - path: zephyr/device-dashboard
-          - path: zephyr/http-client
-          - path: zephyr/http-server
-          - path: zephyr/mqtt-aws-client
-          - path: zephyr/websocket-server
-    name: ${{ matrix.zephyrexample.name }}
     steps:
       - uses: actions/checkout@v3
-      - name: ${{ matrix.zephyrexample.path }}
-        run: make -C examples/${{ matrix.zephyrexample.path }} zephyr build
+      - run: make -C examples/zephyr init
+      - name: minify manifest
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq -i eval '(.manifest.defaults, .manifest.remotes, .manifest.projects[] | select(.name == "cmsis" or .name == "hal_stm32" or .name == "mbedtls" or .name == "mcuboot" or .name == "picolibc" | del(.null) ), .manifest.self) as $i ireduce({};setpath($i | path; $i)) | del(.manifest.projects.[].null) | del(..|select(length==0))' examples/zephyr/zephyrproject/zephyr/west.yml
+      - run: make -C examples/zephyr update
+      - run: make -C examples/zephyr/device-dashboard build
+      - run: make -C examples/zephyr/http-client build
+      - run: make -C examples/zephyr/http-server build
+      - run: make -C examples/zephyr/mqtt-aws-client build
+      - run: make -C examples/zephyr/websocket-server build

--- a/examples/zephyr/Makefile
+++ b/examples/zephyr/Makefile
@@ -1,0 +1,29 @@
+DOCKER_PROJECT_DIR ?= /workdir
+ZEPHYR_DIR ?= zephyrproject
+PROJECT_PATH = $(realpath $(CURDIR))
+ZEPHYR_PATH = $(realpath $(CURDIR))/$(ZEPHYR_DIR)
+DOCKER_PROJECT_PATH = $(DOCKER_PROJECT_DIR)
+DOCKER_ZEPHYR_PATH = $(DOCKER_PROJECT_DIR)/$(ZEPHYR_DIR)
+
+DOCKER ?= docker run --rm -v $(PROJECT_PATH):$(DOCKER_PROJECT_PATH) -v $(ZEPHYR_PATH):$(DOCKER_ZEPHYR_PATH)
+REPO ?= zephyrprojectrtos/ci
+
+YQ ?= yq
+
+example:
+	true
+
+init:
+ifeq ($(wildcard $(ZEPHYR_PATH)/.*),)
+	mkdir $(ZEPHYR_PATH)
+	$(DOCKER) $(REPO) /bin/sh -c 'cd $(DOCKER_PROJECT_DIR) && west init ./$(ZEPHYR_DIR)'
+endif
+
+update:
+	$(DOCKER) $(REPO) /bin/sh -c 'cd $(DOCKER_ZEPHYR_PATH) && west update'
+
+minify:
+	$(YQ) -i eval '(.manifest.defaults, .manifest.remotes, .manifest.projects[] | select(.name == "cmsis" or .name == "hal_stm32" or .name == "mbedtls" or .name == "mcuboot" or .name == "picolibc" | del(.null) ), .manifest.self) as $$i ireduce({};setpath($$i | path; $$i)) | del(.manifest.projects.[].null) | del(..|select(length==0))' zephyrproject/zephyr/west.yml
+
+zephyr: init minify update
+


### PR DESCRIPTION
This:
- clones the Zephyr repo (west init)
- edits the YAML manifest (west.yml) to leave only those HALs/projects of interest for the examples using yq (jq for YAML)
- loads those repos (west update)
- runs make build on each example directory in sequence, so all of them use this trimmed Zephyr repo

This magic is done with a Makefile at the examples/zephyr directory. The regular user will follow the tutorials but we can take advantage of this Makefile to also have a reduced zephyrproject directory. We can run `make zephyr` there and just `make build` on the example of interest. This requires having `yq` installed (and calling with sudo in some systems; or calling with `YQ=`...). For the GA tests, yq is run as an action as provided by its author.
https://github.com/mikefarah/yq
