### PR TITLE
Add mg_print_ip, mg_print_ip_port helper functions

### DIFF
--- a/mongoose.h
+++ b/mongoose.h
@@ -896,9 +896,14 @@ uint64_t mg_millis(void);
 #define mg_htons(x) mg_ntohs(x)
 #define mg_htonl(x) mg_ntohl(x)
 
-#define MG_U32(a, b, c, d)                                      \
+#define MG_U32(a, b, c, d)                                         \
   (((uint32_t) ((a) &255) << 24) | ((uint32_t) ((b) &255) << 16) | \
    ((uint32_t) ((c) &255) << 8) | (uint32_t) ((d) &255))
+
+// For printing IPv4 addresses: printf("%d.%d.%d.%d\n", MG_IPADDR_PARTS(&ip))
+#define MG_U8P(ADDR) ((uint8_t *) (ADDR))
+#define MG_IPADDR_PARTS(ADDR) \
+  MG_U8P(ADDR)[0], MG_U8P(ADDR)[1], MG_U8P(ADDR)[2], MG_U8P(ADDR)[3]
 
 // Linked list management macros
 #define LIST_ADD_HEAD(type_, head_, elem_) \
@@ -1102,8 +1107,12 @@ int mg_mkpipe(struct mg_mgr *, mg_event_handler_t, void *, bool udp);
 struct mg_connection *mg_alloc_conn(struct mg_mgr *);
 void mg_close_conn(struct mg_connection *c);
 bool mg_open_listener(struct mg_connection *c, const char *url);
+
+// Utility functions
 struct mg_timer *mg_timer_add(struct mg_mgr *mgr, uint64_t milliseconds,
                               unsigned flags, void (*fn)(void *), void *arg);
+size_t mg_print_ip(void (*out)(char, void *), void *ptr, va_list *ap);
+size_t mg_print_ip_port(void (*out)(char, void *), void *ptr, va_list *ap);
 
 // Low-level IO primives used by TLS layer
 enum { MG_IO_ERR = -1, MG_IO_WAIT = -2, MG_IO_RESET = -3 };

