### PR TITLE
Avoid duplicated ACKs

### DIFF
--- a/mip/mip.c
+++ b/mip/mip.c
@@ -540,7 +540,7 @@ long mg_io_send(struct mg_connection *c, const void *buf, size_t len) {
   if (tx_tcp(ifp, c->rem.ip, TH_PUSH | TH_ACK, c->loc.port, c->rem.port,
              mg_htonl(s->seq), mg_htonl(s->ack), buf, len) > 0) {
     s->seq += (uint32_t) len;
-    if (s->ttype == MIP_TTYPE_KEEPALIVE) settmout(c, MIP_TTYPE_KEEPALIVE);
+    settmout(c, MIP_TTYPE_KEEPALIVE);
   } else {
     return MG_IO_ERR;
   }

--- a/mongoose.c
+++ b/mongoose.c
@@ -7067,7 +7067,7 @@ long mg_io_send(struct mg_connection *c, const void *buf, size_t len) {
   if (tx_tcp(ifp, c->rem.ip, TH_PUSH | TH_ACK, c->loc.port, c->rem.port,
              mg_htonl(s->seq), mg_htonl(s->ack), buf, len) > 0) {
     s->seq += (uint32_t) len;
-    if (s->ttype == MIP_TTYPE_KEEPALIVE) settmout(c, MIP_TTYPE_KEEPALIVE);
+    settmout(c, MIP_TTYPE_KEEPALIVE);
   } else {
     return MG_IO_ERR;
   }


### PR DESCRIPTION
- We start a timer when we need to send an ACK.
  - If a segment is sent before the timer expires, that timer is not reset
- We restart the keepalive timeout on send only if there was no ACK timeout pending

This patch always restarts the keepalive timeout on send. If there was a pending ACK, it will be sent piggybacked with this segment, so we avoid the dup ack; the keepalive message will be sent if there are no further msgs from this one

Note: the current keepalive strategy is two-way, we only check for no reception when we need to send. It will work as long as we are not streaming and that is not likely... If we have a partially closed socket scenario where we can send but the other end can't, we won't detect it until we stop sending. If we can't send but the other end can, we won't detect it. (unless my reading of the source code was not correct)