### PR TITLE
fix read after free

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -9925,7 +9925,10 @@ static int mg_tls_recv_record(struct mg_connection *c) {
 
 void mg_tls_ioremap(struct mg_connection *c, size_t offset) {
   struct tls_data *tls = (struct tls_data *) c->tls;
-  if (tls->recv.buf != NULL) tls->recv.buf += offset;
+  if (tls->recv.buf != NULL) {
+    size_t newptr = ((size_t) tls->recv.buf) + offset;
+    tls->recv.buf = (unsigned char *) newptr;
+  }
 }
 
 static void mg_tls_calc_cert_verify_hash(struct mg_connection *c,

--- a/mongoose.c
+++ b/mongoose.c
@@ -7514,6 +7514,18 @@ static bool ioalloc(struct mg_connection *c, struct mg_iobuf *io) {
   return res;
 }
 
+#if MG_TLS == MG_TLS_BUILTIN
+void mg_tls_ioremap(struct mg_connection *, size_t);
+static bool tlsioalloc(struct mg_connection *c, struct mg_iobuf *io){
+  unsigned char *old = io->buf;
+  if (!ioalloc(c, io)) return false;
+  mg_tls_ioremap(c, (size_t) (io->buf - old)); // remap current record buffer
+  return true;
+}
+#else
+#define tlsioalloc ioalloc
+#endif
+
 // NOTE(lsm): do only one iteration of reads, cause some systems
 // (e.g. FreeRTOS stack) return 0 instead of -1/EWOULDBLOCK when no data
 static void read_conn(struct mg_connection *c) {
@@ -7525,7 +7537,7 @@ static void read_conn(struct mg_connection *c) {
       // Do not read to the raw TLS buffer if it already has enough.
       // This is to prevent overflowing c->rtls if our reads are slow
       if (c->rtls.len < 16 * 1024 + 40) {  // TLS record, header, MAC, padding
-        if (!ioalloc(c, &c->rtls)) return;
+        if (!tlsioalloc(c, &c->rtls)) return;
         n = recv_raw(c, (char *) &c->rtls.buf[c->rtls.len],
                      c->rtls.size - c->rtls.len);
         if (n == MG_IO_ERR && c->rtls.len == 0) {
@@ -9905,10 +9917,15 @@ static int mg_tls_recv_record(struct mg_connection *c) {
 #endif
   r = msgsz - 16 - 1;
   tls->content_type = msg[msgsz - 16 - 1];
-  tls->recv.buf = msg;
+  tls->recv.buf = msg;  // this is pointing into an iobuf that can be freed
   tls->recv.size = tls->recv.len = msgsz - 16 - 1;
   c->is_client ? tls->enc.sseq++ : tls->enc.cseq++;
   return r;
+}
+
+void mg_tls_ioremap(struct mg_connection *c, size_t offset) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  if (tls->recv.buf != NULL) tls->recv.buf += offset;
 }
 
 static void mg_tls_calc_cert_verify_hash(struct mg_connection *c,

--- a/src/tls_builtin.c
+++ b/src/tls_builtin.c
@@ -477,7 +477,10 @@ static int mg_tls_recv_record(struct mg_connection *c) {
 
 void mg_tls_ioremap(struct mg_connection *c, size_t offset) {
   struct tls_data *tls = (struct tls_data *) c->tls;
-  if (tls->recv.buf != NULL) tls->recv.buf += offset;
+  if (tls->recv.buf != NULL) {
+    size_t newptr = ((size_t) tls->recv.buf) + offset;
+    tls->recv.buf = (unsigned char *) newptr;
+  }
 }
 
 static void mg_tls_calc_cert_verify_hash(struct mg_connection *c,

--- a/src/tls_builtin.c
+++ b/src/tls_builtin.c
@@ -469,10 +469,15 @@ static int mg_tls_recv_record(struct mg_connection *c) {
 #endif
   r = msgsz - 16 - 1;
   tls->content_type = msg[msgsz - 16 - 1];
-  tls->recv.buf = msg;
+  tls->recv.buf = msg;  // this is pointing into an iobuf that can be freed
   tls->recv.size = tls->recv.len = msgsz - 16 - 1;
   c->is_client ? tls->enc.sseq++ : tls->enc.cseq++;
   return r;
+}
+
+void mg_tls_ioremap(struct mg_connection *c, size_t offset) {
+  struct tls_data *tls = (struct tls_data *) c->tls;
+  if (tls->recv.buf != NULL) tls->recv.buf += offset;
 }
 
 static void mg_tls_calc_cert_verify_hash(struct mg_connection *c,


### PR DESCRIPTION
When receiving more than 1 TLS record, that is content > 16K, data is buffered in rtls until a full record is received. This buffer grows at MG_IO_SIZE units when needed.
At this point, our built-in TLS marks a record has been found and holds a pointer to rtls stored in tls->recv. It decrypts and transfers to recv MG_IO_SIZE units.
As more data arrives, rtls is resized again, been freed and re-alloc'ed. But our built-in TLS still has a pointer to the freed content.
This works as long as the content stays there, but eventually triggers some complex failure mechanism.

This PR adds a remap function so our built-in TLS is able to remap its buffer pointers when the actual buffer changes, keeping opaque sections that way.