### PR TITLE
Fix wildcard in Makefile

### DIFF
--- a/examples/stm32/nucleo-f429zi-freertos-mip/Makefile
+++ b/examples/stm32/nucleo-f429zi-freertos-mip/Makefile
@@ -18,7 +18,7 @@ firmware.elf: FreeRTOS-Kernel $(SOURCES)
 	  -IFreeRTOS-Kernel/include \
 	  -IFreeRTOS-Kernel/portable/GCC/ARM_CM4F \
 	  -Wno-conversion \
-	  FreeRTOS-Kernel/*.c \
+	  $(wildcard FreeRTOS-Kernel/*.c) \
 	  FreeRTOS-Kernel/portable/MemMang/heap_4.c \
 	  FreeRTOS-Kernel/portable/GCC/ARM_CM4F/port.c
 	


### PR DESCRIPTION
The construction `*.c` works OK on Un*x derivatives but fails on Windows, as it is the shell who expands the wildcard.
The construction `$(wildcard *.c)` seems to work everywhere as it is make who expands the wildcard.
