### PR TITLE
Fix FreeRTOS-Plus-TCP

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -4598,8 +4598,9 @@ static void mg_iotest(struct mg_mgr *mgr, int ms) {
     EventBits_t bits = FreeRTOS_FD_ISSET(c->fd, mgr->ss);
     c->is_readable = bits & (eSELECT_READ | eSELECT_EXCEPT) ? 1U : 0;
     c->is_writable = bits & eSELECT_WRITE ? 1U : 0;
-    FreeRTOS_FD_CLR(c->fd, mgr->ss,
-                    eSELECT_READ | eSELECT_EXCEPT | eSELECT_WRITE);
+    if (c->fd != MG_INVALID_SOCKET)
+      FreeRTOS_FD_CLR(c->fd, mgr->ss,
+                      eSELECT_READ | eSELECT_EXCEPT | eSELECT_WRITE);
   }
 #elif MG_ENABLE_EPOLL
   size_t max = 1;

--- a/mongoose.h
+++ b/mongoose.h
@@ -537,17 +537,20 @@ int sscanf(const char *, const char *, ...);
 #define SO_ERROR 0
 #define SOL_SOCKET 0
 #define SO_REUSEADDR 0
-#undef EINTR
-#undef EWOULDBLOCK
-#undef EINPROGRESS
-#undef EPIPE
-#undef ECONNRESET
-#define EINTR pdFREERTOS_ERRNO_EINTR
-#define EWOULDBLOCK pdFREERTOS_ERRNO_EWOULDBLOCK
-#define EINPROGRESS pdFREERTOS_ERRNO_EINPROGRESS
-#define EPIPE 0
-#define ECONNRESET 0
-#define EINTR pdFREERTOS_ERRNO_EINTR
+
+#define MG_SOCK_ERR(errcode) ((errcode) < 0 ? (errcode) : 0)
+
+#define MG_SOCK_PENDING(errcode)                 \
+  ((errcode) == -pdFREERTOS_ERRNO_EWOULDBLOCK || \
+   (errcode) == -pdFREERTOS_ERRNO_EISCONN ||     \
+   (errcode) == -pdFREERTOS_ERRNO_EINPROGRESS || \
+   (errcode) == -pdFREERTOS_ERRNO_EAGAIN)
+
+#define MG_SOCK_RESET(errcode) ((errcode) == -pdFREERTOS_ERRNO_ENOTCONN)
+
+// actually only if optional timeout is enabled
+#define MG_SOCK_INTR(fd) (fd == NULL)
+
 #define sockaddr_in freertos_sockaddr
 #define sockaddr freertos_sockaddr
 #define accept(a, b, c) FreeRTOS_accept((a), (b), (c))

--- a/src/net_ft.h
+++ b/src/net_ft.h
@@ -23,17 +23,20 @@
 #define SO_ERROR 0
 #define SOL_SOCKET 0
 #define SO_REUSEADDR 0
-#undef EINTR
-#undef EWOULDBLOCK
-#undef EINPROGRESS
-#undef EPIPE
-#undef ECONNRESET
-#define EINTR pdFREERTOS_ERRNO_EINTR
-#define EWOULDBLOCK pdFREERTOS_ERRNO_EWOULDBLOCK
-#define EINPROGRESS pdFREERTOS_ERRNO_EINPROGRESS
-#define EPIPE 0
-#define ECONNRESET 0
-#define EINTR pdFREERTOS_ERRNO_EINTR
+
+#define MG_SOCK_ERR(errcode) ((errcode) < 0 ? (errcode) : 0)
+
+#define MG_SOCK_PENDING(errcode)                 \
+  ((errcode) == -pdFREERTOS_ERRNO_EWOULDBLOCK || \
+   (errcode) == -pdFREERTOS_ERRNO_EISCONN ||     \
+   (errcode) == -pdFREERTOS_ERRNO_EINPROGRESS || \
+   (errcode) == -pdFREERTOS_ERRNO_EAGAIN)
+
+#define MG_SOCK_RESET(errcode) ((errcode) == -pdFREERTOS_ERRNO_ENOTCONN)
+
+// actually only if optional timeout is enabled
+#define MG_SOCK_INTR(fd) (fd == NULL)
+
 #define sockaddr_in freertos_sockaddr
 #define sockaddr freertos_sockaddr
 #define accept(a, b, c) FreeRTOS_accept((a), (b), (c))

--- a/src/sock.c
+++ b/src/sock.c
@@ -499,8 +499,9 @@ static void mg_iotest(struct mg_mgr *mgr, int ms) {
     EventBits_t bits = FreeRTOS_FD_ISSET(c->fd, mgr->ss);
     c->is_readable = bits & (eSELECT_READ | eSELECT_EXCEPT) ? 1U : 0;
     c->is_writable = bits & eSELECT_WRITE ? 1U : 0;
-    FreeRTOS_FD_CLR(c->fd, mgr->ss,
-                    eSELECT_READ | eSELECT_EXCEPT | eSELECT_WRITE);
+    if (c->fd != MG_INVALID_SOCKET)
+      FreeRTOS_FD_CLR(c->fd, mgr->ss,
+                      eSELECT_READ | eSELECT_EXCEPT | eSELECT_WRITE);
   }
 #elif MG_ENABLE_EPOLL
   size_t max = 1;


### PR DESCRIPTION
- FreeRTOS+ TCP does *NOT* use errno but returns -error
- Use only versions >= 3.x, as prior versions do not implement FREERTOS_SOCK_DEPENDENT_PROTO, which is equivalent to passing 0 as defined by POSIX (in `socket()`)
