### PR TITLE
Randseed

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -2,6 +2,7 @@
 
 #if MG_ENABLE_CUSTOM_RANDOM
 #else
+#define MG_RESEED_PERIOD_MS 60000
 void mg_random(void *buf, size_t len) {
   bool done = false;
   unsigned char *p = (unsigned char *) buf;
@@ -14,6 +15,14 @@ void mg_random(void *buf, size_t len) {
   if (fp != NULL) {
     if (fread(buf, 1, len, fp) == len) done = true;
     fclose(fp);
+  }
+#else
+  static uint64_t millis_last;
+  volatile uint64_t millis = mg_millis();
+  // Seed/reseed on timout
+  if (!millis_last || ((millis - millis_last) > MG_RESEED_PERIOD_MS)) {
+    srand((unsigned int)millis);
+    millis_last = millis;
   }
 #endif
   // If everything above did not work, fallback to a pseudo random generator


### PR DESCRIPTION
For MIP, rand() should be seeded initially and periodically in order to provide random generators.
Tests show it cannot be seeded at init only to make it efficient, since the startup is very predictable.

For every call of mg_random(), and as long as MG is running on MG_TCPIP (ie baremetal driver)
- Provide initial seed based on timer after init sequence
- Re-seed on parameter (60s by default) for every subsequent call