### PR TITLE
Fix UDP listeners in MIP

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -7848,9 +7848,11 @@ static void rx_udp(struct mg_tcpip_if *ifp, struct pkt *pkt) {
   struct mg_connection *c = getpeer(ifp->mgr, pkt, true);
   if (c == NULL) {
     // No UDP listener on this port. Should send ICMP, but keep silent.
-  } else if (c != NULL) {
+  } else {
     c->rem.port = pkt->udp->sport;
     c->rem.ip = pkt->ip->src;
+    struct connstate *s = (struct connstate *) (c + 1);
+    memcpy(s->mac, pkt->eth->src, sizeof(s->mac));
     if (c->recv.len >= MG_MAX_RECV_SIZE) {
       mg_error(c, "max_recv_buf_size reached");
     } else if (c->recv.size - c->recv.len < pkt->pay.len &&

--- a/src/tcpip/tcpip.c
+++ b/src/tcpip/tcpip.c
@@ -404,9 +404,11 @@ static void rx_udp(struct mg_tcpip_if *ifp, struct pkt *pkt) {
   struct mg_connection *c = getpeer(ifp->mgr, pkt, true);
   if (c == NULL) {
     // No UDP listener on this port. Should send ICMP, but keep silent.
-  } else if (c != NULL) {
+  } else {
     c->rem.port = pkt->udp->sport;
     c->rem.ip = pkt->ip->src;
+    struct connstate *s = (struct connstate *) (c + 1);
+    memcpy(s->mac, pkt->eth->src, sizeof(s->mac));
     if (c->recv.len >= MG_MAX_RECV_SIZE) {
       mg_error(c, "max_recv_buf_size reached");
     } else if (c->recv.size - c->recv.len < pkt->pay.len &&


### PR DESCRIPTION
An UDP listener wanting to send a response didn't have the other end MAC address, so responses were being sent to an all-zeroes MAC.
We take it as it is on each received datagram (as we do with IP and port). Perhaps there is a faster way of copying it, but checking for an empty slot is certainly slower...

Fixes #2164 