### PR TITLE
Check return values of calloc() in mongoose.c

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -914,6 +914,7 @@ static void *packed_open(const char *path, int flags) {
   if (data == NULL) return NULL;
   if (flags & MG_FS_WRITE) return NULL;
   fp = (struct packed_file *) calloc(1, sizeof(*fp));
+  if (fp == NULL) return NULL;
   fp->size = size;
   fp->data = data;
   return (void *) fp;


### PR DESCRIPTION
This PR patches mongoose.c, which does not belong to a demo app.
(This PR is a part of #2162, which has been closed.) 