### PR TITLE
fix for multi-threaded build error on Linux "undefined reference to `…

### DIFF
--- a/examples/multi-threaded/Makefile
+++ b/examples/multi-threaded/Makefile
@@ -12,6 +12,7 @@ ifeq ($(OS),Windows_NT)
   DELETE = cmd /C del /f /q /s  # Command prompt command to delete files
 else
   # Mac, Linux
+  CFLAGS += -pthread
   PROG ?= example
   DELETE = rm -rf
 endif


### PR DESCRIPTION
…pthread_create'

collect2: error: ld returned 1 exit status"