### PR TITLE
Adding tls_ctx into mg_mgr for storing TLS context shared by all TLS session

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -28,6 +28,7 @@ struct mg_mgr {
   unsigned long nextid;         // Next connection ID
   unsigned long timerid;        // Next timer ID
   void *userdata;               // Arbitrary user data pointer
+  void *tls_ctx;                // TLS context shared by all TLS sessions
   uint16_t mqtt_id;             // MQTT IDs for pub/sub
   void *active_dns_requests;    // DNS requests in progress
   struct mg_timer *timers;      // Active timers


### PR DESCRIPTION
The context is an opaque pointer to TLS provider-specific data for storing context data (certs, keys, ca, TLS options, etc.) shared by all sessions.