### PR TITLE
fix qos=2 handling

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3376,7 +3376,9 @@ static void mqtt_cb(struct mg_connection *c, int ev, void *ev_data,
               uint32_t remaining_len = sizeof(id);
               if (c->is_mqtt5) remaining_len += 1;
 
-              mg_mqtt_send_header(c, MQTT_CMD_PUBACK, 0, remaining_len);
+              mg_mqtt_send_header(
+                  c, mm.qos == 2 ? MQTT_CMD_PUBREC : MQTT_CMD_PUBACK, 0,
+                  remaining_len);
               mg_send(c, &id, sizeof(id));
 
               if (c->is_mqtt5) {
@@ -3384,7 +3386,7 @@ static void mqtt_cb(struct mg_connection *c, int ev, void *ev_data,
                 mg_send(c, &zero, sizeof(zero));
               }
             }
-            mg_call(c, MG_EV_MQTT_MSG, &mm);
+            mg_call(c, MG_EV_MQTT_MSG, &mm);  // let the app handle qos2 stuff
             break;
           }
         }

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -449,7 +449,9 @@ static void mqtt_cb(struct mg_connection *c, int ev, void *ev_data,
               uint32_t remaining_len = sizeof(id);
               if (c->is_mqtt5) remaining_len += 1;
 
-              mg_mqtt_send_header(c, MQTT_CMD_PUBACK, 0, remaining_len);
+              mg_mqtt_send_header(
+                  c, mm.qos == 2 ? MQTT_CMD_PUBREC : MQTT_CMD_PUBACK, 0,
+                  remaining_len);
               mg_send(c, &id, sizeof(id));
 
               if (c->is_mqtt5) {
@@ -457,7 +459,7 @@ static void mqtt_cb(struct mg_connection *c, int ev, void *ev_data,
                 mg_send(c, &zero, sizeof(zero));
               }
             }
-            mg_call(c, MG_EV_MQTT_MSG, &mm);
+            mg_call(c, MG_EV_MQTT_MSG, &mm);  // let the app handle qos2 stuff
             break;
           }
         }


### PR DESCRIPTION
#2220 
- Properly respond with PUBREC to QoS2 messages (instead of PUBACK)
- The user event handler will still get a message on PUB, so it should store it and catch `MG_EV_MQTT_CMD`, ignoring possible retransmissions of the same msg until it gets PUBREL

Current status:
- For both QoS1 and QoS2, the user event handler should store the msg to be sent and catch `MG_EV_MQTT_CMD`, until it gets PUBACK (for QoS1) / PUBREC (for QoS2) and eventually retransmit on timeout. (QoS2 would also involve setting the DUP bit IIRC)

Should we update our example to show how to do this ?