### PR TITLE
default again to current doc defaults

### DIFF
--- a/examples/device-dashboard/Makefile
+++ b/examples/device-dashboard/Makefile
@@ -49,8 +49,6 @@ ifeq ($(TLS), mbedtls)
 CFLAGS += -DMG_TLS=MG_TLS_MBED -Wno-conversion -Imbedtls/include
 CFLAGS += -DMBEDTLS_CONFIG_FILE=\"mbedtls_config.h\" mbedtls/library/*.c
 $(PROG): mbedtls
-else
-CFLAGS += -DMG_TLS=MG_TLS_BUILTIN
 endif
 
 # Cleanup. Delete built program and all build artifacts

--- a/examples/stm32/nucleo-f746zg-make-baremetal-builtin/Makefile
+++ b/examples/stm32/nucleo-f746zg-make-baremetal-builtin/Makefile
@@ -13,7 +13,6 @@ SOURCES += mongoose.c net.c packed_fs.c
 
 # Example specific build options. See README.md
 CFLAGS += -DHTTP_URL=\"http://0.0.0.0/\" -DHTTPS_URL=\"https://0.0.0.0/\"
-CFLAGS += -DMG_TLS=MG_TLS_BUILTIN
 
 ifeq ($(OS),Windows_NT)
   RM = cmd /C del /Q /F /S


### PR DESCRIPTION
Followup addressing comments in #2538
Avoid clashes with other TLS libs
Current docs instruct to build with no TLS and with mbedTLS (and openSSL); we'll soon default to build with our built-in TLS code, so at that point we would need to address any other changes again.
Any example can be built with our built-in TLS using `CFLAGS_EXTRA="-DMG_TLS=MG_TLS_BUILTIN"`