### PR TITLE
Fix for some compilers

### DIFF
--- a/examples/multi-threaded/Makefile
+++ b/examples/multi-threaded/Makefile
@@ -6,13 +6,15 @@ CFLAGS_MONGOOSE +=
 
 ifeq ($(OS),Windows_NT)
   # Windows settings. Assume MinGW compiler. To use VC: make CC=cl CFLAGS=/MD
-  PROG ?= example.exe           # Use .exe suffix for the binary
-  CC = gcc                      # Use MinGW gcc compiler
-  CFLAGS += -lws2_32            # Link against Winsock library
-  DELETE = cmd /C del /f /q /s  # Command prompt command to delete files
+  PROG ?= example.exe                 # Use .exe suffix for the binary
+  CC = gcc                            # Use MinGW gcc compiler
+  CFLAGS += -lws2_32                  # Link against Winsock library
+  CFLAGS += -Wno-cast-function-type   # Thread functions return void instead of void *
+  DELETE = cmd /C del /f /q /s        # Command prompt command to delete files
 else
   # Mac, Linux
   PROG ?= example
+  CFLAGS += -lpthread                 # Link against POSIX threads library
   DELETE = rm -rf
 endif
 


### PR DESCRIPTION
Many Linux distro gcc compilers require `-lpthread`
closes #2148 
On Windows, MinGW warns:
```
main.c: In function 'start_thread':
main.c:21:16: warning: cast between incompatible function types from 'void * (*)(void *)' to
void (*)(void *)' [-Wcast-function-type]
   21 |   _beginthread((void(__cdecl *)(void *)) f, 0, p);
      |                ^
```
though the cast is OK and works OK, so I disabled it