### PR TITLE
Add arch for CMSIS-RTOS v1 and v2

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -4250,7 +4250,7 @@ static void mg_set_non_blocking_mode(MG_SOCKET_TYPE fd) {
 #elif MG_ARCH == MG_ARCH_WIN32 && MG_ENABLE_WINSOCK
   unsigned long on = 1;
   ioctlsocket(fd, FIONBIO, &on);
-#elif MG_ARCH == MG_ARCH_RTX
+#elif MG_ENABLE_RL
   unsigned long on = 1;
   ioctlsocket(fd, FIONBIO, &on);
 #elif MG_ENABLE_FREERTOS_TCP
@@ -5734,6 +5734,10 @@ uint64_t mg_millis(void) {
   return (uint64_t) Clock_getTicks();
 #elif MG_ARCH == MG_ARCH_ZEPHYR
   return (uint64_t) k_uptime_get();
+#elif MG_ARCH == MG_ARCH_CMSIS_RTOS1
+  return (uint64_t)rt_time_get();
+#elif MG_ARCH == MG_ARCH_CMSIS_RTOS2
+  return (uint64_t)((osKernelGetTickCount() * 1000) / osKernelGetTickFreq());
 #elif MG_ARCH == MG_ARCH_UNIX && defined(__APPLE__)
   // Apple CLOCK_MONOTONIC_RAW is equivalent to CLOCK_BOOTTIME on linux
   // Apple CLOCK_UPTIME_RAW is equivalent to CLOCK_MONOTONIC_RAW on linux

--- a/mongoose.h
+++ b/mongoose.h
@@ -27,19 +27,20 @@ extern "C" {
 #endif
 
 
-#define MG_ARCH_CUSTOM 0     // User creates its own mongoose_custom.h
-#define MG_ARCH_UNIX 1       // Linux, BSD, Mac, ...
-#define MG_ARCH_WIN32 2      // Windows
-#define MG_ARCH_ESP32 3      // ESP32
-#define MG_ARCH_ESP8266 4    // ESP8266
-#define MG_ARCH_FREERTOS 5   // FreeRTOS
-#define MG_ARCH_AZURERTOS 6  // MS Azure RTOS
-#define MG_ARCH_ZEPHYR 7     // Zephyr RTOS
-#define MG_ARCH_NEWLIB 8     // Bare metal ARM
-#define MG_ARCH_RTX 9        // Keil RTX
-#define MG_ARCH_TIRTOS 10    // Texas Semi TI-RTOS
-#define MG_ARCH_RP2040 11    // Raspberry Pi RP2040
-#define MG_ARCH_ARMCC 12     // Keil MDK with Configuration Wizard
+#define MG_ARCH_CUSTOM 0       // User creates its own mongoose_custom.h
+#define MG_ARCH_UNIX 1         // Linux, BSD, Mac, ...
+#define MG_ARCH_WIN32 2        // Windows
+#define MG_ARCH_ESP32 3        // ESP32
+#define MG_ARCH_ESP8266 4      // ESP8266
+#define MG_ARCH_FREERTOS 5     // FreeRTOS
+#define MG_ARCH_AZURERTOS 6    // MS Azure RTOS
+#define MG_ARCH_ZEPHYR 7       // Zephyr RTOS
+#define MG_ARCH_NEWLIB 8       // Bare metal ARM
+#define MG_ARCH_CMSIS_RTOS1 9  // CMSIS-RTOS API v1 (Keil RTX)
+#define MG_ARCH_TIRTOS 10      // Texas Semi TI-RTOS
+#define MG_ARCH_RP2040 11      // Raspberry Pi RP2040
+#define MG_ARCH_ARMCC 12       // Keil MDK-Core with Configuration Wizard
+#define MG_ARCH_CMSIS_RTOS2 13 // CMSIS-RTOS API v2 (Keil RTX5, FreeRTOS)
 
 #if !defined(MG_ARCH)
 #if defined(__unix__) || defined(__APPLE__)
@@ -254,7 +255,8 @@ int mkdir(const char *, mode_t);
 #endif
 
 
-#if MG_ARCH == MG_ARCH_ARMCC || MG_ARCH == MG_ARCH_RTX
+#if MG_ARCH == MG_ARCH_ARMCC || MG_ARCH == MG_ARCH_CMSIS_RTOS1 || \
+    MG_ARCH == MG_ARCH_CMSIS_RTOS2
 
 #include <ctype.h>
 #include <errno.h>
@@ -266,6 +268,13 @@ int mkdir(const char *, mode_t);
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#if MG_ARCH == MG_ARCH_CMSIS_RTOS1
+#include "cmsis_os.h"  // keep this include
+// https://developer.arm.com/documentation/ka003821/latest
+extern uint32_t rt_time_get(void);
+#elif MG_ARCH == MG_ARCH_CMSIS_RTOS2
+#include "cmsis_os2.h"  // keep this include
+#endif
 
 #define strdup(s) ((char *) mg_strdup(mg_str(s)).ptr)
 
@@ -278,8 +287,8 @@ static inline int mg_mkdir(const char *path, mode_t mode) {
 }
 #endif
 
-#if MG_ARCH == MG_ARCH_RTX && !defined MG_ENABLE_RL && \
-    (!defined(MG_ENABLE_LWIP) || !MG_ENABLE_LWIP) &&   \
+#if (MG_ARCH == MG_ARCH_CMSIS_RTOS1 || MG_ARCH == MG_ARCH_CMSIS_RTOS2) &&     \
+    !defined MG_ENABLE_RL && (!defined(MG_ENABLE_LWIP) || !MG_ENABLE_LWIP) && \
     (!defined(MG_ENABLE_TCPIP) || !MG_ENABLE_TCPIP)
 #define MG_ENABLE_RL 1
 #endif

--- a/src/arch.h
+++ b/src/arch.h
@@ -1,18 +1,19 @@
 #pragma once
 
-#define MG_ARCH_CUSTOM 0     // User creates its own mongoose_custom.h
-#define MG_ARCH_UNIX 1       // Linux, BSD, Mac, ...
-#define MG_ARCH_WIN32 2      // Windows
-#define MG_ARCH_ESP32 3      // ESP32
-#define MG_ARCH_ESP8266 4    // ESP8266
-#define MG_ARCH_FREERTOS 5   // FreeRTOS
-#define MG_ARCH_AZURERTOS 6  // MS Azure RTOS
-#define MG_ARCH_ZEPHYR 7     // Zephyr RTOS
-#define MG_ARCH_NEWLIB 8     // Bare metal ARM
-#define MG_ARCH_RTX 9        // Keil RTX
-#define MG_ARCH_TIRTOS 10    // Texas Semi TI-RTOS
-#define MG_ARCH_RP2040 11    // Raspberry Pi RP2040
-#define MG_ARCH_ARMCC 12     // Keil MDK with Configuration Wizard
+#define MG_ARCH_CUSTOM 0       // User creates its own mongoose_custom.h
+#define MG_ARCH_UNIX 1         // Linux, BSD, Mac, ...
+#define MG_ARCH_WIN32 2        // Windows
+#define MG_ARCH_ESP32 3        // ESP32
+#define MG_ARCH_ESP8266 4      // ESP8266
+#define MG_ARCH_FREERTOS 5     // FreeRTOS
+#define MG_ARCH_AZURERTOS 6    // MS Azure RTOS
+#define MG_ARCH_ZEPHYR 7       // Zephyr RTOS
+#define MG_ARCH_NEWLIB 8       // Bare metal ARM
+#define MG_ARCH_CMSIS_RTOS1 9  // CMSIS-RTOS API v1 (Keil RTX)
+#define MG_ARCH_TIRTOS 10      // Texas Semi TI-RTOS
+#define MG_ARCH_RP2040 11      // Raspberry Pi RP2040
+#define MG_ARCH_ARMCC 12       // Keil MDK-Core with Configuration Wizard
+#define MG_ARCH_CMSIS_RTOS2 13 // CMSIS-RTOS API v2 (Keil RTX5, FreeRTOS)
 
 #if !defined(MG_ARCH)
 #if defined(__unix__) || defined(__APPLE__)

--- a/src/arch_rtx.h
+++ b/src/arch_rtx.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#if MG_ARCH == MG_ARCH_ARMCC || MG_ARCH == MG_ARCH_RTX
+#if MG_ARCH == MG_ARCH_ARMCC || MG_ARCH == MG_ARCH_CMSIS_RTOS1 || \
+    MG_ARCH == MG_ARCH_CMSIS_RTOS2
 
 #include <ctype.h>
 #include <errno.h>
@@ -12,6 +13,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#if MG_ARCH == MG_ARCH_CMSIS_RTOS1
+#include "cmsis_os.h"  // keep this include
+// https://developer.arm.com/documentation/ka003821/latest
+extern uint32_t rt_time_get(void);
+#elif MG_ARCH == MG_ARCH_CMSIS_RTOS2
+#include "cmsis_os2.h"  // keep this include
+#endif
 
 #define strdup(s) ((char *) mg_strdup(mg_str(s)).ptr)
 
@@ -24,8 +32,8 @@ static inline int mg_mkdir(const char *path, mode_t mode) {
 }
 #endif
 
-#if MG_ARCH == MG_ARCH_RTX && !defined MG_ENABLE_RL && \
-    (!defined(MG_ENABLE_LWIP) || !MG_ENABLE_LWIP) &&   \
+#if (MG_ARCH == MG_ARCH_CMSIS_RTOS1 || MG_ARCH == MG_ARCH_CMSIS_RTOS2) &&     \
+    !defined MG_ENABLE_RL && (!defined(MG_ENABLE_LWIP) || !MG_ENABLE_LWIP) && \
     (!defined(MG_ENABLE_TCPIP) || !MG_ENABLE_TCPIP)
 #define MG_ENABLE_RL 1
 #endif

--- a/src/sock.c
+++ b/src/sock.c
@@ -151,7 +151,7 @@ static void mg_set_non_blocking_mode(MG_SOCKET_TYPE fd) {
 #elif MG_ARCH == MG_ARCH_WIN32 && MG_ENABLE_WINSOCK
   unsigned long on = 1;
   ioctlsocket(fd, FIONBIO, &on);
-#elif MG_ARCH == MG_ARCH_RTX
+#elif MG_ENABLE_RL
   unsigned long on = 1;
   ioctlsocket(fd, FIONBIO, &on);
 #elif MG_ENABLE_FREERTOS_TCP

--- a/src/util.c
+++ b/src/util.c
@@ -109,6 +109,10 @@ uint64_t mg_millis(void) {
   return (uint64_t) Clock_getTicks();
 #elif MG_ARCH == MG_ARCH_ZEPHYR
   return (uint64_t) k_uptime_get();
+#elif MG_ARCH == MG_ARCH_CMSIS_RTOS1
+  return (uint64_t)rt_time_get();
+#elif MG_ARCH == MG_ARCH_CMSIS_RTOS2
+  return (uint64_t)((osKernelGetTickCount() * 1000) / osKernelGetTickFreq());
 #elif MG_ARCH == MG_ARCH_UNIX && defined(__APPLE__)
   // Apple CLOCK_MONOTONIC_RAW is equivalent to CLOCK_BOOTTIME on linux
   // Apple CLOCK_UPTIME_RAW is equivalent to CLOCK_MONOTONIC_RAW on linux


### PR DESCRIPTION
Remove MG_ARCH_RTX
Add MG_ARCH_CMSIS_RTOS1, serving Keil RTX and adding a timebase function
Add MG_ARCH_CMSIS_RTOS2, serving Keil RTX5 and FreeRTOS (through API v2) and adding a timebase function
Fix a socket call that actually belongs to MDK (RL), not RTX