### PR TITLE
mg_base64: check destination buffer size

### DIFF
--- a/mongoose.h
+++ b/mongoose.h
@@ -1081,8 +1081,8 @@ size_t mg_iobuf_del(struct mg_iobuf *, size_t ofs, size_t len);
 
 int mg_base64_update(unsigned char p, char *to, int len);
 int mg_base64_final(char *to, int len);
-int mg_base64_encode(const unsigned char *p, int n, char *to);
-int mg_base64_decode(const char *src, int n, char *dst);
+int mg_base64_encode(const unsigned char *p, int n, char *to, int tolen);
+int mg_base64_decode(const char *src, int n, char *dst, int dstlen);
 
 
 

--- a/src/base64.c
+++ b/src/base64.c
@@ -58,16 +58,20 @@ int mg_base64_final(char *to, int n) {
   return n;
 }
 
-int mg_base64_encode(const unsigned char *p, int n, char *to) {
+int mg_base64_encode(const unsigned char *p, int n, char *to, int tolen) {
   int i, len = 0;
+  // check if *to is big enough (including null byte)
+  if (tolen < ((n/3) + (n%3?1:0)) * 4 + 1) return 0;
   for (i = 0; i < n; i++) len = mg_base64_update(p[i], to, len);
   len = mg_base64_final(to, len);
   return len;
 }
 
-int mg_base64_decode(const char *src, int n, char *dst) {
+int mg_base64_decode(const char *src, int n, char *dst, int dstlen) {
   const char *end = src == NULL ? NULL : src + n;  // Cannot add to NULL
   int len = 0;
+  // check if *dst is big enough (including null byte, ignoring padding)
+  if (dstlen < (n - n/4) + 1) return 0;
   while (src != NULL && src + 3 < end) {
     int a = mg_b64rev(src[0]), b = mg_b64rev(src[1]), c = mg_b64rev(src[2]),
         d = mg_b64rev(src[3]);

--- a/src/base64.h
+++ b/src/base64.h
@@ -1,5 +1,5 @@
 #pragma once
 int mg_base64_update(unsigned char p, char *to, int len);
 int mg_base64_final(char *to, int len);
-int mg_base64_encode(const unsigned char *p, int n, char *to);
-int mg_base64_decode(const char *src, int n, char *dst);
+int mg_base64_encode(const unsigned char *p, int n, char *to, int tolen);
+int mg_base64_decode(const char *src, int n, char *dst, int dstlen);

--- a/src/http.c
+++ b/src/http.c
@@ -861,7 +861,7 @@ void mg_http_creds(struct mg_http_message *hm, char *user, size_t userlen,
   user[0] = pass[0] = '\0';
   if (v != NULL && v->len > 6 && memcmp(v->ptr, "Basic ", 6) == 0) {
     char buf[256];
-    int n = mg_base64_decode(v->ptr + 6, (int) v->len - 6, buf);
+    int n = mg_base64_decode(v->ptr + 6, (int) v->len - 6, buf, sizeof(buf));
     const char *p = (const char *) memchr(buf, ':', n > 0 ? (size_t) n : 0);
     if (p != NULL) {
       mg_snprintf(user, userlen, "%.*s", (int) (p - buf), buf);

--- a/src/json.c
+++ b/src/json.c
@@ -280,7 +280,7 @@ char *mg_json_get_b64(struct mg_str json, const char *path, int *slen) {
   int len = 0, off = mg_json_get(json, path, &len);
   if (off >= 0 && json.ptr[off] == '"' && len > 1 &&
       (result = (char *) calloc(1, (size_t) len)) != NULL) {
-    int k = mg_base64_decode(json.ptr + off + 1, len - 2, result);
+    int k = mg_base64_decode(json.ptr + off + 1, len - 2, result, len);
     if (slen != NULL) *slen = k;
   }
   return result;

--- a/src/ws.c
+++ b/src/ws.c
@@ -43,7 +43,7 @@ static void ws_handshake(struct mg_connection *c, const struct mg_str *wskey,
   mg_sha1_update(&sha_ctx, (unsigned char *) wskey->ptr, wskey->len);
   mg_sha1_update(&sha_ctx, (unsigned char *) magic, 36);
   mg_sha1_final(sha, &sha_ctx);
-  mg_base64_encode(sha, sizeof(sha), (char *) b64_sha);
+  mg_base64_encode(sha, sizeof(sha), (char *) b64_sha, sizeof(b64_sha));
   mg_xprintf(mg_pfn_iobuf, &c->send,
              "HTTP/1.1 101 Switching Protocols\r\n"
              "Upgrade: websocket\r\n"
@@ -242,7 +242,7 @@ struct mg_connection *mg_ws_connect(struct mg_mgr *mgr, const char *url,
     char nonce[16], key[30];
     struct mg_str host = mg_url_host(url);
     mg_random(nonce, sizeof(nonce));
-    mg_base64_encode((unsigned char *) nonce, sizeof(nonce), key);
+    mg_base64_encode((unsigned char *) nonce, sizeof(nonce), key, sizeof(key));
     mg_xprintf(mg_pfn_iobuf, &c->send,
                "GET %s HTTP/1.1\r\n"
                "Upgrade: websocket\r\n"

--- a/test/fuzz.c
+++ b/test/fuzz.c
@@ -66,11 +66,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   mg_sntp_parse(data, size);
   mg_sntp_parse(NULL, 0);
 
-  char buf[size * 4 / 3 + 5];  // At least 4 chars and nul termination
-  mg_base64_decode((char *) data, (int) size, buf);
-  mg_base64_decode(NULL, 0, buf);
-  mg_base64_encode(data, (int) size, buf);
-  mg_base64_encode(NULL, 0, buf);
+  size_t bufsize = size * 4 / 3 + 5;  // At least 4 chars and nul termination
+  char buf[bufsize];
+  mg_base64_decode((char *) data, (int) size, buf, (int) bufsize);
+  mg_base64_decode(NULL, 0, buf, 0);
+  mg_base64_encode(data, (int) size, buf, (int) bufsize);
+  mg_base64_encode(NULL, 0, buf, 0);
 
   mg_globmatch((char *) data, size, (char *) data, size);
 

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -273,34 +273,41 @@ static void test_url(void) {
   ASSERT(strcmp(mg_url_uri("p://foo/q?mail=a@b.c"), "/q?mail=a@b.c") == 0);
 }
 
+#define BUFSIZE 128
 static void test_base64(void) {
-  char buf[128];
+  char buf[BUFSIZE];
 
-  ASSERT(mg_base64_encode((uint8_t *) "", 0, buf) == 0);
+  ASSERT(mg_base64_encode((uint8_t *) "", 0, buf, BUFSIZE) == 0);
   ASSERT(strcmp(buf, "") == 0);
-  ASSERT(mg_base64_encode((uint8_t *) "x", 1, buf) == 4);
+  ASSERT(mg_base64_encode((uint8_t *) "x", 1, buf, BUFSIZE) == 4);
   ASSERT(strcmp(buf, "eA==") == 0);
-  ASSERT(mg_base64_encode((uint8_t *) "xyz", 3, buf) == 4);
+  ASSERT(mg_base64_encode((uint8_t *) "xyz", 3, buf, BUFSIZE) == 4);
   ASSERT(strcmp(buf, "eHl6") == 0);
-  ASSERT(mg_base64_encode((uint8_t *) "abcdef", 6, buf) == 8);
+  ASSERT(mg_base64_encode((uint8_t *) "abcdef", 6, buf, BUFSIZE) == 8);
   ASSERT(strcmp(buf, "YWJjZGVm") == 0);
-  ASSERT(mg_base64_encode((uint8_t *) "ы", 2, buf) == 4);
+  ASSERT(mg_base64_encode((uint8_t *) "ы", 2, buf, BUFSIZE) == 4);
   ASSERT(strcmp(buf, "0Ys=") == 0);
-  ASSERT(mg_base64_encode((uint8_t *) "xy", 3, buf) == 4);
+  ASSERT(mg_base64_encode((uint8_t *) "xy", 3, buf, BUFSIZE) == 4);
   ASSERT(strcmp(buf, "eHkA") == 0);
-  ASSERT(mg_base64_encode((uint8_t *) "test", 4, buf) == 8);
+  ASSERT(mg_base64_encode((uint8_t *) "test", 4, buf, BUFSIZE) == 8);
   ASSERT(strcmp(buf, "dGVzdA==") == 0);
-  ASSERT(mg_base64_encode((uint8_t *) "abcde", 5, buf) == 8);
+  ASSERT(mg_base64_encode((uint8_t *) "abcde", 5, buf, BUFSIZE) == 8);
   ASSERT(strcmp(buf, "YWJjZGU=") == 0);
 
-  ASSERT(mg_base64_decode("кю", 4, buf) == 0);
-  ASSERT(mg_base64_decode("A", 1, buf) == 0);
-  ASSERT(mg_base64_decode("A=", 2, buf) == 0);
-  ASSERT(mg_base64_decode("AA=", 3, buf) == 0);
-  ASSERT(mg_base64_decode("AAA=", 4, buf) == 2);
-  ASSERT(mg_base64_decode("AAAA====", 8, buf) == 0);
-  ASSERT(mg_base64_decode("AAAA----", 8, buf) == 0);
-  ASSERT(mg_base64_decode("Q2VzYW50YQ==", 12, buf) == 7);
+  // destination buffer too small
+  ASSERT(mg_base64_encode((uint8_t *) "abcde", 5, buf, 8) == 0);
+  ASSERT(mg_base64_encode((uint8_t *) "abcde", 5, buf, -1) == 0);
+  ASSERT(mg_base64_decode("Q2VzYW50YQ==", 12, buf, 7) == 0);
+  ASSERT(mg_base64_decode("Q2VzYW50YQ==", 12, buf, -1) == 0);
+
+  ASSERT(mg_base64_decode("кю", 4, buf, BUFSIZE) == 0);
+  ASSERT(mg_base64_decode("A", 1, buf, BUFSIZE) == 0);
+  ASSERT(mg_base64_decode("A=", 2, buf, BUFSIZE) == 0);
+  ASSERT(mg_base64_decode("AA=", 3, buf, BUFSIZE) == 0);
+  ASSERT(mg_base64_decode("AAA=", 4, buf, BUFSIZE) == 2);
+  ASSERT(mg_base64_decode("AAAA====", 8, buf, BUFSIZE) == 0);
+  ASSERT(mg_base64_decode("AAAA----", 8, buf, BUFSIZE) == 0);
+  ASSERT(mg_base64_decode("Q2VzYW50YQ==", 12, buf, BUFSIZE) == 7);
   ASSERT(strcmp(buf, "Cesanta") == 0);
 }
 


### PR DESCRIPTION
Fix usage of base64 en/decode functions to include a destination size