### PR TITLE
feat: Allow zero-length payloads for Will messages

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -4333,7 +4333,7 @@ void mg_mqtt_login(struct mg_connection *c, const struct mg_mqtt_opts *opts) {
     total_len += 2 + (uint32_t) opts->pass.len;
     hdr[7] |= MQTT_HAS_PASSWORD;
   }
-  if (opts->topic.len > 0 && opts->message.len > 0) {
+  if (opts->topic.len > 0 && opts->message.len >= 0) { // Zero-length payloads are valid
     total_len += 4 + (uint32_t) opts->topic.len + (uint32_t) opts->message.len;
     hdr[7] |= MQTT_HAS_WILL;
   }

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -277,7 +277,7 @@ void mg_mqtt_login(struct mg_connection *c, const struct mg_mqtt_opts *opts) {
     total_len += 2 + (uint32_t) opts->pass.len;
     hdr[7] |= MQTT_HAS_PASSWORD;
   }
-  if (opts->topic.len > 0 && opts->message.len > 0) {
+  if (opts->topic.len > 0 && opts->message.len >= 0) { // Zero-length payloads are valid
     total_len += 4 + (uint32_t) opts->topic.len + (uint32_t) opts->message.len;
     hdr[7] |= MQTT_HAS_WILL;
   }


### PR DESCRIPTION
#2700

* zero-length payloads available;
* in case of Mosquitto, zero-length payloads will remove retained payloads from will topic