### PR TITLE
Fix #2570: close only when TLS buffers drained

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -7299,14 +7299,12 @@ static void read_conn(struct mg_connection *c) {
       n = recv_raw(c, (char *) &c->rtls.buf[c->rtls.len],
                    c->rtls.size - c->rtls.len);
       // MG_DEBUG(("%lu %ld", c->id, n));
-      if (n == MG_IO_ERR) {
+      if (n == MG_IO_ERR && mg_tls_pending(c) == 0 && c->rtls.len == 0) {
         c->is_closing = 1;
-      } else if (n > 0) {
-        c->rtls.len += (size_t) n;
+      } else {
+        if (n > 0) c->rtls.len += (size_t) n;
         if (c->is_tls_hs) mg_tls_handshake(c);
         if (c->is_tls_hs) return;
-        n = mg_tls_recv(c, buf, len);
-      } else if (n == MG_IO_WAIT) {
         n = mg_tls_recv(c, buf, len);
       }
     } else {

--- a/src/sock.c
+++ b/src/sock.c
@@ -282,14 +282,13 @@ static void read_conn(struct mg_connection *c) {
       n = recv_raw(c, (char *) &c->rtls.buf[c->rtls.len],
                    c->rtls.size - c->rtls.len);
       // MG_DEBUG(("%lu %ld", c->id, n));
-      if (n == MG_IO_ERR) {
+      if (n == MG_IO_ERR && mg_tls_pending(c) == 0 && c->rtls.len == 0) {
+        // Close only if we have fully drained both raw (rtls) and TLS buffers
         c->is_closing = 1;
-      } else if (n > 0) {
-        c->rtls.len += (size_t) n;
+      } else {
+        if (n > 0) c->rtls.len += (size_t) n;
         if (c->is_tls_hs) mg_tls_handshake(c);
         if (c->is_tls_hs) return;
-        n = mg_tls_recv(c, buf, len);
-      } else if (n == MG_IO_WAIT) {
         n = mg_tls_recv(c, buf, len);
       }
     } else {


### PR DESCRIPTION
Mongoose reads raw encrypted data into the c->rtls buffer. Then, it feeds that data to the TLS library.
Currently, if server finished sending the data, it closes the connection. Mongoose reads data into c->rtls, so c->rtls has some data to be decrypted, then Mongoose reads 0 from the socket, indicating that server has closed the connection.
And Mongoose closed the connection too, despite it has some data in c->rtls yet to be decrypted!

This PR fixes that issue and decrypts everything before closing the connection.