### PR TITLE
fix stack trashing

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -9886,9 +9886,14 @@ static int mg_tls_recv_record(struct mg_connection *c) {
   nonce[10] ^= (uint8_t) ((seq >> 8) & 255U);
   nonce[11] ^= (uint8_t) ((seq) & 255U);
 #if CHACHA20
-  uint8_t dec[8192];
+  uint8_t *dec = (uint8_t *) malloc(msgsz);
+  if (dec == NULL) {
+    mg_error(c, "TLS OOM");
+    return -1;
+  }
   size_t n = mg_chacha20_poly1305_decrypt(dec, key, nonce, msg, msgsz);
   memmove(msg, dec, n);
+  free(dec);
 #else
   mg_aes_gcm_decrypt(msg, msg, msgsz - 16, key, 16, nonce, sizeof(nonce));
 #endif

--- a/src/tls_builtin.c
+++ b/src/tls_builtin.c
@@ -456,9 +456,14 @@ static int mg_tls_recv_record(struct mg_connection *c) {
   nonce[10] ^= (uint8_t) ((seq >> 8) & 255U);
   nonce[11] ^= (uint8_t) ((seq) & 255U);
 #if CHACHA20
-  uint8_t dec[8192];
+  uint8_t *dec = (uint8_t *) malloc(msgsz);
+  if (dec == NULL) {
+    mg_error(c, "TLS OOM");
+    return -1;
+  }
   size_t n = mg_chacha20_poly1305_decrypt(dec, key, nonce, msg, msgsz);
   memmove(msg, dec, n);
+  free(dec);
 #else
   mg_aes_gcm_decrypt(msg, msg, msgsz - 16, key, 16, nonce, sizeof(nonce));
 #endif


### PR DESCRIPTION
CHACHA20 buffering code reserves 8KB stack space for temporary decryption room.
This is not enough, as messages can be above 16K when receiving files above that size.

This PR removes that stack strain (our docs instruct to have an 8KB stack space and these wouldn't be enough when using our built-in TLS) and places it on the heap, allocating as much as needed for that particular message size.