### PR TITLE
Minor tweaks in STM32 examples

### DIFF
--- a/examples/stm32/nucleo-f429zi-baremetal/boot.c
+++ b/examples/stm32/nucleo-f429zi-baremetal/boot.c
@@ -3,9 +3,6 @@
 
 // Startup code
 __attribute__((naked, noreturn)) void _reset(void) {
-  // Init stack
-  asm("ldr sp, = _estack");
-
   // Initialise memory
   extern long _sbss, _ebss, _sdata, _edata, _sidata;
   for (long *src = &_sbss; src < &_ebss; src++) *src = 0;
@@ -125,9 +122,10 @@ WEAK_ALIAS void LTDC_ER_IRQHandler(void);
 WEAK_ALIAS void DMA2D_IRQHandler(void);
 
 // IRQ table
+extern void _estack();
 __attribute__((section(".vectors"))) void (*tab[16 + 91])(void) = {
     // Cortex interrupts
-    0, _reset, NMI_Handler, HardFault_Handler, MemManage_Handler,
+    _estack, _reset, NMI_Handler, HardFault_Handler, MemManage_Handler,
     BusFault_Handler, UsageFault_Handler, 0, 0, 0, 0, SVC_Handler,
     DebugMon_Handler, 0, PendSV_Handler, SysTick_Handler,
 

--- a/examples/stm32/nucleo-f429zi-baremetal/main.c
+++ b/examples/stm32/nucleo-f429zi-baremetal/main.c
@@ -68,7 +68,7 @@ int main(void) {
   mg_timer_add(&mgr, 500, MG_TIMER_REPEAT, blink_cb, &mgr);
 
   // Initialise Mongoose network stack
-  // Specify MAC address, and use 0 for IP, mask, GW - i.e. use DHCP
+  // Specify MAC address, either set use_dhcp or enter a static config.
   // For static configuration, specify IP/mask/GW in network byte order
   struct mip_driver_stm32 driver_data = {.mdc_cr = 4};  // See driver_stm32.h
   struct mip_if mif = {

--- a/examples/stm32/nucleo-f429zi-baremetal/mcu.h
+++ b/examples/stm32/nucleo-f429zi-baremetal/mcu.h
@@ -65,7 +65,6 @@ static inline void systick_init(uint32_t ticks) {
   SYSTICK->LOAD = ticks - 1;
   SYSTICK->VAL = 0;
   SYSTICK->CTRL = BIT(0) | BIT(1) | BIT(2);  // Enable systick
-  RCC->APB2ENR |= BIT(14);                   // Enable SYSCFG
 }
 
 struct flash {

--- a/examples/stm32/nucleo-f429zi-freertos-mip/main.c
+++ b/examples/stm32/nucleo-f429zi-freertos-mip/main.c
@@ -31,6 +31,7 @@ static void ethernet_init(void) {
   }
 
   NVIC_EnableIRQ(61);                           // Setup Ethernet IRQ handler
+  RCC->APB2ENR |= BIT(14);                      // Enable SYSCFG
   SYSCFG->PMC |= BIT(23);                       // Use RMII. Goes first!
   RCC->AHB1ENR |= BIT(25) | BIT(26) | BIT(27);  // Enable Ethernet clocks
   RCC->AHB1RSTR |= BIT(25);                     // ETHMAC force reset
@@ -43,7 +44,7 @@ static void server(void *args) {
   mg_log_set(MG_LL_DEBUG);  // Set log level
 
   // Initialise Mongoose network stack
-  // Specify MAC address, and use 0 for IP, mask, GW - i.e. use DHCP
+  // Specify MAC address, either set use_dhcp or enter a static config.
   // For static configuration, specify IP/mask/GW in network byte order
   MG_INFO(("Initializing Ethernet driver"));
   ethernet_init();
@@ -74,7 +75,6 @@ static void blinker(void *args) {
 }
 
 int main(void) {
-  RCC->APB2ENR |= BIT(14);    // Enable SYSCFG: for systick & Ethernet
   clock_init();               // Set clock to max of 180 MHz
   systick_init(FREQ / 1000);  // Tick every 1 ms
   uart_init(UART3, 115200);   // Initialise UART

--- a/examples/stm32/nucleo-f746zg-baremetal/boot.c
+++ b/examples/stm32/nucleo-f746zg-baremetal/boot.c
@@ -3,9 +3,6 @@
 
 // Startup code
 __attribute__((naked, noreturn)) void _reset(void) {
-  // Init stack
-  asm("ldr sp, = _estack");
-
   // Initialise memory
   extern long _sbss, _ebss, _sdata, _edata, _sidata;
   for (long *src = &_sbss; src < &_ebss; src++) *src = 0;
@@ -132,9 +129,10 @@ WEAK_ALIAS void I2C4_ER_IRQHandler(void);
 WEAK_ALIAS void SPDIF_RX_IRQHandler(void);
 
 // IRQ table
+extern void _estack();
 __attribute__((section(".vectors"))) void (*tab[16 + 98])(void) = {
     // Cortex interrupts
-    0, _reset, NMI_Handler, HardFault_Handler, MemManage_Handler,
+    _estack, _reset, NMI_Handler, HardFault_Handler, MemManage_Handler,
     BusFault_Handler, UsageFault_Handler, 0, 0, 0, 0, SVC_Handler,
     DebugMon_Handler, 0, PendSV_Handler, SysTick_Handler,
 

--- a/examples/stm32/nucleo-f746zg-baremetal/main.c
+++ b/examples/stm32/nucleo-f746zg-baremetal/main.c
@@ -68,7 +68,7 @@ int main(void) {
   mg_timer_add(&mgr, 500, MG_TIMER_REPEAT, blink_cb, &mgr);
 
   // Initialise Mongoose network stack
-  // Specify MAC address, and use 0 for IP, mask, GW - i.e. use DHCP
+  // Specify MAC address, either set use_dhcp or enter a static config.
   // For static configuration, specify IP/mask/GW in network byte order
   struct mip_driver_stm32 driver_data = {.mdc_cr = 4};  // See driver_stm32.h
   struct mip_if mif = {

--- a/examples/stm32/nucleo-f746zg-baremetal/mcu.h
+++ b/examples/stm32/nucleo-f746zg-baremetal/mcu.h
@@ -66,7 +66,6 @@ static inline void systick_init(uint32_t ticks) {
   SYSTICK->LOAD = ticks - 1;
   SYSTICK->VAL = 0;
   SYSTICK->CTRL = BIT(0) | BIT(1) | BIT(2);  // Enable systick
-  RCC->APB2ENR |= BIT(14);                   // Enable SYSCFG
 }
 
 struct flash {


### PR DESCRIPTION
Fix comments in newer mip initialization (main.c)
Correct stack initialization (boot.c)
Remove SCC clock enable when not needed (mcu.h)