### PR TITLE
Bugfix OpenSSL TLS SNI

### DIFF
--- a/src/tls_openssl.c
+++ b/src/tls_openssl.c
@@ -94,6 +94,7 @@ void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
   if (opts->srvname.len > 0) {
     char *s = mg_mprintf("%.*s", (int) opts->srvname.len, opts->srvname.ptr);
     SSL_set1_host(tls->ssl, s);
+    SSL_set_tlsext_host_name(tls->ssl, s);
     free(s);
   }
 #endif


### PR DESCRIPTION
After this (https://github.com/cesanta/mongoose/commit/d76f86f7db59838fa4a2727d7d07710c6cf7470c) change, `SSL_set_tlsext_host_name` is missing, and SNI (Server Name Indication) did not work.

In that commit `SSL_set_tlsext_host_name` is replaced by `SSL_set1_host`, but the both are not same. `SSL_set_tlsext_host_name` is for SNI and `SSL_set1_host` for certification.

This pull request adds `SSL_set_tlsext_host_name` aside `SSL_set1_host` in the `tls_openssl.c`.