### PR TITLE
Remove no longer necessary includes

### DIFF
--- a/examples/stm32/nucleo-f429zi-freertos/mongoose_custom.h
+++ b/examples/stm32/nucleo-f429zi-freertos/mongoose_custom.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <errno.h>	// we are not using lwIP
-
 // See https://mongoose.ws/documentation/#build-options
 #define MG_ARCH MG_ARCH_FREERTOS
 #define MG_ENABLE_TCPIP 1

--- a/examples/stm32/nucleo-f746zg-freertos/mongoose_custom.h
+++ b/examples/stm32/nucleo-f746zg-freertos/mongoose_custom.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <errno.h>	// we are not using lwIP
-
 // See https://mongoose.ws/documentation/#build-options
 #define MG_ARCH MG_ARCH_FREERTOS
 #define MG_ENABLE_TCPIP 1

--- a/examples/ti/ek-tm4c1294xl-freertos/mongoose_custom.h
+++ b/examples/ti/ek-tm4c1294xl-freertos/mongoose_custom.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <errno.h>	// we are not using lwIP
-
 // See https://mongoose.ws/documentation/#build-options
 #define MG_ARCH MG_ARCH_FREERTOS
 #define MG_ENABLE_TCPIP 1


### PR DESCRIPTION
#2128 adds inclusion of errno.h when lwIP is not added to MG_ARCH_FREERTOS
