### PR TITLE
Update RMII example, enhance MIP

### DIFF
--- a/examples/rp2040/pico-rmii/main.c
+++ b/examples/rp2040/pico-rmii/main.c
@@ -42,6 +42,8 @@ int main(void) {
   struct mg_tcpip_if mif = {
       .mac = {2, 0, 1, 2, 3, 5},
       .ip = 0,
+      .enable_mac_check = true,
+      .enable_crc32_check = true,
       .driver = &mg_tcpip_driver_rp2040_rmii,
       .driver_data = &driver_data,
   };

--- a/mongoose.h
+++ b/mongoose.h
@@ -1514,11 +1514,13 @@ struct mg_tcpip_driver {
 
 // Network interface
 struct mg_tcpip_if {
-  uint8_t mac[6];                  // MAC address. Must be set to a valid MAC
-  uint32_t ip, mask, gw;           // IP address, mask, default gateway
-  struct mg_str tx;                // Output (TX) buffer
-  bool enable_dhcp_client;         // Enable DCHP client
-  bool enable_dhcp_server;         // Enable DCHP server
+  uint8_t mac[6];           // MAC address. Must be set to a valid MAC
+  uint32_t ip, mask, gw;    // IP address, mask, default gateway
+  struct mg_str tx;         // Output (TX) buffer
+  bool enable_dhcp_client;  // Enable DCHP client
+  bool enable_dhcp_server;  // Enable DCHP server
+  bool enable_crc32_check;  // Do a CRC check on rx frames and strip it
+  bool enable_mac_check;    // Do a MAC check on rx frames
   struct mg_tcpip_driver *driver;  // Low level driver
   void *driver_data;               // Driver-specific data
   struct mg_mgr *mgr;              // Mongoose event manager
@@ -1543,9 +1545,6 @@ struct mg_tcpip_if {
 void mg_tcpip_init(struct mg_mgr *, struct mg_tcpip_if *);
 void mg_tcpip_free(struct mg_tcpip_if *);
 void mg_tcpip_qwrite(void *buf, size_t len, struct mg_tcpip_if *ifp);
-size_t mg_tcpip_qread(void *buf, struct mg_tcpip_if *ifp);
-// conveniency rx function for IRQ-driven drivers
-size_t mg_tcpip_driver_rx(void *buf, size_t len, struct mg_tcpip_if *ifp);
 
 extern struct mg_tcpip_driver mg_tcpip_driver_stm32;
 extern struct mg_tcpip_driver mg_tcpip_driver_w5500;

--- a/src/tcpip/tcpip.h
+++ b/src/tcpip/tcpip.h
@@ -15,11 +15,13 @@ struct mg_tcpip_driver {
 
 // Network interface
 struct mg_tcpip_if {
-  uint8_t mac[6];                  // MAC address. Must be set to a valid MAC
-  uint32_t ip, mask, gw;           // IP address, mask, default gateway
-  struct mg_str tx;                // Output (TX) buffer
-  bool enable_dhcp_client;         // Enable DCHP client
-  bool enable_dhcp_server;         // Enable DCHP server
+  uint8_t mac[6];           // MAC address. Must be set to a valid MAC
+  uint32_t ip, mask, gw;    // IP address, mask, default gateway
+  struct mg_str tx;         // Output (TX) buffer
+  bool enable_dhcp_client;  // Enable DCHP client
+  bool enable_dhcp_server;  // Enable DCHP server
+  bool enable_crc32_check;  // Do a CRC check on rx frames and strip it
+  bool enable_mac_check;    // Do a MAC check on rx frames
   struct mg_tcpip_driver *driver;  // Low level driver
   void *driver_data;               // Driver-specific data
   struct mg_mgr *mgr;              // Mongoose event manager
@@ -44,9 +46,6 @@ struct mg_tcpip_if {
 void mg_tcpip_init(struct mg_mgr *, struct mg_tcpip_if *);
 void mg_tcpip_free(struct mg_tcpip_if *);
 void mg_tcpip_qwrite(void *buf, size_t len, struct mg_tcpip_if *ifp);
-size_t mg_tcpip_qread(void *buf, struct mg_tcpip_if *ifp);
-// conveniency rx function for IRQ-driven drivers
-size_t mg_tcpip_driver_rx(void *buf, size_t len, struct mg_tcpip_if *ifp);
 
 extern struct mg_tcpip_driver mg_tcpip_driver_stm32;
 extern struct mg_tcpip_driver mg_tcpip_driver_w5500;
@@ -64,8 +63,8 @@ struct mg_tcpip_spi {
 
 #if MG_ENABLE_TCPIP
 #if !defined(MG_ENABLE_DRIVER_STM32H) && !defined(MG_ENABLE_DRIVER_TM4C)
-  #define MG_ENABLE_DRIVER_STM32 1
+#define MG_ENABLE_DRIVER_STM32 1
 #else
-  #define MG_ENABLE_DRIVER_STM32 0
+#define MG_ENABLE_DRIVER_STM32 0
 #endif
 #endif

--- a/src/util.c
+++ b/src/util.c
@@ -48,11 +48,16 @@ uint16_t mg_ntohs(uint16_t net) {
 }
 
 uint32_t mg_crc32(uint32_t crc, const char *buf, size_t len) {
-  int i;
+  static const uint32_t crclut[16] = {
+      // table for polynomial 0xEDB88320 (reflected)
+      0x00000000, 0x1DB71064, 0x3B6E20C8, 0x26D930AC, 0x76DC4190, 0x6B6B51F4,
+      0x4DB26158, 0x5005713C, 0xEDB88320, 0xF00F9344, 0xD6D6A3E8, 0xCB61B38C,
+      0x9B64C2B0, 0x86D3D2D4, 0xA00AE278, 0xBDBDF21C};
   crc = ~crc;
   while (len--) {
-    crc ^= *(unsigned char *) buf++;
-    for (i = 0; i < 8; i++) crc = crc & 1 ? (crc >> 1) ^ 0xedb88320 : crc >> 1;
+    uint8_t byte = *(uint8_t *)buf++;
+    crc = crclut[(crc ^ byte) & 0x0F] ^ (crc >> 4);
+    crc = crclut[(crc ^ (byte >> 4)) & 0x0F] ^ (crc >> 4);
   }
   return ~crc;
 }
@@ -130,4 +135,3 @@ uint64_t mg_millis(void) {
 #endif
 }
 #endif
-


### PR DESCRIPTION
Add option to check MAC, defaults to off (not checking from now on as most controllers do that for us)
Add option to check CRC, defaults to off (most controllers do that for us)
Re-allow driver to set queue size
Improve `mg_crc32()`
Remove `mg_tcpip_driver_rx()`
Fix removed `mg_tcpip_qread()` still showing up in `tcpip.h`