### PR TITLE
mongoose.h: fix posix zephyr compiler warning

### DIFF
--- a/mongoose.h
+++ b/mongoose.h
@@ -522,7 +522,7 @@ typedef int socklen_t;
 
 #include <ctype.h>
 #include <errno.h>
-#include <fcntl.h>
+#include <zephyr/posix/fcntl.h>
 #include <zephyr/net/socket.h>
 #include <stdarg.h>
 #include <stdbool.h>


### PR DESCRIPTION
## Problem

```
note: '#pragma message: #include <fcntl.h> without CONFIG_POSIX_API is deprecated. Please use CONFIG_POSIX_API or #include <zephyr/posix/fcntl.h>'
   11 | #pragma message("#include <fcntl.h> without CONFIG_POSIX_API is deprecated. "
```

This pull request addresses a deprecation warning in the codebase related to the fcntl.h library in Zephyr. The deprecation warning arises from the direct inclusion of fcntl.h, prompting the compiler to flag this section. To resolve this warning, the suggested approach is either to define CONFIG_POSIX_API or utilize #include <zephyr/posix/fcntl.h> instead.

## Solution

The changes introduced in this pull request ensure compliance with the recommended practices, mitigating the deprecation warning and enhancing code maintainability within the Zephyr framework.

This pull request aims to streamline the codebase by adopting the appropriate header inclusion method and adhering to the suggested conventions for utilizing the fcntl.h library in Zephyr.

## Screenshot

![image](https://github.com/cesanta/mongoose/assets/58497719/287438de-6e4e-4b5e-b772-7c95fa6d2de5)

## Versions

* mongoose: 7.13
* zephyr: 3.6.0
* cmake: 3.26.0-rc5
* gcc: GNU 12.2.0

## Example application

https://github.com/mustafaabdullahk/mongoose-example-application
