### PR TITLE
fix H563 FreeRTOS Cortex-M33 port SystemInit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,8 +232,8 @@ jobs:
       run: sudo apt -y update; sudo apt -y install gcc-arm-none-eabi
     - if: ${{ env.GO == 1 }}
       run:  make -C examples/stm32/nucleo-h563zi-make-baremetal-builtin test VCON_API_KEY=${{secrets.VCON_API_KEY}}
-#    - if: ${{ env.GO == 1 }}
-# WIP      run:  make -C examples/stm32/nucleo-h563zi-make-freertos-builtin test VCON_API_KEY=${{secrets.VCON_API_KEY}}
+    - if: ${{ env.GO == 1 }}
+      run:  make -C examples/stm32/nucleo-h563zi-make-freertos-builtin test VCON_API_KEY=${{secrets.VCON_API_KEY}}
 
   test_rt1020:
     runs-on: ubuntu-latest

--- a/examples/stm32/nucleo-h563zi-make-freertos-builtin/sysinit.c
+++ b/examples/stm32/nucleo-h563zi-make-freertos-builtin/sysinit.c
@@ -37,5 +37,5 @@ void SystemInit(void) {  // Called automatically by startup code
   while ((RCC->CFGR1 & (7 << 3)) != (3 << 3)) spin(1);  // Wait until done
 
   rng_init();                            // Initialise random number generator
-  SysTick_Config(CPU_FREQUENCY / 1000);  // Sys tick every 1ms
+  // let FreeRTOS initialize SysTick
 }


### PR DESCRIPTION
This port takes over SysTick and has its own initialization. As the device also has a lot of RAM, initializing SysTick ourselves causes an early unexpected IRQ ending in a HardFault.