### PR TITLE
Fix _sbrk()

### DIFF
--- a/examples/stm32/nucleo-f429zi-baremetal/syscalls.c
+++ b/examples/stm32/nucleo-f429zi-baremetal/syscalls.c
@@ -12,8 +12,11 @@ void *_sbrk(int incr) {
   extern char _end;
   static unsigned char *heap = NULL;
   unsigned char *prev_heap;
+  unsigned char x = 0, *heap_end = (unsigned char *)((size_t) &x - 512);
+  (void) x;
   if (heap == NULL) heap = (unsigned char *) &_end;
   prev_heap = heap;
+  if (heap + incr > heap_end) return (void *) -1;
   heap += incr;
   return prev_heap;
 }

--- a/examples/stm32/nucleo-f429zi-rndis/syscalls.c
+++ b/examples/stm32/nucleo-f429zi-rndis/syscalls.c
@@ -12,8 +12,11 @@ void *_sbrk(int incr) {
   extern char _end;
   static unsigned char *heap = NULL;
   unsigned char *prev_heap;
+  unsigned char x = 0, *heap_end = (unsigned char *)((size_t) &x - 512);
+  (void) x;
   if (heap == NULL) heap = (unsigned char *) &_end;
   prev_heap = heap;
+  if (heap + incr > heap_end) return (void *) -1;
   heap += incr;
   return prev_heap;
 }

--- a/examples/stm32/nucleo-f746zg-baremetal/syscalls.c
+++ b/examples/stm32/nucleo-f746zg-baremetal/syscalls.c
@@ -12,8 +12,11 @@ void *_sbrk(int incr) {
   extern char _end;
   static unsigned char *heap = NULL;
   unsigned char *prev_heap;
+  unsigned char x = 0, *heap_end = (unsigned char *)((size_t) &x - 512);
+  (void) x;
   if (heap == NULL) heap = (unsigned char *) &_end;
   prev_heap = heap;
+  if (heap + incr > heap_end) return (void *) -1;
   heap += incr;
   return prev_heap;
 }

--- a/examples/stm32/nucleo-f746zg-rndis/syscalls.c
+++ b/examples/stm32/nucleo-f746zg-rndis/syscalls.c
@@ -12,8 +12,11 @@ void *_sbrk(int incr) {
   extern char _end;
   static unsigned char *heap = NULL;
   unsigned char *prev_heap;
+  unsigned char x = 0, *heap_end = (unsigned char *)((size_t) &x - 512);
+  (void) x;
   if (heap == NULL) heap = (unsigned char *) &_end;
   prev_heap = heap;
+  if (heap + incr > heap_end) return (void *) -1;
   heap += incr;
   return prev_heap;
 }

--- a/examples/stm32/nucleo-h743zi-baremetal/syscalls.c
+++ b/examples/stm32/nucleo-h743zi-baremetal/syscalls.c
@@ -12,8 +12,11 @@ void *_sbrk(int incr) {
   extern char _end;
   static unsigned char *heap = NULL;
   unsigned char *prev_heap;
+  unsigned char x = 0, *heap_end = (unsigned char *)((size_t) &x - 512);
+  (void) x;
   if (heap == NULL) heap = (unsigned char *) &_end;
   prev_heap = heap;
+  if (heap + incr > heap_end) return (void *) -1;
   heap += incr;
   return prev_heap;
 }


### PR DESCRIPTION
After following the source code learned that we need to return -1 when the heap is exhausted
The strange crash after applying the fix was arm gcc 11.3 fault when malloc() tried to beg some memory out of the freed list.
Latest 12.2 works OK

Not applying to FreeRTOS examples as it has its own heap limit