### PR TITLE
Update CodeQL Analysis Workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,12 +3,15 @@ name: "CodeQL Scanning"
 
 on:
   push:
+    branches: [ "master" ]
     paths:
       - "Makefile"
       - "mongoose.c"
       - "mongoose.h"
       - test/unit-test
       - test/mip-test
+  pull_request:
+    branches: '*'
 
 env:
   IPV6: 0
@@ -17,19 +20,65 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      matrix:
+        language: [ 'cpp' ]
     permissions:
       security-events: write
+      
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout repository
+      uses: actions/checkout@v3
       with: { fetch-depth: 2 }
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
-        languages: cpp
+        languages: ${{ matrix.language }}
+        queries: security-and-quality
+      
     - run: |
         make test CC=gcc ASAN= ASAN_OPTIONS=
         ./test/setup_ga_network.sh && make mip_test CC=gcc ASAN= ASAN_OPTIONS=
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"
+        upload: false
+      id: step1
+
+    # Filter out rules with low severity or high false positve rate
+    # Also filter out warnings in third-party code
+    - name: Filter out unwanted errors and warnings
+      uses: advanced-security/filter-sarif@v1
+      with:
+        patterns: |
+          -**:cpp/path-injection
+          -**:cpp/world-writable-file-creation
+          -**:cpp/poorly-documented-function
+          -**:cpp/potentially-dangerous-function
+          -**:cpp/use-of-goto
+          -**:cpp/integer-multiplication-cast-to-long
+          -**:cpp/comparison-with-wider-type
+          -**:cpp/leap-year/*
+          -**:cpp/ambiguously-signed-bit-field
+          -**:cpp/suspicious-pointer-scaling
+          -**:cpp/suspicious-pointer-scaling-void
+          -**:cpp/unsigned-comparison-zero
+          -**/cmake*/Modules/**
+        input: ${{ steps.step1.outputs.sarif-output }}/cpp.sarif
+        output: ${{ steps.step1.outputs.sarif-output }}/cpp.sarif
+
+    - name: Upload CodeQL results to code scanning
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        sarif_file: ${{ steps.step1.outputs.sarif-output }}
+        category: "/language:${{matrix.language}}"
+
+    - name: Upload CodeQL results as an artifact
+      if: success() || failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: codeql-results
+        path: ${{ steps.step1.outputs.sarif-output }}
+        retention-days: 5


### PR DESCRIPTION
Features:

- Runs on every PR
- Uploading analysis results to code scanning
- Uploading analysis results as an artifact for 5 days
- Allows for rule/library filtering to filter out queries with too many false positives and third party libraries

In response to issue https://github.com/cesanta/mongoose/issues/2496