### PR TITLE
Ask for gw mac when needed and not known

### DIFF
--- a/mip/mip.c
+++ b/mip/mip.c
@@ -297,6 +297,7 @@ static struct ip *tx_ip(struct mip_if *ifp, uint8_t proto, uint32_t ip_src,
   if (!mac && ((ip_dst & ifp->mask) == (ifp->ip & ifp->mask)))
     arp_ask(ifp, ip_dst);                             // Same net, lookup
   if (!mac) mac = arp_cache_find(ifp, ifp->gw);       // Use gateway MAC
+  if (!mac) arp_ask(ifp, ifp->gw);                    // Not found? lookup
   if (mac) memcpy(eth->dst, mac, sizeof(eth->dst));   // Found? Use it
   if (!mac) memset(eth->dst, 255, sizeof(eth->dst));  // No? Use broadcast
   memcpy(eth->src, ifp->mac, sizeof(eth->src));       // TODO(cpq): ARP lookup

--- a/mongoose.c
+++ b/mongoose.c
@@ -6824,6 +6824,7 @@ static struct ip *tx_ip(struct mip_if *ifp, uint8_t proto, uint32_t ip_src,
   if (!mac && ((ip_dst & ifp->mask) == (ifp->ip & ifp->mask)))
     arp_ask(ifp, ip_dst);                             // Same net, lookup
   if (!mac) mac = arp_cache_find(ifp, ifp->gw);       // Use gateway MAC
+  if (!mac) arp_ask(ifp, ifp->gw);                    // Not found? lookup
   if (mac) memcpy(eth->dst, mac, sizeof(eth->dst));   // Found? Use it
   if (!mac) memset(eth->dst, 255, sizeof(eth->dst));  // No? Use broadcast
   memcpy(eth->src, ifp->mac, sizeof(eth->src));       // TODO(cpq): ARP lookup


### PR DESCRIPTION
We ask for gw MAC address as soon as we get its IP address from DHCP.
In environments with noticeable frame loss, that response sometimes gets lost. We no longer ask, so when trying to send packets to the router, we end up sending broadcasts, that don't reach its destination.
Now if we need to send to the router and we don't have its MAC, we ask for it.