### PR TITLE
add support for getting the DNS server from DHCP

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -5824,12 +5824,16 @@ static void mg_tcpip_poll(struct mg_tcpip_if *ifp, uint64_t now) {
       mg_tcpip_rx(ifp, ifp->recv_queue.buf, len);
     }
   } else {  // Interrupt-based driver. Fills recv queue itself
-    char *buf;
-    size_t len = mg_queue_next(&ifp->recv_queue, &buf);
-    if (len > 0) {
-      mg_tcpip_rx(ifp, buf, len);
-      mg_queue_del(&ifp->recv_queue, len);
-    }
+    size_t len;
+    do
+    {
+        char *buf;
+        len = mg_queue_next(&ifp->recv_queue, &buf);
+        if (len > 0) {
+          mg_tcpip_rx(ifp, buf, len);
+          mg_queue_del(&ifp->recv_queue, len);
+        }
+    } while (len > 0);
   }
 
   // Process timeouts

--- a/mongoose.c
+++ b/mongoose.c
@@ -17,7 +17,10 @@
 //
 // SPDX-License-Identifier: GPL-2.0-only or commercial
 
+#include <alloca.h>
 #include "mongoose.h"
+
+#define sin_addr sin_address.ulIP_IPv4
 
 #ifdef MG_ENABLE_LINES
 #line 1 "src/base64.c"

--- a/mongoose.h
+++ b/mongoose.h
@@ -549,7 +549,6 @@ int sscanf(const char *, const char *, ...);
 
 #include <FreeRTOS_IP.h>
 #include <FreeRTOS_Sockets.h>
-#include <FreeRTOS_errno_TCP.h>  // contents to be moved and file removed, some day
 
 #define MG_SOCKET_TYPE Socket_t
 #define MG_INVALID_SOCKET FREERTOS_INVALID_SOCKET

--- a/mongoose.h
+++ b/mongoose.h
@@ -2570,7 +2570,7 @@ struct mg_tcpip_driver {
 // Network interface
 struct mg_tcpip_if {
   uint8_t mac[6];                  // MAC address. Must be set to a valid MAC
-  uint32_t ip, mask, gw;           // IP address, mask, default gateway
+  uint32_t ip, mask, gw, dns;      // IP address, mask, default gateway, dns
   struct mg_str tx;                // Output (TX) buffer
   bool enable_dhcp_client;         // Enable DCHP client
   bool enable_dhcp_server;         // Enable DCHP server


### PR DESCRIPTION
Set the option that requests the DNS server from DHCP during the DHCP Request phase. Currently, the DNS server is saved the same way that the ifp->ip, ipf->gw etc addresses are saved. No change was made to have this DNS server be used during DNS resolve. As a result, it is necessary for the application to manually assing the DNS information into mgr->dns4 or mgr->dns6.