### PR TITLE
Add wolfSSL support

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ssl: ["", BUILTIN]
+        ssl: [""]
     name: S390 SSL=${{ matrix.ssl }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         cc: [gcc, clang, g++, clang++]
         target: [test, mip_test]
-        ssl: ["", BUILTIN, MBEDTLS, OPENSSL]
+        ssl: ["", BUILTIN, MBEDTLS, OPENSSL, WOLFSSL]
         select: ["-DMG_ENABLE_POLL=0 -DMG_ENABLE_EPOLL=0", "-DMG_ENABLE_POLL=1 -DMG_ENABLE_EPOLL=0", "-DMG_ENABLE_POLL=0 -DMG_ENABLE_EPOLL=1"]
         exclude:
         - ssl: MBEDTLS
@@ -25,6 +25,10 @@ jobs:
           select: "-DMG_ENABLE_POLL=0 -DMG_ENABLE_EPOLL=0"
         - ssl: OPENSSL
           select: "-DMG_ENABLE_POLL=1 -DMG_ENABLE_EPOLL=0"
+        - ssl: WOLFSSL
+          select: "-DMG_ENABLE_POLL=0 -DMG_ENABLE_EPOLL=0"
+        - ssl: WOLFSSL
+          select: "-DMG_ENABLE_POLL=1 -DMG_ENABLE_EPOLL=0"
     name: linux ${{ matrix.target }} CC=${{ matrix.cc }} SSL=${{ matrix.ssl }} TFLAGS=${{ matrix.select }}
     env:
       CC: ${{ matrix.cc }}
@@ -33,7 +37,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with: { fetch-depth: 2 }
-    - run: ./test/setup_ga_network.sh && sudo apt -y update ; sudo apt -y install libmbedtls-dev && make -C test ${{ matrix.target }}
+    - run: ./test/setup_ga_network.sh && sudo apt -y update ; sudo apt -y install libmbedtls-dev libwolfssl-dev && make -C test ${{ matrix.target }}
   s390:
     runs-on: ubuntu-latest
     strategy:
@@ -61,36 +65,38 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ssl: ["", BUILTIN, MBEDTLS, OPENSSL]
+        ssl: ["", BUILTIN, MBEDTLS, OPENSSL, WOLFSSL]
     name: unamalgamated-mg_prefix SSL=${{ matrix.ssl }}
     steps:
     - uses: actions/checkout@v4
       with: { fetch-depth: 2 }
-    - run: sudo apt -y update ; sudo apt -y install libmbedtls-dev
+    - run: sudo apt -y update ; sudo apt -y install libmbedtls-dev libwolfssl-dev
     - run: make -C test unamalgamated && make -C test mg_prefix
   valgrind:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        ssl: ["", BUILTIN, MBEDTLS, OPENSSL]
+        ssl: ["", BUILTIN, MBEDTLS, OPENSSL, WOLFSSL]
     name: Valgrind SSL=${{ matrix.ssl }}
     steps:
     - uses: actions/checkout@v4
       with: { fetch-depth: 2 }
-    - run: sudo apt -y update ; sudo apt -y install libmbedtls-dev valgrind
+    - run: sudo apt -y update ; sudo apt -y install libmbedtls-dev libwolfssl-dev valgrind
     - run: make -C test valgrind SSL=${{ matrix.ssl }}
   macos:
     runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
-        ssl: ["", BUILTIN, MBEDTLS, OPENSSL]
+        ssl: ["", BUILTIN, MBEDTLS, OPENSSL, WOLFSSL]
         select: [-DMG_ENABLE_POLL=0, -DMG_ENABLE_POLL=1]
         exclude:
         - ssl: MBEDTLS
           select: -DMG_ENABLE_POLL=0
         - ssl: OPENSSL
+          select: -DMG_ENABLE_POLL=0
+        - ssl: WOLFSSL
           select: -DMG_ENABLE_POLL=0
     name: macos SSL=${{ matrix.ssl }} TFLAGS=${{ matrix.select }}
     env:
@@ -100,8 +106,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with: { fetch-depth: 2 }
-    - run: brew install jq mbedtls openssl
-    - run: make -C test test ASAN_OPTIONS= MBEDTLS=$(echo $(brew --cellar)/mbedtls*/*) OPENSSL=$(echo $(brew --cellar)/openssl*/*)
+    - run: brew install jq mbedtls openssl wolfssl
+    - run: make -C test test ASAN_OPTIONS= MBEDTLS=$(echo $(brew --cellar)/mbedtls*/*) OPENSSL=$(echo $(brew --cellar)/openssl*/*) WOLFSSL=$(echo $(brew --cellar)/wolfssl*/*)
   windows:
     runs-on: ubuntu-latest
     strategy:
@@ -152,7 +158,7 @@ jobs:
     name: examples ${{ matrix.ssl }}
     steps:
     - uses: actions/checkout@v4
-    - run: sudo apt -y install libmbedtls-dev libpcap-dev
+    - run: sudo apt -y install libmbedtls-dev libwolfssl-dev libpcap-dev
     - run: make -C test examples CFLAGS_EXTRA="${{ matrix.ssl }}"
     - run: make -C test clean_examples
   examples_win:
@@ -237,7 +243,7 @@ jobs:
     name: tutorials ${{ matrix.ssl }}
     steps:
     - uses: actions/checkout@v4
-    - run: sudo apt -y install libmbedtls-dev libpcap-dev
+    - run: sudo apt -y install libmbedtls-dev libwolfssl-dev libpcap-dev
     - run: make -C test tutorials CFLAGS_EXTRA="${{ matrix.ssl }}"
     - run: make -C test clean_tutorials
   tutorials_win:

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -80,10 +80,10 @@ static size_t encode_varint(uint8_t *buf, size_t value) {
   size_t len = 0;
 
   do {
-    uint8_t byte = (uint8_t) (value % 128);
+    uint8_t b = (uint8_t) (value % 128);
     value /= 128;
-    if (value > 0) byte |= 0x80;
-    buf[len++] = byte;
+    if (value > 0) b |= 0x80;
+    buf[len++] = b;
   } while (value > 0);
 
   return len;

--- a/src/util.c
+++ b/src/util.c
@@ -63,9 +63,9 @@ uint32_t mg_crc32(uint32_t crc, const char *buf, size_t len) {
       0x9B64C2B0, 0x86D3D2D4, 0xA00AE278, 0xBDBDF21C};
   crc = ~crc;
   while (len--) {
-    uint8_t byte = *(uint8_t *) buf++;
-    crc = crclut[(crc ^ byte) & 0x0F] ^ (crc >> 4);
-    crc = crclut[(crc ^ (byte >> 4)) & 0x0F] ^ (crc >> 4);
+    uint8_t b = *(uint8_t *) buf++;
+    crc = crclut[(crc ^ b) & 0x0F] ^ (crc >> 4);
+    crc = crclut[(crc ^ (b >> 4)) & 0x0F] ^ (crc >> 4);
   }
   return ~crc;
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -53,6 +53,12 @@ CFLAGS  += -DMG_TLS=MG_TLS_OPENSSL -I$(OPENSSL)/include
 LDFLAGS += -L$(OPENSSL)/lib -lssl -lcrypto
 endif
 
+ifeq "$(SSL)" "WOLFSSL"
+WOLFSSL ?= /usr/local
+CFLAGS  += -DMG_TLS=MG_TLS_OPENSSL -I$(WOLFSSL)/include -I$(WOLFSSL)/include/wolfssl -DEXTERNAL_OPTS_OPENVPN
+LDFLAGS += -L$(WOLFSSL)/lib -lwolfssl
+endif
+
 ifeq "$(SSL)" "BUILTIN"
 CFLAGS  += -DMG_TLS=MG_TLS_BUILTIN
 endif


### PR DESCRIPTION
- Added Makefile wolfSSL build option with `SSL=WOLFSSL`
- Fixed missing BIO symbol errors
- Rename `fe` to `mg_fe` as it collides with `fe` defined in `wolfssl/wolfcrypt/fe_operations.h`
- `byte` variable name shadows the wolfSSL `byte` type
-  Updated nightly to run wolfSSL tests

Tested with `make test`