### PR TITLE
Add FreeRTOS + MIP example on TM4C

### DIFF
--- a/examples/ti/ek-tm4c1294xl-freertos-mip/FreeRTOSConfig.h
+++ b/examples/ti/ek-tm4c1294xl-freertos-mip/FreeRTOSConfig.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "mcu.h"
+
+#define configUSE_PREEMPTION 1
+#define configCPU_CLOCK_HZ FREQ
+#define configTICK_RATE_HZ 1000
+#define configMAX_PRIORITIES 5
+#define configUSE_16_BIT_TICKS 0
+#define configUSE_TICK_HOOK 0
+#define configUSE_IDLE_HOOK 0
+#define configUSE_TIMERS 0
+#define configUSE_CO_ROUTINES 0
+#define configUSE_MALLOC_FAILED_HOOK 0
+#define configMINIMAL_STACK_SIZE 128
+#define configTOTAL_HEAP_SIZE (1024 * 128)
+#define INCLUDE_vTaskDelay 1
+
+#ifdef __NVIC_PRIO_BITS
+#define configPRIO_BITS __NVIC_PRIO_BITS
+#else
+#define configPRIO_BITS 3
+#endif
+#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY 15
+#define configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY 5
+#define configKERNEL_INTERRUPT_PRIORITY \
+  (configLIBRARY_LOWEST_INTERRUPT_PRIORITY << (8 - configPRIO_BITS))
+
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY \
+  (configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY << (8 - configPRIO_BITS))
+
+#define configASSERT(expr) \
+  if (!(expr)) printf("FAILURE %s:%d: %s\n", __FILE__, __LINE__, #expr)
+
+#define vPortSVCHandler SVC_Handler
+#define xPortPendSVHandler PendSV_Handler
+#define xPortSysTickHandler SysTick_Handler

--- a/examples/ti/ek-tm4c1294xl-freertos-mip/Makefile
+++ b/examples/ti/ek-tm4c1294xl-freertos-mip/Makefile
@@ -1,0 +1,33 @@
+ROOT    ?= $(realpath $(CURDIR)/../../..)
+DOCKER  ?= docker run --platform linux/amd64 --rm -v $(ROOT):$(ROOT) -w $(CURDIR) mdashnet/armgcc
+CFLAGS  ?=  -W -Wall -Wextra -Werror -Wundef -Wshadow -Wdouble-promotion \
+            -Wformat-truncation -fno-common -Wconversion \
+            -g3 -Os -ffunction-sections -fdata-sections \
+            -mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16 \
+            -I. -I../../../ $(EXTRA_CFLAGS)
+LDFLAGS ?= -Tlink.ld -nostartfiles -nostdlib --specs nano.specs -lc -lgcc -Wl,--gc-sections -Wl,-Map=$@.map
+SOURCES = main.c boot.c syscalls.c ../../../mongoose.c
+
+FREERTOS_VERSION ?= V10.5.0
+FREERTOS_REPO ?= https://github.com/FreeRTOS/FreeRTOS-Kernel 
+
+build example: firmware.bin
+
+firmware.elf: FreeRTOS-Kernel $(SOURCES) 
+	$(DOCKER) arm-none-eabi-gcc -o $@ $(SOURCES) $(CFLAGS)\
+	  -IFreeRTOS-Kernel/include \
+	  -IFreeRTOS-Kernel/portable/GCC/ARM_CM4F \
+	  -Wno-conversion \
+	  $(wildcard FreeRTOS-Kernel/*.c) \
+	  FreeRTOS-Kernel/portable/MemMang/heap_4.c \
+	  FreeRTOS-Kernel/portable/GCC/ARM_CM4F/port.c \
+	  $(LDFLAGS) 
+	
+firmware.bin: firmware.elf
+	$(DOCKER) arm-none-eabi-objcopy -O binary $< $@
+
+FreeRTOS-Kernel:
+	git clone --depth 1 -b $(FREERTOS_VERSION) $(FREERTOS_REPO) $@
+
+clean:
+	rm -rf firmware.* FreeRTOS-Kernel

--- a/examples/ti/ek-tm4c1294xl-freertos-mip/boot.c
+++ b/examples/ti/ek-tm4c1294xl-freertos-mip/boot.c
@@ -1,0 +1,162 @@
+// Copyright (c) 2022 Cesanta Software Limited
+// All rights reserved
+
+// Startup code
+__attribute__((naked, noreturn)) void _reset(void) {
+  // Initialise memory
+  extern long _sbss, _ebss, _sdata, _edata, _sidata;
+  for (long *src = &_sbss; src < &_ebss; src++) *src = 0;
+  for (long *src = &_sdata, *dst = &_sidata; src < &_edata;) *src++ = *dst++;
+
+  // Call main()
+  extern void main(void);
+  main();
+  for (;;) (void) 0;
+}
+
+void __attribute__((weak)) DefaultIRQHandler(void) {
+  for (;;) (void) 0;
+}
+
+#define WEAK_ALIAS __attribute__((weak, alias("DefaultIRQHandler")))
+
+WEAK_ALIAS void NMI_Handler(void);
+WEAK_ALIAS void HardFault_Handler(void);
+WEAK_ALIAS void MemManage_Handler(void);
+WEAK_ALIAS void BusFault_Handler(void);
+WEAK_ALIAS void UsageFault_Handler(void);
+WEAK_ALIAS void SVC_Handler(void);
+WEAK_ALIAS void DebugMon_Handler(void);
+WEAK_ALIAS void PendSV_Handler(void);
+WEAK_ALIAS void SysTick_Handler(void);
+
+WEAK_ALIAS void GPIOA_Handler(void);
+WEAK_ALIAS void GPIOB_Handler(void);
+WEAK_ALIAS void GPIOC_Handler(void);
+WEAK_ALIAS void GPIOD_Handler(void);
+WEAK_ALIAS void GPIOE_Handler(void);
+WEAK_ALIAS void UART0_Handler(void);
+WEAK_ALIAS void UART1_Handler(void);
+WEAK_ALIAS void SSI0_Handler(void);
+WEAK_ALIAS void I2C0_Handler(void);
+WEAK_ALIAS void PMW0_FAULT_Handler(void);
+WEAK_ALIAS void PWM0_0_Handler(void);
+WEAK_ALIAS void PWM0_1_Handler(void);
+WEAK_ALIAS void PWM0_2_Handler(void);
+WEAK_ALIAS void QEI0_Handler(void);
+WEAK_ALIAS void ADC0SS0_Handler(void);
+WEAK_ALIAS void ADC0SS1_Handler(void);
+WEAK_ALIAS void ADC0SS2_Handler(void);
+WEAK_ALIAS void ADC0SS3_Handler(void);
+WEAK_ALIAS void WDT0_Handler(void);
+WEAK_ALIAS void TIMER0A_Handler(void);
+WEAK_ALIAS void TIMER0B_Handler(void);
+WEAK_ALIAS void TIMER1A_Handler(void);
+WEAK_ALIAS void TIMER1B_Handler(void);
+WEAK_ALIAS void TIMER2A_Handler(void);
+WEAK_ALIAS void TIMER2B_Handler(void);
+WEAK_ALIAS void COMP0_Handler(void);
+WEAK_ALIAS void COMP1_Handler(void);
+WEAK_ALIAS void COMP2_Handler(void);
+WEAK_ALIAS void SYSCTL_Handler(void);
+WEAK_ALIAS void FLASH_Handler(void);
+WEAK_ALIAS void GPIOF_Handler(void);
+WEAK_ALIAS void GPIOG_Handler(void);
+WEAK_ALIAS void GPIOH_Handler(void);
+WEAK_ALIAS void UART2_Handler(void);
+WEAK_ALIAS void SSI1_Handler(void);
+WEAK_ALIAS void TIMER3A_Handler(void);
+WEAK_ALIAS void TIMER3B_Handler(void);
+WEAK_ALIAS void I2C1_Handler(void);
+WEAK_ALIAS void CAN0_Handler(void);
+WEAK_ALIAS void CAN1_Handler(void);
+WEAK_ALIAS void EMAC0_IRQHandler(void);
+WEAK_ALIAS void HIB_Handler(void);
+WEAK_ALIAS void USB0_Handler(void);
+WEAK_ALIAS void PWM0_3_Handler(void);
+WEAK_ALIAS void UDMA_Handler(void);
+WEAK_ALIAS void UDMAERR_Handler(void);
+WEAK_ALIAS void ADC1SS0_Handler(void);
+WEAK_ALIAS void ADC1SS1_Handler(void);
+WEAK_ALIAS void ADC1SS2_Handler(void);
+WEAK_ALIAS void ADC1SS3_Handler(void);
+WEAK_ALIAS void EPI0_Handler(void);
+WEAK_ALIAS void GPIOJ_Handler(void);
+WEAK_ALIAS void GPIOK_Handler(void);
+WEAK_ALIAS void GPIOL_Handler(void);
+WEAK_ALIAS void SSI2_Handler(void);
+WEAK_ALIAS void SSI3_Handler(void);
+WEAK_ALIAS void UART3_Handler(void);
+WEAK_ALIAS void UART4_Handler(void);
+WEAK_ALIAS void UART5_Handler(void);
+WEAK_ALIAS void UART6_Handler(void);
+WEAK_ALIAS void UART7_Handler(void);
+WEAK_ALIAS void I2C2_Handler(void);
+WEAK_ALIAS void I2C3_Handler(void);
+WEAK_ALIAS void TIMER4A_Handler(void);
+WEAK_ALIAS void TIMER4B_Handler(void);
+WEAK_ALIAS void TIMER5A_Handler(void);
+WEAK_ALIAS void TIMER5B_Handler(void);
+WEAK_ALIAS void FPU_Handler(void);
+WEAK_ALIAS void I2C4_Handler(void);
+WEAK_ALIAS void I2C5_Handler(void);
+WEAK_ALIAS void GPIOM_Handler(void);
+WEAK_ALIAS void GPION_Handler(void);
+WEAK_ALIAS void TAMPER_Handler(void);
+WEAK_ALIAS void GPIOP0_Handler(void);
+WEAK_ALIAS void GPIOP1_Handler(void);
+WEAK_ALIAS void GPIOP2_Handler(void);
+WEAK_ALIAS void GPIOP3_Handler(void);
+WEAK_ALIAS void GPIOP4_Handler(void);
+WEAK_ALIAS void GPIOP5_Handler(void);
+WEAK_ALIAS void GPIOP6_Handler(void);
+WEAK_ALIAS void GPIOP7_Handler(void);
+WEAK_ALIAS void GPIOQ0_Handler(void);
+WEAK_ALIAS void GPIOQ1_Handler(void);
+WEAK_ALIAS void GPIOQ2_Handler(void);
+WEAK_ALIAS void GPIOQ3_Handler(void);
+WEAK_ALIAS void GPIOQ4_Handler(void);
+WEAK_ALIAS void GPIOQ5_Handler(void);
+WEAK_ALIAS void GPIOQ6_Handler(void);
+WEAK_ALIAS void GPIOQ7_Handler(void);
+WEAK_ALIAS void TIMER6A_Handler(void);
+WEAK_ALIAS void TIMER6B_Handler(void);
+WEAK_ALIAS void TIMER7A_Handler(void);
+WEAK_ALIAS void TIMER7B_Handler(void);
+WEAK_ALIAS void I2C6_Handler(void);
+WEAK_ALIAS void I2C7_Handler(void);
+WEAK_ALIAS void I2C8_Handler(void);
+WEAK_ALIAS void I2C9_Handler(void);
+
+// IRQ table, 2.5.1 Table 2-9
+extern void _estack();
+__attribute__((section(".vectors"))) void (*tab[16 + 114])(void) = {
+    // Cortex interrupts
+    _estack, _reset, NMI_Handler, HardFault_Handler, MemManage_Handler,
+    BusFault_Handler, UsageFault_Handler, 0, 0, 0, 0, SVC_Handler,
+    DebugMon_Handler, 0, PendSV_Handler, SysTick_Handler,
+
+    // Interrupts from peripherals
+    GPIOA_Handler, GPIOB_Handler, GPIOC_Handler, GPIOD_Handler, GPIOE_Handler,
+    UART0_Handler, UART1_Handler, SSI0_Handler, I2C0_Handler,
+    PMW0_FAULT_Handler, PWM0_0_Handler, PWM0_1_Handler, PWM0_2_Handler,
+    QEI0_Handler, ADC0SS0_Handler, ADC0SS1_Handler, ADC0SS2_Handler,
+    ADC0SS3_Handler, WDT0_Handler, TIMER0A_Handler, TIMER0B_Handler,
+    TIMER1A_Handler, TIMER1B_Handler, TIMER2A_Handler, TIMER2B_Handler,
+    COMP0_Handler, COMP1_Handler, COMP2_Handler, SYSCTL_Handler, FLASH_Handler,
+    GPIOF_Handler, GPIOG_Handler, GPIOH_Handler, UART2_Handler, SSI1_Handler,
+    TIMER3A_Handler, TIMER3B_Handler, I2C1_Handler, CAN0_Handler, CAN1_Handler,
+    EMAC0_IRQHandler, HIB_Handler, USB0_Handler, PWM0_3_Handler, UDMA_Handler,
+    UDMAERR_Handler, ADC1SS0_Handler, ADC1SS1_Handler, ADC1SS2_Handler,
+    ADC1SS3_Handler, EPI0_Handler, GPIOJ_Handler, GPIOK_Handler, GPIOL_Handler,
+    SSI2_Handler, SSI3_Handler, UART3_Handler, UART4_Handler, UART5_Handler,
+    UART6_Handler, UART7_Handler, I2C2_Handler, I2C3_Handler, TIMER4A_Handler,
+    TIMER4B_Handler, TIMER5A_Handler, TIMER5B_Handler, FPU_Handler, 0, 0,
+    I2C4_Handler, I2C5_Handler, GPIOM_Handler, GPION_Handler, 0, TAMPER_Handler,
+    GPIOP0_Handler, GPIOP1_Handler, GPIOP2_Handler, GPIOP3_Handler,
+    GPIOP4_Handler, GPIOP5_Handler, GPIOP6_Handler, GPIOP7_Handler,
+    GPIOQ0_Handler, GPIOQ1_Handler, GPIOQ2_Handler, GPIOQ3_Handler,
+    GPIOQ4_Handler, GPIOQ5_Handler, GPIOQ6_Handler, GPIOQ7_Handler, 0, 0, 0, 0,
+    0, 0, TIMER6A_Handler, TIMER6B_Handler, TIMER7A_Handler, TIMER7B_Handler,
+    I2C6_Handler, I2C7_Handler, 0, 0, 0, 0, 0, I2C8_Handler, I2C9_Handler, 0, 0,
+    0};

--- a/examples/ti/ek-tm4c1294xl-freertos-mip/link.ld
+++ b/examples/ti/ek-tm4c1294xl-freertos-mip/link.ld
@@ -1,0 +1,29 @@
+ENTRY(_reset);
+MEMORY {
+  flash(rx)  : ORIGIN = 0x00000000, LENGTH = 1024k
+  sram(rwx) : ORIGIN = 0x20000000, LENGTH = 256k
+}
+_estack     = ORIGIN(sram) + LENGTH(sram);    /* stack points to end of SRAM */
+
+SECTIONS {
+  .vectors  : { KEEP(*(.vectors)) }   > flash
+  .text     : { *(.text*) }           > flash
+  .rodata   : { *(.rodata*) }         > flash
+
+  .data : {
+    _sdata = .;   /* for init_ram() */
+    *(.first_data)
+    *(.data SORT(.data.*))
+    _edata = .;  /* for init_ram() */
+  } > sram AT > flash
+  _sidata = LOADADDR(.data);
+
+  .bss : {
+    _sbss = .;              /* for init_ram() */
+    *(.bss SORT(.bss.*) COMMON)
+    _ebss = .;              /* for init_ram() */
+  } > sram
+
+  . = ALIGN(8);
+  _end = .;     /* for cmsis_gcc.h and init_ram() */
+}

--- a/examples/ti/ek-tm4c1294xl-freertos-mip/main.c
+++ b/examples/ti/ek-tm4c1294xl-freertos-mip/main.c
@@ -1,0 +1,102 @@
+// Copyright (c) 2022 Cesanta Software Limited
+// All rights reserved
+
+#include "mcu.h"
+#include "mongoose.h"
+
+#define LED1 PIN('N', 1)  // On-board LED pin
+#define LED2 PIN('N', 0)  // On-board LED pin
+#define LED3 PIN('F', 4)  // On-board LED pin
+#define LED4 PIN('F', 0)  // On-board LED pin
+
+// HTTP server event handler function
+static void fn(struct mg_connection *c, int ev, void *ev_data, void *fn_data) {
+  if (ev == MG_EV_HTTP_MSG) {
+    struct mg_http_message *hm = (struct mg_http_message *) ev_data;
+    if (mg_http_match_uri(hm, "/api/debug")) {
+      int level = mg_json_get_long(hm->body, "$.level", MG_LL_DEBUG);
+      mg_log_set(level);
+      mg_http_reply(c, 200, "", "Debug level set to %d\n", level);
+    } else {
+      mg_http_reply(c, 200, "", "%s\n", "hi");
+    }
+  }
+  (void) fn_data;
+}
+
+static void ethernet_init(void) {
+  // See datasheet: https://www.ti.com/lit/pdf/spms433
+  // Assign LED3 and LED4 to the EPHY, "activity" and "link", respectively.
+  // (20.4.2.4)
+  gpio_init(LED3, GPIO_MODE_AF, GPIO_OTYPE_PUSH_PULL, GPIO_SPEED_HIGH,
+            GPIO_PULL_NONE, 5);  // EN0LED1
+  gpio_init(LED4, GPIO_MODE_AF, GPIO_OTYPE_PUSH_PULL, GPIO_SPEED_HIGH,
+            GPIO_PULL_NONE, 5);  // EN0LED0
+  nvic_enable_irq(40);  // Setup Ethernet IRQ handler
+  // Initialize Ethernet clocks, see datasheet section 5
+  // Turn Flash Prefetch off (silicon errata ETH#02)
+  volatile uint32_t *IMC = (uint32_t *) 0x400FD000;
+  uint32_t val = IMC[0xFC8 / sizeof(*IMC)];
+  val &= ~BIT(17);
+  val |= BIT(16);
+  IMC[0xFC8 / sizeof(*IMC)] = val;
+  SYSCTL->RCGCEMAC |= BIT(0);  // Enable EMAC clock
+  SYSCTL->SREMAC |= BIT(0);    // Reset EMAC
+  SYSCTL->SREMAC &= ~BIT(0);
+  SYSCTL->RCGCEPHY |= BIT(0);  // Enable EPHY clock
+  SYSCTL->SREPHY |= BIT(0);    // Reset EPHY
+  SYSCTL->SREPHY &= ~BIT(0);
+  while (!(SYSCTL->PREMAC & BIT(0)) || !(SYSCTL->PREPHY & BIT(0)))
+    spin(1);  // Wait for reset to complete
+}
+
+static void server(void *args) {
+  struct mg_mgr mgr;        // Initialise Mongoose event manager
+  mg_mgr_init(&mgr);        // and attach it to the MIP interface
+  mg_log_set(MG_LL_DEBUG);  // Set log level
+
+  // Initialise Mongoose network stack
+  // Specify MAC address, either set use_dhcp or enter a static config.
+  // For static configuration, specify IP/mask/GW in network byte order
+  MG_INFO(("Initializing Ethernet driver"));
+  ethernet_init();
+  struct mip_driver_tm4c driver_data = {.mdc_cr = 1};  // See driver_tm4c.h
+  struct mip_if mif = {
+      .mac = {2, 0, 1, 2, 3, 5},
+      .use_dhcp = true,
+      .driver = &mip_driver_tm4c,
+      .driver_data = &driver_data,
+  };
+  mip_init(&mgr, &mif);
+  volatile uint32_t *IMC = (uint32_t *) 0x400FD000;
+  uint32_t val = IMC[0xFC8 / sizeof(*IMC)];  // Turn Flash Prefetch on again
+  val &= ~BIT(16);
+  val |= BIT(17);
+  IMC[0xFC8 / sizeof(*IMC)] = val;
+
+  MG_INFO(("Starting Mongoose v%s", MG_VERSION));    // Tell the world
+  mg_http_listen(&mgr, "http://0.0.0.0", fn, &mgr);  // Web listener
+  while (args == NULL) mg_mgr_poll(&mgr, 1000);      // Infinite event loop
+  mg_mgr_free(&mgr);                                 // Unreachable
+}
+
+static void blinker(void *args) {
+  gpio_init(LED1, GPIO_MODE_OUTPUT, GPIO_OTYPE_PUSH_PULL, GPIO_SPEED_HIGH,
+            GPIO_PULL_NONE, 0);
+  for (;;) {
+    gpio_toggle(LED1);
+    vTaskDelay(pdMS_TO_TICKS(750));
+    (void)args;//MG_INFO(("blink %s,  RAM: %u", (char *) args, xPortGetFreeHeapSize()));
+  }
+}
+
+int main(void) {
+  static struct uart *uart = UART0;  // Use UART0 (attached to ICDI)
+  clock_init();                      // Set clock to 120MHz
+  systick_init(FREQ / 1000);  // Tick every 1 ms
+  uart_init(uart, 115200);   // Initialise UART
+  xTaskCreate(blinker, "blinker", 128, ":)", configMAX_PRIORITIES - 1, NULL);
+  xTaskCreate(server, "server", 2048, 0, configMAX_PRIORITIES - 1, NULL);
+  vTaskStartScheduler();  // This blocks
+  return 0;
+}

--- a/examples/ti/ek-tm4c1294xl-freertos-mip/mcu.h
+++ b/examples/ti/ek-tm4c1294xl-freertos-mip/mcu.h
@@ -1,0 +1,257 @@
+// Copyright (c) 2022 Cesanta Software Limited
+// All rights reserved
+// https://www.ti.com/lit/pdf/spms433
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#define BIT(x) (1UL << (x))
+#define SETBITS(R, CLEARMASK, SETMASK) (R) = ((R) & ~(CLEARMASK)) | (SETMASK)
+#define PIN(bank, num) ((bank << 8) | (num))
+#define PINNO(pin) (pin & 255)
+#define PINBANK(pin) pinbank(pin >> 8)
+// This MCU doesn't have GPIOI nor GPIOO
+static inline unsigned int pinbank(unsigned int bank) {
+  bank = bank > 'O' ? bank - 2 : bank > 'I' ? bank - 1 : bank;
+  return bank - 'A';
+}
+
+// 5.5, Table 5-12: configure flash (and EEPROM) timing in accordance to clock
+// freq
+enum {
+  PLL_CLK = 25,
+  PLL_M = 96,
+  PLL_N = 5,
+  PLL_Q = 1,
+  PSYSDIV = 4
+};  // Run at 120 Mhz
+#define PLL_FREQ (PLL_CLK * PLL_M / PLL_N / PLL_Q / PSYSDIV)
+#define FLASH_CLKHIGH 6
+#define FLASH_WAITST 5
+#define FREQ (PLL_FREQ * 1000000)
+
+static inline void spin(volatile uint32_t count) {
+  while (count--) asm("nop");
+}
+
+struct systick {
+  volatile uint32_t CTRL, LOAD, VAL, CALIB;
+};
+#define SYSTICK ((struct systick *) 0xe000e010)
+static inline void systick_init(uint32_t ticks) {
+  if ((ticks - 1) > 0xffffff) return;  // Systick timer is 24 bit
+  SYSTICK->LOAD = ticks - 1;
+  SYSTICK->VAL = 0;
+  SYSTICK->CTRL = BIT(0) | BIT(1) | BIT(2);  // Enable systick
+}
+
+struct nvic {
+  volatile uint32_t ISER[8], RESERVED0[24], ICER[8], RSERVED1[24], ISPR[8],
+      RESERVED2[24], ICPR[8], RESERVED3[24], IABR[8], RESERVED4[56], IP[240],
+      RESERVED5[644], STIR;
+};
+#define NVIC ((struct nvic *) 0xe000e100)
+static inline void nvic_set_prio(int irq, uint32_t prio) {
+  NVIC->IP[irq] = prio << 4;
+}
+static inline void nvic_enable_irq(int irq) {
+  NVIC->ISER[irq >> 5] = (uint32_t) (1 << (irq & 31));
+}
+
+struct scb {
+  volatile uint32_t CPUID, ICSR, VTOR, AIRCR, SCR, CCR, SHPR[3], SHCSR, CFSR,
+      HFSR, DFSR, MMFAR, BFAR, AFSR, ID_PFR[2], ID_DFR, ID_AFR, ID_MFR[4],
+      ID_ISAR[5], RESERVED0[1], CLIDR, CTR, CCSIDR, CSSELR, CPACR,
+      RESERVED3[93], STIR, RESERVED4[15], MVFR0, MVFR1, MVFR2, RESERVED5[1],
+      ICIALLU, RESERVED6[1], ICIMVAU, DCIMVAC, DCISW, DCCMVAU, DCCMVAC, DCCSW,
+      DCCIMVAC, DCCISW, RESERVED7[6], ITCMCR, DTCMCR, AHBPCR, CACR, AHBSCR,
+      RESERVED8[1], ABFSR;
+};
+#define SCB ((struct scb *) 0xe000ed00)
+
+struct sysctl {
+  volatile uint32_t DONTCARE0[31], MOSCCTL, RESERVED0[12], RSCLKCFG,
+      RESERVED1[3], MEMTIM0, DONTCARE1[39], PLLFREQ0, PLLFREQ1, PLLSTAT,
+      DONTCARE2[241], SREPHY, DONTCARE3[26], SREMAC, DONTCARE4[26], RCGCGPIO,
+      DONTCARE5[3], RCGCUART, DONTCARE6[5], RCGCEPHY, DONTCARE7[26], RCGCEMAC,
+      DONTCARE8[228], PREPHY, DONTCARE9[26], PREMAC;
+};
+#define SYSCTL ((struct sysctl *) 0x400FE000)
+
+enum { GPIO_MODE_INPUT, GPIO_MODE_OUTPUT, GPIO_MODE_AF, GPIO_MODE_ANALOG };
+enum { GPIO_OTYPE_PUSH_PULL, GPIO_OTYPE_OPEN_DRAIN };
+enum { GPIO_SPEED_LOW, GPIO_SPEED_HIGH };
+enum { GPIO_PULL_NONE, GPIO_PULL_UP, GPIO_PULL_DOWN };
+
+// 10.3, 10.6
+struct gpio {
+  volatile uint32_t GPIODATA[256], GPIODIR, GPIOIS, GPIOIBE, GPIOIEV, GPIOIM,
+      GPIORIS, GPIOMIS, GPIOICR, GPIOAFSEL, RESERVED1[55], GPIODR2R, GPIODR4R,
+      GPIODR8R, GPIOODR, GPIOPUR, GPIOPDR, GPIOSLR, GPIODEN, GPIOLOCK, GPIOCR,
+      GPIOAMSEL, GPIOPCTL, GPIOADCCTL, GPIODMACTL, GPIOSI, GPIODR12R,
+      GPIOWAKEPEN, GPIOWAKELVL, GPIOWAKESTAT, RESERVED2[669], GPIOPP, GPIOPC,
+      RESERVED3[2], GPIOPeriphID4, GPIOPeriphID5, GPIOPeriphID6, GPIOPeriphID7,
+      GPIOPeriphID0, GPIOPeriphID1, GPIOPeriphID2, GPIOPeriphID3, GPIOPCellID0,
+      GPIOPCellID1, GPIOPCellID2, GPIOPCellID3;
+};
+#define GPIO(N) ((struct gpio *) (0x40058000 + 0x1000 * (N)))
+
+static struct gpio *gpio_bank(uint16_t pin) {
+  return GPIO(PINBANK(pin));
+}
+static inline void gpio_toggle(uint16_t pin) {
+  struct gpio *gpio = gpio_bank(pin);
+  uint8_t mask = BIT(PINNO(pin));
+  gpio->GPIODATA[mask] ^= mask;
+}
+static inline int gpio_read(uint16_t pin) {
+  return gpio_bank(pin)->GPIODATA[BIT(PINNO(pin))] ? 1 : 0;
+}
+static inline void gpio_write(uint16_t pin, bool val) {
+  struct gpio *gpio = gpio_bank(pin);
+  uint8_t mask = BIT(PINNO(pin));
+  gpio->GPIODATA[mask] = val ? mask : 0;
+}
+static inline void gpio_init(uint16_t pin, uint8_t mode, uint8_t type,
+                             uint8_t speed, uint8_t pull, uint8_t af) {
+  struct gpio *gpio = gpio_bank(pin);
+  uint8_t n = (uint8_t) (PINNO(pin));
+  SYSCTL->RCGCGPIO |= BIT(PINBANK(pin));  // Enable GPIO clock
+  if (mode == GPIO_MODE_ANALOG) {
+    gpio->GPIOAMSEL |= BIT(PINNO(pin));
+    return;
+  }
+  if (mode == GPIO_MODE_INPUT) {
+    gpio->GPIODIR &= ~BIT(PINNO(pin));
+  } else if (mode == GPIO_MODE_OUTPUT) {
+    gpio->GPIODIR |= BIT(PINNO(pin));
+  } else {  // GPIO_MODE_AF
+    SETBITS(gpio->GPIOPCTL, 15UL << ((n & 7) * 4),
+            ((uint32_t) af) << ((n & 7) * 4));
+    gpio->GPIOAFSEL |= BIT(PINNO(pin));
+  }
+  gpio->GPIODEN |= BIT(PINNO(pin));  // Enable pin as digital function
+  if (type == GPIO_OTYPE_OPEN_DRAIN)
+    gpio->GPIOODR |= BIT(PINNO(pin));
+  else  // GPIO_OTYPE_PUSH_PULL
+    gpio->GPIOODR &= ~BIT(PINNO(pin));
+  if (speed == GPIO_SPEED_LOW)
+    gpio->GPIOSLR |= BIT(PINNO(pin));
+  else  // GPIO_SPEED_HIGH
+    gpio->GPIOSLR &= ~BIT(PINNO(pin));
+  if (pull == GPIO_PULL_UP) {
+    gpio->GPIOPUR |= BIT(PINNO(pin));  // setting one...
+  } else if (pull == GPIO_PULL_DOWN) {
+    gpio->GPIOPDR |= BIT(PINNO(pin));  // ...just clears the other
+  } else {
+    gpio->GPIOPUR &= ~BIT(PINNO(pin));
+    gpio->GPIOPDR &= ~BIT(PINNO(pin));
+  }
+}
+static inline void gpio_input(uint16_t pin) {
+  gpio_init(pin, GPIO_MODE_INPUT, GPIO_OTYPE_PUSH_PULL, GPIO_SPEED_HIGH,
+            GPIO_PULL_UP, 0);  // EK does not have pull-up resistors
+}
+static inline void gpio_output(uint16_t pin) {
+  gpio_init(pin, GPIO_MODE_OUTPUT, GPIO_OTYPE_PUSH_PULL, GPIO_SPEED_HIGH,
+            GPIO_PULL_NONE, 0);
+}
+
+static inline void gpio_irq_attach(uint16_t pin) {
+  uint8_t irqvecs[] = {16, 17, 18, 19, 20, 30, 31, 32,
+                       51, 52, 53, 72, 73, 76, 84};
+  struct gpio *gpio = gpio_bank(pin);
+  gpio->GPIOIS &= ~BIT(PINNO(pin));    // edge sensitive
+  gpio->GPIOIBE |= BIT(PINNO(pin));    // both edges
+  gpio->GPIOIM |= BIT(PINNO(pin));     // enable pin irq
+  int irqvec = irqvecs[PINBANK(pin)];  // IRQ vector index, 2.5.2
+  nvic_set_prio(irqvec, 3);
+  nvic_enable_irq(irqvec);
+}
+
+struct uart {
+  volatile uint32_t UARTDR, UARTRSR, RESERVED0[4], UARTFR, RESERVED1, UARTILPR,
+      UARTIBRD, UARTFBRD, UARTLCRH, UARTCTL, UARTIFLS, UARTIM, UARTRIS, UARTMIS,
+      UARTICR, UARTDMACTL, RESERVED2[22], UART9BITADDR, UART9BITAMASK,
+      RESERVED3[965], UARTPP, RESERVED4, UARTCC, RESERVED5, UARTPeriphID4,
+      UARTPeriphID5, UARTPeriphID6, UARTPeriphID7, UARTPeriphID0, UARTPeriphID1,
+      UARTPeriphID2, UARTPeriphID3, UARTPCellID0, UARTPCellID1, UARTPCellID2,
+      UARTPCellID3;
+};
+#define UARTECR UARTRSR
+#define USART_BASE 0x4000C000
+#define USART_OFFSET 0x1000
+#define USART(N) ((struct uart *) (USART_BASE + USART_OFFSET * (N)))
+#define UARTNO(u) ((uint8_t)(((unsigned int) (u) - USART_BASE) / USART_OFFSET))
+
+#define UART0 USART(0)
+
+static inline void uart_init(struct uart *uart, unsigned long baud) {
+  struct uarthw {
+    uint16_t rx, tx;  // pins
+    uint8_t af;       // Alternate function
+  };
+  // af, rx, tx for UART0
+  struct uarthw uarthw[1] = {{PIN('A', 0), PIN('A', 1), 1}};
+
+  if (uart != UART0) return;  // uarthw is not populated for other UARTs
+
+  uint8_t uartno = UARTNO(uart);
+  SYSCTL->RCGCUART |= BIT(uartno);  // Enable peripheral clock
+
+  gpio_init(uarthw[uartno].tx, GPIO_MODE_AF, GPIO_OTYPE_PUSH_PULL,
+            GPIO_SPEED_HIGH, 0, uarthw[uartno].af);
+  gpio_init(uarthw[uartno].rx, GPIO_MODE_AF, GPIO_OTYPE_PUSH_PULL,
+            GPIO_SPEED_HIGH, 0, uarthw[uartno].af);
+  // (16.3.2) ClkDiv = 16 (HSE=0)
+  // BRD = BRDI + BRDF = UARTSysClk / (ClkDiv * Baud Rate)
+  // UARTFBRD[DIVFRAC] = integer(BRDF * 64 + 0.5)
+  // must write in this order
+  uart->UARTCTL = 0;                    // Disable this UART, clear HSE
+  uart->UARTIBRD = FREQ / (16 * baud);  // Baud rate, integer part
+  uart->UARTFBRD =
+      ((FREQ % (16 * baud)) >> 26) & 0x3F;    // Baud rate, fractional part
+  uart->UARTLCRH = (3 << 5);                  // 8N1, no FIFOs;
+  uart->UARTCTL |= BIT(0) | BIT(9) | BIT(8);  // Set UARTEN, RXE, TXE
+}
+static inline void uart_write_byte(struct uart *uart, uint8_t byte) {
+  uart->UARTDR = byte;
+  while ((uart->UARTFR & BIT(7)) == 0) spin(1);
+}
+static inline void uart_write_buf(struct uart *uart, char *buf, size_t len) {
+  while (len-- > 0) uart_write_byte(uart, *(uint8_t *) buf++);
+}
+static inline int uart_read_ready(struct uart *uart) {
+  return uart->UARTFR & BIT(6);  // If RXFF bit is set, data is ready
+}
+static inline uint8_t uart_read_byte(struct uart *uart) {
+  return (uint8_t) (uart->UARTDR & 0xFF);
+}
+
+static inline void clock_init(void) {                 // Set clock frequency
+  SCB->CPACR |= ((3UL << 10 * 2) | (3UL << 11 * 2));  // Enable FPU
+  asm("DSB");
+  asm("ISB");
+  SETBITS(SYSCTL->MOSCCTL, BIT(3) | BIT(2),
+          BIT(4));  // Enable MOSC circuit (clear NOXTAL and PWRDN, set >10MHz
+                    // range)
+  SETBITS(SYSCTL->MEMTIM0,
+          BIT(21) | BIT(5) | 0x1F << 21 | 0xF << 16 | 0x1F << 5 | 0xF << 0,
+          FLASH_CLKHIGH << 22 | FLASH_WAITST << 16 | FLASH_CLKHIGH << 5 |
+              FLASH_WAITST << 0);  // Configure flash timing (not yet applied)
+  SETBITS(SYSCTL->RSCLKCFG, 0xF << 24 | (BIT(9) - 1),
+          3 << 24);  // Clear PLL divider, set MOSC as PLL source
+  SYSCTL->PLLFREQ1 = (PLL_Q - 1) << 8 | (PLL_N - 1)
+                                            << 0;  // Set PLL_Q and PLL_N
+  SYSCTL->PLLFREQ0 =
+      BIT(23) | PLL_M << 0;  // Set PLL_Q, power up PLL (if it were on, we'd
+                             // need to set NEWFREQ in RSCLKCFG instead)
+  while ((SYSCTL->PLLSTAT & BIT(0)) == 0) spin(1);  // Wait for lock
+  SYSCTL->RSCLKCFG |=
+      BIT(31) | BIT(28) |
+      (PSYSDIV - 1) << 0;  // Update memory timing, use PLL, set clock divisor
+}

--- a/examples/ti/ek-tm4c1294xl-freertos-mip/mongoose_custom.h
+++ b/examples/ti/ek-tm4c1294xl-freertos-mip/mongoose_custom.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <errno.h>	// we are not using lwIP
+
+#define MG_ARCH MG_ARCH_FREERTOS
+#define MG_ENABLE_MIP 1
+#define MG_ENABLE_DRIVER_TM4C 1
+#define MG_IO_SIZE 256

--- a/examples/ti/ek-tm4c1294xl-freertos-mip/syscalls.c
+++ b/examples/ti/ek-tm4c1294xl-freertos-mip/syscalls.c
@@ -1,0 +1,45 @@
+#include <sys/stat.h>
+
+#include "mcu.h"
+
+int _fstat(int fd, struct stat *st) {
+  if (fd < 0) return -1;
+  st->st_mode = S_IFCHR;
+  return 0;
+}
+
+int _write(int fd, char *ptr, int len) {
+  (void) fd, (void) ptr, (void) len;
+  if (fd == 1) uart_write_buf(UART0, ptr, (size_t) len);
+  return len;
+}
+
+void *_sbrk(int incr) {
+  extern char _end;
+  static unsigned char *heap = NULL;
+  unsigned char *prev_heap;
+  if (heap == NULL) heap = (unsigned char *) &_end;
+  prev_heap = heap;
+  heap += incr;
+  return prev_heap;
+}
+
+int _close(int fd) {
+  (void) fd;
+  return -1;
+}
+
+int _isatty(int fd) {
+  (void) fd;
+  return 1;
+}
+
+int _read(int fd, char *ptr, int len) {
+  (void) fd, (void) ptr, (void) len;
+  return -1;
+}
+
+int _lseek(int fd, int ptr, int dir) {
+  (void) fd, (void) ptr, (void) dir;
+  return 0;
+}

--- a/mip/driver_tm4c.c
+++ b/mip/driver_tm4c.c
@@ -1,6 +1,6 @@
 #include "mip.h"
 
-#if MG_ENABLE_MIP && defined(MG_ENABLE_DRIVER_TM4C) &&  MG_ENABLE_DRIVER_TM4C
+#if MG_ENABLE_MIP && defined(MG_ENABLE_DRIVER_TM4C) && MG_ENABLE_DRIVER_TM4C
 struct tm4c_emac {
   volatile uint32_t EMACCFG, EMACFRAMEFLTR, EMACHASHTBLH, EMACHASHTBLL,
       EMACMIIADDR, EMACMIIDATA, EMACFLOWCTL, EMACVLANTG, RESERVED0, EMACSTATUS,
@@ -21,8 +21,10 @@ struct tm4c_emac {
       RESERVED15[218], EMACPP, EMACPC, EMACCC, RESERVED16, EMACEPHYRIS,
       EMACEPHYIM, EMACEPHYIMSC;
 };
+#undef EMAC
 #define EMAC ((struct tm4c_emac *) (uintptr_t) 0x400EC000)
 
+#undef BIT
 #define BIT(x) ((uint32_t) 1 << (x))
 #define ETH_PKT_SIZE 1540  // Max frame size
 #define ETH_DESC_CNT 4     // Descriptors count
@@ -36,7 +38,7 @@ static void (*s_rx)(void *, size_t, void *);         // Recv callback
 static void *s_rxdata;                               // Recv callback data
 enum { EPHY_ADDR = 0, EPHYBMCR = 0, EPHYBMSR = 1 };  // PHY constants
 
-static inline void spin(volatile uint32_t count) {
+static inline void tm4cspin(volatile uint32_t count) {
   while (count--) (void) 0;
 }
 
@@ -44,7 +46,7 @@ static uint32_t emac_read_phy(uint8_t addr, uint8_t reg) {
   EMAC->EMACMIIADDR &= (0xf << 2);
   EMAC->EMACMIIADDR |= ((uint32_t) addr << 11) | ((uint32_t) reg << 6);
   EMAC->EMACMIIADDR |= BIT(0);
-  while (EMAC->EMACMIIADDR & BIT(0)) spin(1);
+  while (EMAC->EMACMIIADDR & BIT(0)) tm4cspin(1);
   return EMAC->EMACMIIDATA;
 }
 
@@ -53,7 +55,7 @@ static void emac_write_phy(uint8_t addr, uint8_t reg, uint32_t val) {
   EMAC->EMACMIIADDR &= (0xf << 2);
   EMAC->EMACMIIADDR |= ((uint32_t) addr << 11) | ((uint32_t) reg << 6) | BIT(1);
   EMAC->EMACMIIADDR |= BIT(0);
-  while (EMAC->EMACMIIADDR & BIT(0)) spin(1);
+  while (EMAC->EMACMIIADDR & BIT(0)) tm4cspin(1);
 }
 
 // TODO(scaprile) TEST
@@ -61,27 +63,27 @@ static uint32_t get_sysclk(void) {
   struct sysctl {
     volatile uint32_t DONTCARE0[44], RSCLKCFG, DONTCARE1[43], PLLFREQ0,
         PLLFREQ1;
-  } *SYSCTL = (struct sysctl *) 0x400FE000;
+  } *sysctl = (struct sysctl *) 0x400FE000;
   uint32_t clk = 0, piosc = 16000000 /* 16 MHz */, mosc = 25000000 /* 25MHz */;
-  uint32_t oscsrc = (SYSCTL->RSCLKCFG & (0xf << 20)) >> 20;
+  uint32_t oscsrc = (sysctl->RSCLKCFG & (0xf << 20)) >> 20;
   if (oscsrc == 0)
     clk = piosc;
   else if (oscsrc == 3)
     clk = mosc;
   else
     MG_ERROR(("Unsupported clock source"));
-  if (SYSCTL->RSCLKCFG & (1 << 28)) {  // USEPLL
+  if (sysctl->RSCLKCFG & (1 << 28)) {  // USEPLL
     uint32_t fin, vco, mdiv, n, q, psysdiv;
-    q = (SYSCTL->PLLFREQ1 & (0x1f << 8)) >> 8;
-    n = (SYSCTL->PLLFREQ1 & (0x1f << 0)) >> 0;
+    q = (sysctl->PLLFREQ1 & (0x1f << 8)) >> 8;
+    n = (sysctl->PLLFREQ1 & (0x1f << 0)) >> 0;
     fin = clk / ((q + 1) * (n + 1));
-    mdiv = (SYSCTL->PLLFREQ0 & (0x3ff << 0)) >>
+    mdiv = (sysctl->PLLFREQ0 & (0x3ff << 0)) >>
            0;  // mint + (mfrac / 1024); MFRAC not supported
-    psysdiv = (SYSCTL->RSCLKCFG & (0x3f << 0)) >> 0;
+    psysdiv = (sysctl->RSCLKCFG & (0x3f << 0)) >> 0;
     vco = (uint32_t) ((uint64_t) fin * mdiv);
     return vco / (psysdiv + 1);
   }
-  uint32_t osysdiv = (SYSCTL->RSCLKCFG & (0xf << 16)) >> 16;
+  uint32_t osysdiv = (sysctl->RSCLKCFG & (0xf << 16)) >> 16;
   return clk / (osysdiv + 1);
 }
 
@@ -133,8 +135,8 @@ static bool mip_driver_tm4c_init(uint8_t *mac, void *userdata) {
         (uint32_t) (uintptr_t) s_txdesc[(i + 1) % ETH_DESC_CNT];  // Chain
   }
 
-  EMAC->EMACDMABUSMOD |= BIT(0);                        // Software reset
-  while ((EMAC->EMACDMABUSMOD & BIT(0)) != 0) spin(1);  // Wait until done
+  EMAC->EMACDMABUSMOD |= BIT(0);                            // Software reset
+  while ((EMAC->EMACDMABUSMOD & BIT(0)) != 0) tm4cspin(1);  // Wait until done
 
   // Set MDC clock divider. If user told us the value, use it. Otherwise, guess
   int cr = (d == NULL || d->mdc_cr < 0) ? guess_mdc_cr() : d->mdc_cr;
@@ -150,17 +152,11 @@ static bool mip_driver_tm4c_init(uint8_t *mac, void *userdata) {
   emac_write_phy(EPHY_ADDR, EPHYBMCR, BIT(15));  // Reset internal PHY (EPHY)
   emac_write_phy(EPHY_ADDR, EPHYBMCR, BIT(12));  // Set autonegotiation
   EMAC->EMACRXDLADDR = (uint32_t) (uintptr_t) s_rxdesc;  // RX descriptors
-  EMAC->EMACTXDLADDR = (uint32_t) (uintptr_t) s_txdesc;  // RX descriptors
+  EMAC->EMACTXDLADDR = (uint32_t) (uintptr_t) s_txdesc;  // TX descriptors
   EMAC->EMACDMAIM = BIT(6) | BIT(16);                    // RIE, NIE
   EMAC->EMACCFG = BIT(2) | BIT(3) | BIT(11) | BIT(14);   // RE, TE, Duplex, Fast
   EMAC->EMACDMAOPMODE =
       BIT(1) | BIT(13) | BIT(21) | BIT(25);  // SR, ST, TSF, RSF
-  // TODO(scaprile) we are not using EPHY interrupts, we could probably use
-  // them, have a status flag, and avoid polling the PHY
-
-  // MAC address filtering NOTE(scaprile): This is currently ignored by
-  // configuration of EMACFRAMEFLTR above; MIP receives all frames. This also
-  // applies to the STM32 driver (Nov 1st 2022)
   EMAC->EMACADDR0H = ((uint32_t) mac[5] << 8U) | mac[4];
   EMAC->EMACADDR0L = (uint32_t) (mac[3] << 24) | ((uint32_t) mac[2] << 16) |
                      ((uint32_t) mac[1] << 8) | mac[0];


### PR DESCRIPTION
Had to modify the driver to avoid name clashes (now I understand those name changes you introduced on the STM driver)
Latest forced push is just in case the mac filtering requires a rebase
