### PR TITLE
Improve driver

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -6625,6 +6625,19 @@ struct stm32_eth {
 #undef ETH
 #define ETH ((struct stm32_eth *) (uintptr_t) 0x40028000)
 
+#undef DSB
+#if defined(__CC_ARM)
+#define DSB() __dsb(0xF)
+#elif defined(__ARMCC_VERSION)
+#define DSB() __builtin_arm_dsb(0xF)
+#elif defined(__GNUC__) && defined(__arm__) && defined(__thumb__)
+#define DSB() asm("DSB 0xF")
+#elif defined(__ICCARM__)
+#define DSB() __iar_builtin_DSB()
+#else
+#define DSB()
+#endif
+
 #undef BIT
 #define BIT(x) ((uint32_t) 1 << (x))
 #define ETH_PKT_SIZE 1540  // Max frame size
@@ -6774,10 +6787,11 @@ static size_t mg_tcpip_driver_stm32_tx(const void *buf, size_t len,
   } else {
     memcpy(s_txbuf[s_txno], buf, len);     // Copy data
     s_txdesc[s_txno][1] = (uint32_t) len;  // Set data len
-    s_txdesc[s_txno][0] = BIT(20) | BIT(28) | BIT(29) | BIT(30);  // Chain,FS,LS
+    s_txdesc[s_txno][0] = BIT(20) | BIT(28) | BIT(29);  // Chain,FS,LS
     s_txdesc[s_txno][0] |= BIT(31);  // Set OWN bit - let DMA take over
     if (++s_txno >= ETH_DESC_CNT) s_txno = 0;
   }
+  DSB();                         // ensure descriptors have been written
   ETH->DMASR = BIT(2) | BIT(5);  // Clear any prior TBUS/TUS
   ETH->DMATPDR = 0;              // and resume
   return len;

--- a/src/tcpip/driver_stm32.c
+++ b/src/tcpip/driver_stm32.c
@@ -17,6 +17,19 @@ struct stm32_eth {
 #undef ETH
 #define ETH ((struct stm32_eth *) (uintptr_t) 0x40028000)
 
+#undef DSB
+#if defined(__CC_ARM)
+#define DSB() __dsb(0xF)
+#elif defined(__ARMCC_VERSION)
+#define DSB() __builtin_arm_dsb(0xF)
+#elif defined(__GNUC__) && defined(__arm__) && defined(__thumb__)
+#define DSB() asm("DSB 0xF")
+#elif defined(__ICCARM__)
+#define DSB() __iar_builtin_DSB()
+#else
+#define DSB()
+#endif
+
 #undef BIT
 #define BIT(x) ((uint32_t) 1 << (x))
 #define ETH_PKT_SIZE 1540  // Max frame size
@@ -166,10 +179,11 @@ static size_t mg_tcpip_driver_stm32_tx(const void *buf, size_t len,
   } else {
     memcpy(s_txbuf[s_txno], buf, len);     // Copy data
     s_txdesc[s_txno][1] = (uint32_t) len;  // Set data len
-    s_txdesc[s_txno][0] = BIT(20) | BIT(28) | BIT(29) | BIT(30);  // Chain,FS,LS
+    s_txdesc[s_txno][0] = BIT(20) | BIT(28) | BIT(29);  // Chain,FS,LS
     s_txdesc[s_txno][0] |= BIT(31);  // Set OWN bit - let DMA take over
     if (++s_txno >= ETH_DESC_CNT) s_txno = 0;
   }
+  DSB();                         // ensure descriptors have been written
   ETH->DMASR = BIT(2) | BIT(5);  // Clear any prior TBUS/TUS
   ETH->DMATPDR = 0;              // and resume
   return len;


### PR DESCRIPTION
Apparently in some micros, depending on the compiler, descriptors are still being written when the DMA registers are configured to start tx. This commit inserts a DSB to prevent that.