### PR TITLE
TLS layer: c->rtls to optimise recvd TLS data

### DIFF
--- a/mongoose.h
+++ b/mongoose.h
@@ -1254,6 +1254,7 @@ struct mg_connection {
   struct mg_iobuf recv;        // Incoming data
   struct mg_iobuf send;        // Outgoing data
   struct mg_iobuf prof;        // Profile data enabled by MG_ENABLE_PROFILE
+  struct mg_iobuf rtls;        // TLS only. Incoming encrypted data
   mg_event_handler_t fn;       // User-specified event handler function
   void *fn_data;               // User-specified function parameter
   mg_event_handler_t pfn;      // Protocol-specific handler function
@@ -1526,6 +1527,7 @@ struct mg_tls {
 #include <openssl/ssl.h>
 
 struct mg_tls {
+  BIO_METHOD *bm;
   SSL_CTX *ctx;
   SSL *ssl;
 };

--- a/src/net.h
+++ b/src/net.h
@@ -50,6 +50,7 @@ struct mg_connection {
   struct mg_iobuf recv;        // Incoming data
   struct mg_iobuf send;        // Outgoing data
   struct mg_iobuf prof;        // Profile data enabled by MG_ENABLE_PROFILE
+  struct mg_iobuf rtls;        // TLS only. Incoming encrypted data
   mg_event_handler_t fn;       // User-specified event handler function
   void *fn_data;               // User-specified function parameter
   mg_event_handler_t pfn;      // Protocol-specific handler function

--- a/src/tls_mbed.c
+++ b/src/tls_mbed.c
@@ -104,6 +104,7 @@ void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
   }
   if (c->is_listening) goto fail;
   MG_DEBUG(("%lu Setting TLS", c->id));
+  MG_PROF_ADD(c, "mbedtls_init_start");
   mbedtls_ssl_init(&tls->ssl);
   mbedtls_ssl_config_init(&tls->conf);
   mbedtls_x509_crt_init(&tls->ca);
@@ -156,6 +157,7 @@ void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
   c->is_tls = 1;
   c->is_tls_hs = 1;
   mbedtls_ssl_set_bio(&tls->ssl, c, mg_net_send, mg_net_recv, 0);
+  MG_PROF_ADD(c, "mbedtls_init_end");
   if (c->is_client && c->is_resolving == 0 && c->is_connecting == 0) {
     mg_tls_handshake(c);
   }

--- a/src/tls_openssl.h
+++ b/src/tls_openssl.h
@@ -6,6 +6,7 @@
 #include <openssl/ssl.h>
 
 struct mg_tls {
+  BIO_METHOD *bm;
   SSL_CTX *ctx;
   SSL *ssl;
 };

--- a/test/fuzz.c
+++ b/test/fuzz.c
@@ -23,7 +23,7 @@ static void fn(struct mg_connection *c, int ev, void *ev_data, void *fn_data) {
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-  mg_log_set(MG_LL_NONE);
+  mg_log_set(MG_LL_INFO);
 
   struct mg_dns_message dm;
   mg_dns_parse(data, size, &dm);

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -3136,7 +3136,7 @@ static void producer(void *param) {
   size_t len, ofs = sizeof(tmp);
   for (s_out = 0; s_out < NMESSAGES; s_out++) {
     if (ofs >= sizeof(tmp)) mg_random(tmp, sizeof(tmp)), ofs = 0;
-    len = ((uint8_t *) tmp)[ofs] % 55 + 1;
+    len = ((uint8_t *) tmp)[ofs] % 55U + 1U;
     if (ofs + len > sizeof(tmp)) len = sizeof(tmp) - ofs;
     while ((mg_queue_book(q, &buf, len)) < len) (void) 0;
     memcpy(buf, &tmp[ofs], len);


### PR DESCRIPTION
The reason for this PR is to minimise the amount of data copies for the TLS case. TLDR: raw data is now received in the `c->rtls` IO buffer, and can be accessed directly. 

So, receive path:
`stack receives new raw data -> c->rtls -> (TLS decrypt) -> c->recv`

Note that the send path does not have the same. Apparently, TLS implementation can just encrypt data (`mg_tls_send()`) data on-the-fly.

Right now, the builtin receive path looks like this:

1. Stack. Packet data gets copied to the s->raw IO buffer
2. Stack. Call mg_tls_recv
3. TLS. mg_tls_recv copies data in its own recv buffer
4. TLS. mg_tls_recv decrypts the data and returns
5. Stack gets decrypted data and copies into c->recv

This PR unifies receive path to all TLS implementations by creating `c->rtls` IO buffer for the raw, encrypted data.

This change required OpenSSL implementation be changed, because OpenSSL accessed an underlying socket descriptor directly. Instead, OpenSSL must use our own low-level send/recv primitives for the low level IO - just like mbedTLS does. So, OpenSSL code was refactored: a custom BIO is created that implements the IO rather that relying on the socket. Theoretically, it makes it possible to use OpenSSL with the builtin stack - which is unlikely anyways.