### PR TITLE
Fix H743 FreeRTOS early SysTick crash

### DIFF
--- a/examples/stm32/nucleo-h743zi-make-freertos-builtin/FreeRTOSConfig.h
+++ b/examples/stm32/nucleo-h743zi-make-freertos-builtin/FreeRTOSConfig.h
@@ -35,4 +35,4 @@
 
 #define vPortSVCHandler SVC_Handler
 #define xPortPendSVHandler PendSV_Handler
-#define xPortSysTickHandler SysTick_Handler
+//#define xPortSysTickHandler SysTick_Handler

--- a/examples/stm32/nucleo-h743zi-make-freertos-builtin/main.c
+++ b/examples/stm32/nucleo-h743zi-make-freertos-builtin/main.c
@@ -7,6 +7,13 @@
 
 #define BLINK_PERIOD_MS 1000  // LED blinking period in millis
 
+// workaround SysTick firing before FreeRTOS has fully initialized (startup)
+extern void xPortSysTickHandler(void);
+void SysTick_Handler(void) {
+  if (xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED)
+    xPortSysTickHandler();
+}
+
 void mg_random(void *buf, size_t len) {  // Use on-board RNG
   for (size_t n = 0; n < len; n += sizeof(uint32_t)) {
     uint32_t r = rng_read();


### PR DESCRIPTION
Startup code takes two long to clear RAM, SystemInit is called right after reset, so sometimes SysTick fires before FreeRTOS has fully initialized
