### PR TITLE
Fix http-reverse-proxy for keep-alive incoming connections

### DIFF
--- a/examples/http-reverse-proxy/main.c
+++ b/examples/http-reverse-proxy/main.c
@@ -64,6 +64,7 @@ static void fn(struct mg_connection *c, int ev, void *ev_data, void *fn_data) {
       }
       c->fn_data = c2;
       forward_request(hm, c2);
+      c->is_resp = 0; // process further msgs in keep-alive connection
       c2->is_hexdumping = 1;
     }
   } else if (ev == MG_EV_CLOSE) {


### PR DESCRIPTION
Fix #2190 
Since no reply is sent, `c->is_resp` remains set and further requests on the same connection in keep-alive mode are ignored.
Clearing this flag once a response has started to be written allows further processing and fixes this.