### PR TITLE
Add MG_ENABLE_CUSTOM_LOG

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3217,6 +3217,9 @@ void mg_log_set(int log_level) {
   s_level = log_level;
 }
 
+#if MG_ENABLE_CUSTOM_LOG
+// Let user define their own mg_log_prefix() and mg_log()
+#else
 bool mg_log_prefix(int level, const char *file, int line, const char *fname) {
   if (level <= s_level) {
     const char *p = strrchr(file, '/');
@@ -3241,6 +3244,7 @@ void mg_log(const char *fmt, ...) {
   va_end(ap);
   logs("\r\n", 2);
 }
+#endif
 
 static unsigned char nibble(unsigned c) {
   return (unsigned char) (c < 10 ? c + '0' : c + 'W');

--- a/mongoose.h
+++ b/mongoose.h
@@ -669,6 +669,10 @@ struct timeval {
 #define MG_ENABLE_LOG 1
 #endif
 
+#ifndef MG_ENABLE_CUSTOM_LOG
+#define MG_ENABLE_CUSTOM_LOG 0  // Let user define their own MG_LOG
+#endif
+
 #ifndef MG_ENABLE_TCPIP
 #define MG_ENABLE_TCPIP 0  // Mongoose built-in network stack
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -4,6 +4,10 @@
 #define MG_ENABLE_LOG 1
 #endif
 
+#ifndef MG_ENABLE_CUSTOM_LOG
+#define MG_ENABLE_CUSTOM_LOG 0  // Let user define their own MG_LOG
+#endif
+
 #ifndef MG_ENABLE_TCPIP
 #define MG_ENABLE_TCPIP 0  // Mongoose built-in network stack
 #endif

--- a/src/log.c
+++ b/src/log.c
@@ -26,6 +26,9 @@ void mg_log_set(int log_level) {
   s_level = log_level;
 }
 
+#if MG_ENABLE_CUSTOM_LOG
+// Let user define their own mg_log_prefix() and mg_log()
+#else
 bool mg_log_prefix(int level, const char *file, int line, const char *fname) {
   if (level <= s_level) {
     const char *p = strrchr(file, '/');
@@ -50,6 +53,7 @@ void mg_log(const char *fmt, ...) {
   va_end(ap);
   logs("\r\n", 2);
 }
+#endif
 
 static unsigned char nibble(unsigned c) {
   return (unsigned char) (c < 10 ? c + '0' : c + 'W');


### PR DESCRIPTION
Allows customers to redefine their own `mg_log_prefix()` and `mg_log()` functions, to completely change logging logic.