--- a/src/dns.c
+++ b/src/dns.c
@@ -161,9 +161,7 @@ static void dns_cb(struct mg_connection *c, int ev, void *ev_data,
           if (dm.resolved) {
             dm.addr.port = d->c->rem.port;  // Save port
             d->c->rem = dm.addr;            // Copy resolved address
-            MG_DEBUG(
-                ("%lu %s is %I", d->c->id, dm.name, d->c->rem.is_ip6 ? 16 : 4,
-                 d->c->rem.is_ip6 ? &d->c->rem.ip6 : (void *) &d->c->rem.ip));
+            MG_DEBUG(("%lu %s is %M", d->c->id, dm.name, mg_print_ip, &c->rem));
             mg_connect_resolved(d->c);
 #if MG_ENABLE_IPV6
           } else if (dm.addr.is_ip6 == false && dm.name[0] != '\0' &&

--- a/src/net.c
+++ b/src/net.c
@@ -207,6 +207,25 @@ struct mg_timer *mg_timer_add(struct mg_mgr *mgr, uint64_t milliseconds,
   return t;
 }
 
+size_t mg_print_ip(void (*out)(char, void *), void *arg, va_list *ap) {
+  struct mg_addr *addr = va_arg(*ap, struct mg_addr *);
+  if (addr->is_ip6) {
+    uint16_t *p = (uint16_t *) addr->ip6;
+    return mg_xprintf(out, arg, "[%x:%x:%x:%x:%x:%x:%x:%x]", mg_htons(p[0]),
+                      mg_htons(p[1]), mg_htons(p[2]), mg_htons(p[3]),
+                      mg_htons(p[4]), mg_htons(p[5]), mg_htons(p[6]),
+                      mg_htons(p[7]));
+  } else {
+    uint8_t *p = (uint8_t *) &addr->ip;
+    return mg_xprintf(out, arg, "%d.%d.%d.%d", p[0], p[1], p[2], p[3]);
+  }
+}
+
+size_t mg_print_ip_port(void (*out)(char, void *), void *arg, va_list *ap) {
+  struct mg_addr *a = va_arg(*ap, struct mg_addr *);
+  return mg_xprintf(out, arg, "%M:%hu", mg_print_ip, a, mg_ntohs(a->port));
+}
+
 void mg_mgr_free(struct mg_mgr *mgr) {
   struct mg_connection *c;
   struct mg_timer *tmp, *t = mgr->timers;

--- a/src/net.h
+++ b/src/net.h
@@ -94,8 +94,12 @@ int mg_mkpipe(struct mg_mgr *, mg_event_handler_t, void *, bool udp);
 struct mg_connection *mg_alloc_conn(struct mg_mgr *);
 void mg_close_conn(struct mg_connection *c);
 bool mg_open_listener(struct mg_connection *c, const char *url);
+
+// Utility functions
 struct mg_timer *mg_timer_add(struct mg_mgr *mgr, uint64_t milliseconds,
                               unsigned flags, void (*fn)(void *), void *arg);
+size_t mg_print_ip(void (*out)(char, void *), void *ptr, va_list *ap);
+size_t mg_print_ip_port(void (*out)(char, void *), void *ptr, va_list *ap);
 
 // Low-level IO primives used by TLS layer
 enum { MG_IO_ERR = -1, MG_IO_WAIT = -2, MG_IO_RESET = -3 };

--- a/src/sock.c
+++ b/src/sock.c
@@ -101,8 +101,8 @@ static void iolog(struct mg_connection *c, char *buf, long n, bool r) {
       union usa usa;
       socklen_t slen = sizeof(usa.sin);
       if (getsockname(FD(c), &usa.sa, &slen) < 0) (void) 0;  // Ignore result
-      MG_INFO(("\n-- %lu %I %s %I %ld", c->id, 4, &usa.sin.sin_addr,
-               r ? "<-" : "->", 4, &c->rem.ip, n));
+      MG_INFO(("\n-- %lu %M %s %M %ld", c->id, mg_print_ip_port, &c->loc,
+               r ? "<-" : "->", mg_print_ip_port, &c->rem, n));
 
       mg_hexdump(buf, (size_t) n);
     }
@@ -357,8 +357,7 @@ void mg_connect_resolved(struct mg_connection *c) {
     if ((rc = connect(FD(c), &usa.sa, slen)) == 0) {
       mg_call(c, MG_EV_CONNECT, NULL);
     } else if (mg_sock_would_block()) {
-      MG_DEBUG(("%lu %p -> %I:%hu pend", c->id, c->fd, 4, &c->rem.ip,
-                mg_ntohs(c->rem.port)));
+      MG_DEBUG(("%lu %p -> %M pend", c->id, c->fd, mg_print_ip_port, &c->rem));
       c->is_connecting = 1;
     } else {
       mg_error(c, "connect: %d", MG_SOCKET_ERRNO);
@@ -413,8 +412,8 @@ static void accept_conn(struct mg_mgr *mgr, struct mg_connection *lsn) {
     c->pfn_data = lsn->pfn_data;
     c->fn = lsn->fn;
     c->fn_data = lsn->fn_data;
-    MG_DEBUG(("%lu %p accepted %I.%hu -> %I.%hu", c->id, c->fd, 4, &c->rem.ip,
-              mg_ntohs(c->rem.port), 4, &c->loc.ip, mg_ntohs(c->loc.port)));
+    MG_DEBUG(("%lu %p accepted %M -> %M", c->id, c->fd, mg_print_ip_port,
+              &c->rem, mg_print_ip_port, &c->loc));
     mg_call(c, MG_EV_OPEN, NULL);
     mg_call(c, MG_EV_ACCEPT, NULL);
   }

--- a/src/tls_mbed.c
+++ b/src/tls_mbed.c
@@ -26,7 +26,7 @@ void mg_tls_free(struct mg_connection *c) {
 
 static int mg_net_send(void *ctx, const unsigned char *buf, size_t len) {
   long n = mg_io_send((struct mg_connection *) ctx, buf, len);
-  MG_VERBOSE(("%lu n=%ld", ((struct mg_connection *) ctx)->id, n));
+  MG_VERBOSE(("%lu n=%ld e=%d", ((struct mg_connection *) ctx)->id, n, errno));
   if (n == MG_IO_WAIT) return MBEDTLS_ERR_SSL_WANT_WRITE;
   if (n == MG_IO_RESET) return MBEDTLS_ERR_NET_CONN_RESET;
   if (n == MG_IO_ERR) return MBEDTLS_ERR_NET_SEND_FAILED;
@@ -66,7 +66,7 @@ static int mbed_rng(void *ctx, unsigned char *buf, size_t len) {
 
 static void debug_cb(void *c, int lev, const char *s, int n, const char *s2) {
   n = (int) strlen(s2) - 1;
-  MG_VERBOSE(("%lu %d %.*s", ((struct mg_connection *) c)->id, lev, n, s2));
+  MG_INFO(("%lu %d %.*s", ((struct mg_connection *) c)->id, lev, n, s2));
   (void) s;
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -14,9 +14,14 @@ uint64_t mg_millis(void);
 #define mg_htons(x) mg_ntohs(x)
 #define mg_htonl(x) mg_ntohl(x)
 
-#define MG_U32(a, b, c, d)                                      \
+#define MG_U32(a, b, c, d)                                         \
   (((uint32_t) ((a) &255) << 24) | ((uint32_t) ((b) &255) << 16) | \
    ((uint32_t) ((c) &255) << 8) | (uint32_t) ((d) &255))
+
+// For printing IPv4 addresses: printf("%d.%d.%d.%d\n", MG_IPADDR_PARTS(&ip))
+#define MG_U8P(ADDR) ((uint8_t *) (ADDR))
+#define MG_IPADDR_PARTS(ADDR) \
+  MG_U8P(ADDR)[0], MG_U8P(ADDR)[1], MG_U8P(ADDR)[2], MG_U8P(ADDR)[3]
 
 // Linked list management macros
 #define LIST_ADD_HEAD(type_, head_, elem_) \

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -360,8 +360,8 @@ static void mqtt_cb(struct mg_connection *c, int ev, void *evd, void *fnd) {
     }
   } else if (ev == MG_EV_MQTT_MSG) {
     struct mg_mqtt_message *mm = (struct mg_mqtt_message *) evd;
-    snprintf(buf + 1, test_data->bufsize, "%.*s/%.*s", (int) mm->topic.len, mm->topic.ptr,
-            (int) mm->data.len, mm->data.ptr);
+    snprintf(buf + 1, test_data->bufsize, "%.*s/%.*s", (int) mm->topic.len,
+             mm->topic.ptr, (int) mm->data.len, mm->data.ptr);
   }
   (void) c;
 }
@@ -1284,9 +1284,7 @@ static void test_http_range(void) {
   ASSERT(mgr.conns == NULL);
 }
 
-static void f1(void *arg) {
-  (*(int *) arg)++;
-}
+static void f1(void *arg) { (*(int *) arg)++; }
 
 static void test_timer(void) {
   int v1 = 0, v2 = 0, v3 = 0;
@@ -1641,16 +1639,24 @@ static void test_str(void) {
 
   {
     char buf[100];
-    struct mg_addr a = {0, mg_htonl(0x10111213), {1, 100, 33}, false};
-    ASSERT(mg_snprintf(buf, sizeof(buf), "%I", 4, &a.ip) == 11);
-    ASSERT(strcmp(buf, "16.17.18.19") == 0);
-    ASSERT(mg_snprintf(buf, sizeof(buf), "%I", 6, &a.ip6) == 20);
-    ASSERT(strcmp(buf, "164:2100:0:0:0:0:0:0") == 0);
+    struct mg_addr a = {mg_htons(3), mg_htonl(0x2000001), {1, 100, 33}, false};
+    ASSERT(mg_snprintf(buf, sizeof(buf), "%M %d", mg_print_ip, &a, 7) == 9);
+    ASSERT(strcmp(buf, "2.0.0.1 7") == 0);
+    ASSERT(mg_snprintf(buf, sizeof(buf), "%M %d", mg_print_ip_port, &a, 7) ==
+           11);
+    ASSERT(strcmp(buf, "2.0.0.1:3 7") == 0);
+    a.is_ip6 = true;
+    ASSERT(mg_snprintf(buf, sizeof(buf), "%M %d", mg_print_ip, &a, 7) == 24);
+    ASSERT(strcmp(buf, "[164:2100:0:0:0:0:0:0] 7") == 0);
+    ASSERT(mg_snprintf(buf, sizeof(buf), "%M %d", mg_print_ip_port, &a, 7) ==
+           26);
+    ASSERT(strcmp(buf, "[164:2100:0:0:0:0:0:0]:3 7") == 0);
   }
 }
 
 static void fn1(struct mg_connection *c, int ev, void *ev_data, void *fn_data) {
-  if (ev == MG_EV_ERROR) *(char **) fn_data = mg_mprintf("%s", (char *) ev_data);
+  if (ev == MG_EV_ERROR)
+    *(char **) fn_data = mg_mprintf("%s", (char *) ev_data);
   (void) c;
 }
 


### PR DESCRIPTION
Our mg_*printf API has a non-standard extensions: `%M`, `%I`, `%H`, `%A`, etc etc.

We might want more functionality.
For example, we currently have `%Q` specifier for double-quoted string - we might want to add a non-quoted variant for strings, to handle cases e.g. `mg_printf(c, "{%Q: \"hello, %q\"}", "message", "escape, but not quote");` 

Extra functionality is good.
But non-standard is bad.

We should move towards using a minimum non-standard features.
This PR makes `%I` specifier not needed anymore:

Before:

```c
mg_printf(c, "%I", c->rem.ip);  // Prints IPv4 address. Caller must be sure it is IPv4
```
After:

```c
mg_printf(c, "%M", mg_print_ip, &c->rem);  // Prints IP address, IPv4 or IPv6
```

This PR cleans up `%I` usage in `src/` and `test/`. 
Examples, and README still have `I%`