### PR TITLE
Use SO_EXCLUSIVEADDRUSE on Windows, as intended

### DIFF
--- a/src/sock.c
+++ b/src/sock.c
@@ -192,28 +192,28 @@ bool mg_open_listener(struct mg_connection *c, const char *url) {
 
     if ((fd = socket(af, type, proto)) == MG_INVALID_SOCKET) {
       MG_ERROR(("socket: %d", MG_SOCK_ERR(-1)));
-#if ((MG_ARCH == MG_ARCH_WIN32) || (MG_ARCH == MG_ARCH_UNIX) || \
-     (defined(LWIP_SOCKET) && SO_REUSE == 1))
+#if MG_ARCH == MG_ARCH_WIN32
+      // SO_REUSEADDR is not enabled on Windows because the semantics of
+      // SO_REUSEADDR on UNIX and Windows is different. On Windows,
+      // SO_REUSEADDR allows to bind a socket to a port without error even
+      // if the port is already open by another program. This is not the
+      // behavior SO_REUSEADDR was designed for, and leads to hard-to-track
+      // failure scenarios. Therefore, SO_REUSEADDR is disabled on Windows.
+      // SO_EXCLUSIVEADDRUSE is used on Windows instead if supported.
+#if defined(SO_EXCLUSIVEADDRUSE) && !defined(WINCE)
+    } else if ((rc = setsockopt(fd, SOL_SOCKET, SO_EXCLUSIVEADDRUSE,
+                                (char *) &on, sizeof(on))) != 0) {
+      // Use SO_EXCLUSIVEADDRUSE instead of SO_REUSEADDR.
+      MG_ERROR(("exclusiveaddruse: %d", MG_SOCK_ERR(rc)));
+#endif
+#elif (MG_ARCH == MG_ARCH_UNIX) || (defined(LWIP_SOCKET) && SO_REUSE == 1)
     } else if ((rc = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char *) &on,
                                 sizeof(on))) != 0) {
-      // 1. SO_RESUSEADDR is not enabled on Windows because the semantics of
-      //    SO_REUSEADDR on UNIX and Windows is different. On Windows,
-      //    SO_REUSEADDR allows to bind a socket to a port without error even
-      //    if the port is already open by another program. This is not the
-      //    behavior SO_REUSEADDR was designed for, and leads to hard-to-track
-      //    failure scenarios. Therefore, SO_REUSEADDR was disabled on Windows
-      //    unless SO_EXCLUSIVEADDRUSE is supported and set on a socket.
-      // 2. In case of LWIP, SO_REUSEADDR should be explicitly enabled, by
+      // In case of LWIP, SO_REUSEADDR should be explicitly enabled, by
       // defining
       //    SO_REUSE (in lwipopts.h), otherwise the code below will compile
       //    but won't work! (setsockopt will return EINVAL)
       MG_ERROR(("reuseaddr: %d", MG_SOCK_ERR(rc)));
-#endif
-#if MG_ARCH == MG_ARCH_WIN32 && !defined(SO_EXCLUSIVEADDRUSE) && !defined(WINCE)
-    } else if ((rc = setsockopt(fd, SOL_SOCKET, SO_EXCLUSIVEADDRUSE,
-                                (char *) &on, sizeof(on))) != 0) {
-      // "Using SO_REUSEADDR and SO_EXCLUSIVEADDRUSE"
-      MG_ERROR(("exclusiveaddruse: %d", MG_SOCK_ERR(rc)));
 #endif
     } else if ((rc = bind(fd, &usa.sa, slen)) != 0) {
       MG_ERROR(("bind: %d", MG_SOCK_ERR(rc)));

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -2692,6 +2692,18 @@ static void test_poll(void) {
   mg_mgr_free(&mgr);
 }
 
+static void no_op_callback(struct mg_connection *c, int ev, void *ev_data,
+                           void *fn_data) {
+}
+
+static void test_two_servers_on_same_port_fails(void) {
+  struct mg_mgr mgr;
+  mg_mgr_init(&mgr);
+  ASSERT(mg_http_listen(&mgr, "http://127.0.0.1:12346", no_op_callback, NULL) != NULL);
+  ASSERT(mg_http_listen(&mgr, "http://127.0.0.1:12346", no_op_callback, NULL) == NULL);
+  mg_mgr_free(&mgr);
+}
+
 #define NMESSAGES 99999
 static uint32_t s_qcrc = 0;
 static int s_out, s_in;
@@ -2809,6 +2821,7 @@ int main(void) {
   test_sntp();
   test_mqtt();
   test_poll();
+  test_two_servers_on_same_port_fails();
   printf("SUCCESS. Total tests: %d\n", s_num_tests);
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
Commit 31ce2195 introduced a bug causing both SO_REUSEADDR and SO_EXCLUSIVEADDRUSE to be used on Windows. This is invalid.

Commit d5993ba2 tried to fix this bug. However, the fix was incorrect. The correct fix was to use SO_EXCLUSIVEADDRUSE and not use SO_REUSEADDR. Instead, commit d5993ba2 disabled SO_EXCLUSIVEADDRUSE and kept SO_REUSEADDR.

In this patch, fix the mistakes of both commits 31ce2195 and d5993ba2:

* On Windows, use SO_EXCLUSIVEADDRUSE if available.
* On Windows, never use SO_REUSEADDR.

Refs: 31ce219544c81b387a506dbb2118c6865edc71e6
Refs: d5993ba27ece4b406c230eca63b76dd5d2c28a2d