### PR TITLE
Add missing include

### DIFF
--- a/examples/mip-tap/main.c
+++ b/examples/mip-tap/main.c
@@ -3,6 +3,7 @@
 //
 // example using MIP and a TUN/TAP interface
 
+#include <sys/socket.h>
 #include <linux/if.h>
 #include <linux/if_tun.h>
 #include <sys/ioctl.h>


### PR DESCRIPTION
linux/if uses struct sockaddr that is defined in sys/socket.h. This breaks building on some systems (RHEL7). It went unnoticed as it was hidden by mongoose.h being included first