### PR TITLE
MG_EV_POLL generation on MIP

### DIFF
--- a/mip/mip.c
+++ b/mip/mip.c
@@ -925,6 +925,10 @@ void mg_mgr_poll(struct mg_mgr *mgr, int ms) {
   mg_timer_poll(&mgr->timers, now);
   for (c = mgr->conns; c != NULL; c = tmp) {
     tmp = c->next;
+    mg_call(c, MG_EV_POLL, &now);
+    MG_VERBOSE(("%lu .. %c%c%c%c%c", c->id, c->is_tls ? 'T' : 't',
+                c->is_connecting ? 'C' : 'c', c->is_tls_hs ? 'H' : 'h',
+                c->is_resolving ? 'R' : 'r', c->is_closing ? 'C' : 'c'));
     if (c->is_tls_hs) mg_tls_handshake(c);
     if (can_write(c)) write_conn(c);
     if (c->is_draining && c->send.len == 0) c->is_closing = 1;

--- a/mongoose.c
+++ b/mongoose.c
@@ -7451,6 +7451,10 @@ void mg_mgr_poll(struct mg_mgr *mgr, int ms) {
   mg_timer_poll(&mgr->timers, now);
   for (c = mgr->conns; c != NULL; c = tmp) {
     tmp = c->next;
+    mg_call(c, MG_EV_POLL, &now);
+    MG_VERBOSE(("%lu .. %c%c%c%c%c", c->id, c->is_tls ? 'T' : 't',
+                c->is_connecting ? 'C' : 'c', c->is_tls_hs ? 'H' : 'h',
+                c->is_resolving ? 'R' : 'r', c->is_closing ? 'C' : 'c'));
     if (c->is_tls_hs) mg_tls_handshake(c);
     if (can_write(c)) write_conn(c);
     if (c->is_draining && c->send.len == 0) c->is_closing = 1;

--- a/test/driver_mock.c
+++ b/test/driver_mock.c
@@ -10,7 +10,7 @@ static size_t mock_tx(const void *buf, size_t len, void *data) {
 
 static size_t mock_rx(void *buf, size_t len, void *data) {
   (void) buf, (void) len, (void) data;
-  return len;
+  return 0;
 }
 
 static bool mock_up(void *data) {

--- a/test/mip_test.c
+++ b/test/mip_test.c
@@ -266,12 +266,17 @@ static void ph(struct mg_connection *c, int ev, void *ev_data, void *fn_data) {
 }
 
 static void test_poll(void) {
-  int count = 0;
+  int count = 0, i;
   struct mg_mgr mgr;
   mg_mgr_init(&mgr);
+  struct mip_if mif;
+  memset(&mif, 0, sizeof(mif));
+  mif.driver = &mip_driver_mock;
+  mip_init(&mgr, &mif);
   mg_http_listen(&mgr, "http://127.0.0.1:12346", ph, &count);
-  for (int i = 0; i < 10; i++) mg_mgr_poll(&mgr, 0);
+  for (i = 0; i < 10; i++) mg_mgr_poll(&mgr, 0);
   ASSERT(count == 10);
+  mip_free(&mif);
   mg_mgr_free(&mgr);
 }
 

--- a/test/mip_test.c
+++ b/test/mip_test.c
@@ -4,6 +4,7 @@
 #define MG_ENABLE_PACKED_FS 0
 
 #include <assert.h>
+#include <sys/socket.h>
 #include <linux/if.h>
 #include <linux/if_tun.h>
 #include <sys/ioctl.h>
@@ -259,10 +260,26 @@ static void test_http_fetch(void) {
   close(fd);
 }
 
+static void ph(struct mg_connection *c, int ev, void *ev_data, void *fn_data) {
+  if (ev == MG_EV_POLL) ++(*(int *) fn_data);
+  (void) c, (void) ev_data;
+}
+
+static void test_poll(void) {
+  int count = 0;
+  struct mg_mgr mgr;
+  mg_mgr_init(&mgr);
+  mg_http_listen(&mgr, "http://127.0.0.1:12346", ph, &count);
+  for (int i = 0; i < 10; i++) mg_mgr_poll(&mgr, 0);
+  ASSERT(count == 10);
+  mg_mgr_free(&mgr);
+}
+
 int main(void) {
   test_queue();
   test_statechange();
   test_http_fetch();
+  test_poll();
   printf("SUCCESS. Total tests: %d\n", s_num_tests);
   return 0;
 }


### PR DESCRIPTION
Stage 1: Add test. Passes on unit_test, fails on mip_test (forced push was to make VC98 happy)
Stage 2: Fix it.
Note: driver_mock rx func was returning len, that aparently caused MIP to allocate memory and the sanitizer would complain. Modified the driver to return 0.

Q: The order of calling is not being respected, POLL is now fired after a possible data event
Q: Should we move these common tests to a common file called by both unit and mip_test ? Do you expect more common tests to follow ? (We are now testing UDP with DHCP, we could run the SNTP test; we test TCP with the HTTP fetch)