### PR TITLE
standardize header inclusion

### DIFF
--- a/examples/stm32/nucleo-f746zg-freertos-tcp/main.c
+++ b/examples/stm32/nucleo-f746zg-freertos-tcp/main.c
@@ -2,6 +2,7 @@
 // All rights reserved
 
 #include "hal.h"
+#include "mongoose.h"
 #include "net.h"
 
 #define LED1 PIN('B', 0)   // On-board LED pin (green)

--- a/examples/stm32/nucleo-f746zg-keil-baremetal/main.c
+++ b/examples/stm32/nucleo-f746zg-keil-baremetal/main.c
@@ -2,8 +2,9 @@
 // All rights reserved
 
 #include "hal.h"
-#include "net.h"
+#include "mongoose.h"
 #include "main.h"
+#include "net.h"
 
 #define BLINK_PERIOD_MS 1000  // LED blinking period in millis
 

--- a/examples/stm32/nucleo-f746zg-keil-freertos-lwip/main.c
+++ b/examples/stm32/nucleo-f746zg-keil-freertos-lwip/main.c
@@ -2,8 +2,9 @@
 // All rights reserved
 
 #include "hal.h"
-#include "net.h"
+#include "mongoose.h"
 #include "main.h"
+#include "net.h"
 #include "ethernetif.h"
 #include "lwip/dhcp.h"
 #include "lwip/netif.h"

--- a/examples/stm32/nucleo-f746zg-keil-freertos-tcp/main.c
+++ b/examples/stm32/nucleo-f746zg-keil-freertos-tcp/main.c
@@ -2,8 +2,9 @@
 // All rights reserved
 
 #include "hal.h"
-#include "net.h"
+#include "mongoose.h"
 #include "main.h"
+#include "net.h"
 
 extern RNG_HandleTypeDef hrng;
 

--- a/examples/stm32/nucleo-f746zg-keil-freertos/main.c
+++ b/examples/stm32/nucleo-f746zg-keil-freertos/main.c
@@ -2,8 +2,9 @@
 // All rights reserved
 
 #include "hal.h"
-#include "net.h"
+#include "mongoose.h"
 #include "main.h"
+#include "net.h"
 
 #define BLINK_PERIOD_MS 1000  // LED blinking period in millis
 

--- a/examples/stm32/nucleo-f746zg-keil-freertos_cmsis2-lwip/main.c
+++ b/examples/stm32/nucleo-f746zg-keil-freertos_cmsis2-lwip/main.c
@@ -2,8 +2,9 @@
 // All rights reserved
 
 #include "hal.h"
-#include "net.h"
+#include "mongoose.h"
 #include "main.h"
+#include "net.h"
 #include "cmsis_os2.h" 
 #include "ethernetif.h"
 #include "lwip/dhcp.h"

--- a/examples/stm32/nucleo-f746zg-keil-freertos_cmsis2/main.c
+++ b/examples/stm32/nucleo-f746zg-keil-freertos_cmsis2/main.c
@@ -4,6 +4,7 @@
 #include "hal.h"
 #include "mongoose.h"
 #include "main.h"
+#include "net.h"
 #include "cmsis_os2.h" 
 
 #define BLINK_PERIOD_MS 1000  // LED blinking period in millis

--- a/examples/stm32/nucleo-f746zg-keil-rtx-mdk/main.c
+++ b/examples/stm32/nucleo-f746zg-keil-rtx-mdk/main.c
@@ -2,8 +2,9 @@
 // All rights reserved
 
 #include "hal.h"
-#include "net.h"
+#include "mongoose.h"
 #include "main.h"
+#include "net.h"
 #include "cmsis_os.h" 
 
 #define BLINK_PERIOD_MS 1000  // LED blinking period in millis

--- a/examples/stm32/nucleo-f746zg-keil-rtx/main.c
+++ b/examples/stm32/nucleo-f746zg-keil-rtx/main.c
@@ -2,8 +2,9 @@
 // All rights reserved
 
 #include "hal.h"
-#include "net.h"
+#include "mongoose.h"
 #include "main.h"
+#include "net.h"
 #include "cmsis_os.h" 
 
 #define BLINK_PERIOD_MS 1000  // LED blinking period in millis

--- a/examples/stm32/nucleo-f746zg-keil-rtx5-lwip/main.c
+++ b/examples/stm32/nucleo-f746zg-keil-rtx5-lwip/main.c
@@ -2,8 +2,9 @@
 // All rights reserved
 
 #include "hal.h"
-#include "net.h"
+#include "mongoose.h"
 #include "main.h"
+#include "net.h"
 #include "cmsis_os2.h" 
 #include "ethernetif.h"
 #include "lwip/dhcp.h"

--- a/examples/stm32/nucleo-f746zg-keil-rtx5-mdk/main.c
+++ b/examples/stm32/nucleo-f746zg-keil-rtx5-mdk/main.c
@@ -2,8 +2,9 @@
 // All rights reserved
 
 #include "hal.h"
-#include "net.h"
+#include "mongoose.h"
 #include "main.h"
+#include "net.h"
 #include "cmsis_os2.h" 
 
 #define BLINK_PERIOD_MS 1000  // LED blinking period in millis

--- a/examples/stm32/nucleo-f746zg-keil-rtx5/main.c
+++ b/examples/stm32/nucleo-f746zg-keil-rtx5/main.c
@@ -2,8 +2,9 @@
 // All rights reserved
 
 #include "hal.h"
-#include "net.h"
+#include "mongoose.h"
 #include "main.h"
+#include "net.h"
 #include "cmsis_os2.h" 
 
 #define BLINK_PERIOD_MS 1000  // LED blinking period in millis


### PR DESCRIPTION
and fix examples/stm32/nucleo-f746zg-keil-freertos_cmsis2
