### PR TITLE
Treat ms=-1 as indefinite timeout in mg_mgr_poll

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -4668,12 +4668,18 @@ static void mg_iotest(struct mg_mgr *mgr, int ms) {
     }
   }
 #else
-  struct timeval tv = {ms / 1000, (ms % 1000) * 1000}, tv_zero = {0, 0};
+  struct timeval tv_buffer, tv_zero = {0, 0};
+  struct timeval *tv = NULL;
   struct mg_connection *c;
   fd_set rset, wset, eset;
   MG_SOCKET_TYPE maxfd = 0;
   int rc;
 
+  if (ms >= 0) {
+    tv_buffer.tv_sec = ms / 1000;
+    tv_buffer.tv_usec = (ms % 1000) * 1000;
+    tv = &tv_buffer;
+  }
   FD_ZERO(&rset);
   FD_ZERO(&wset);
   FD_ZERO(&eset);
@@ -4683,11 +4689,11 @@ static void mg_iotest(struct mg_mgr *mgr, int ms) {
     FD_SET(FD(c), &eset);
     if (can_read(c)) FD_SET(FD(c), &rset);
     if (can_write(c)) FD_SET(FD(c), &wset);
-    if (mg_tls_pending(c) > 0) tv = tv_zero;
+    if (mg_tls_pending(c) > 0) tv = &tv_zero;
     if (FD(c) > maxfd) maxfd = FD(c);
   }
 
-  if ((rc = select((int) maxfd + 1, &rset, &wset, &eset, &tv)) < 0) {
+  if ((rc = select((int) maxfd + 1, &rset, &wset, &eset, tv)) < 0) {
 #if MG_ARCH == MG_ARCH_WIN32
     if (maxfd == 0) Sleep(ms);  // On Windows, select fails if no sockets
 #else

--- a/src/sock.c
+++ b/src/sock.c
@@ -569,12 +569,18 @@ static void mg_iotest(struct mg_mgr *mgr, int ms) {
     }
   }
 #else
-  struct timeval tv = {ms / 1000, (ms % 1000) * 1000}, tv_zero = {0, 0};
+  struct timeval tv_buffer, tv_zero = {0, 0};
+  struct timeval *tv = NULL;
   struct mg_connection *c;
   fd_set rset, wset, eset;
   MG_SOCKET_TYPE maxfd = 0;
   int rc;
 
+  if (ms >= 0) {
+    tv_buffer.tv_sec = ms / 1000;
+    tv_buffer.tv_usec = (ms % 1000) * 1000;
+    tv = &tv_buffer;
+  }
   FD_ZERO(&rset);
   FD_ZERO(&wset);
   FD_ZERO(&eset);
@@ -584,11 +590,11 @@ static void mg_iotest(struct mg_mgr *mgr, int ms) {
     FD_SET(FD(c), &eset);
     if (can_read(c)) FD_SET(FD(c), &rset);
     if (can_write(c)) FD_SET(FD(c), &wset);
-    if (mg_tls_pending(c) > 0) tv = tv_zero;
+    if (mg_tls_pending(c) > 0) tv = &tv_zero;
     if (FD(c) > maxfd) maxfd = FD(c);
   }
 
-  if ((rc = select((int) maxfd + 1, &rset, &wset, &eset, &tv)) < 0) {
+  if ((rc = select((int) maxfd + 1, &rset, &wset, &eset, tv)) < 0) {
 #if MG_ARCH == MG_ARCH_WIN32
     if (maxfd == 0) Sleep(ms);  // On Windows, select fails if no sockets
 #else


### PR DESCRIPTION
If mg_mgr_poll is called with the 'ms' parameter set to '-1', the behavior differs between operating systems:

* FreeRTOS: (I don't know)
* epoll (Linux): wait indefinitely
* poll (macOS, BSDs): wait indefinitely
* select (Windows, other OSs): wait for -1000 microseconds (???)

Change the behavior of mg_mgr_poll(mgr, -1) on Windows (and some other operating systems) to instead block indefinitely, matching the behavior of POSIX platforms.