### PR TITLE
Patch KSZ PHY for NXP

### DIFF
--- a/examples/nxp/rt1060-evk-make-baremetal-builtin/hal.h
+++ b/examples/nxp/rt1060-evk-make-baremetal-builtin/hal.h
@@ -285,7 +285,7 @@ static inline void ethernet_init(void) {
                   GPIO_SPEED_HIGH, GPIO_PULL_UP);
   gpio_mux_config(kIOMUXC_SW_MUX_CTL_PAD_GPIO_B1_11, 3);  // set for RXERR
   periph_mux_config(kIOMUXC_ENET_RXERR_SELECT_INPUT,
-                    1);  // drive peripheral from B0_12
+                    1);  // drive peripheral from B1_11
   gpio_pad_config(kIOMUXC_SW_PAD_CTL_PAD_GPIO_B1_11, GPIO_OTYPE_PUSH_PULL,
                   GPIO_SPEED_HIGH, GPIO_PULL_UP);
   gpio_mux_config(kIOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_40, 4);  // set for MDC

--- a/examples/nxp/rt1060-evk-make-freertos-builtin/hal.h
+++ b/examples/nxp/rt1060-evk-make-freertos-builtin/hal.h
@@ -285,7 +285,7 @@ static inline void ethernet_init(void) {
                   GPIO_SPEED_HIGH, GPIO_PULL_UP);
   gpio_mux_config(kIOMUXC_SW_MUX_CTL_PAD_GPIO_B1_11, 3);  // set for RXERR
   periph_mux_config(kIOMUXC_ENET_RXERR_SELECT_INPUT,
-                    1);  // drive peripheral from B0_12
+                    1);  // drive peripheral from B1_11
   gpio_pad_config(kIOMUXC_SW_PAD_CTL_PAD_GPIO_B1_11, GPIO_OTYPE_PUSH_PULL,
                   GPIO_SPEED_HIGH, GPIO_PULL_UP);
   gpio_mux_config(kIOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_40, 4);  // set for MDC

--- a/mongoose.c
+++ b/mongoose.c
@@ -17174,7 +17174,7 @@ void mg_phy_init(struct mg_phy *phy, uint8_t phy_addr, uint8_t config) {
   MG_INFO(("PHY ID: %#04x %#04x (%s)", id1, id2, mg_phy_id_to_str(id1, id2)));
 
   if (id1 == MG_PHY_DP83x && id2 == MG_PHY_DP83867) {
-    phy->write_reg(phy_addr, 0x0d, 0x1f);    // write 0x10d to IO_MUX_CFG (0x0170)
+    phy->write_reg(phy_addr, 0x0d, 0x1f);  // write 0x10d to IO_MUX_CFG (0x0170)
     phy->write_reg(phy_addr, 0x0e, 0x170);
     phy->write_reg(phy_addr, 0x0d, 0x401f);
     phy->write_reg(phy_addr, 0x0e, 0x10d);
@@ -17188,6 +17188,9 @@ void mg_phy_init(struct mg_phy *phy, uint8_t phy_addr, uint8_t config) {
     if (id1 == MG_PHY_DP83x && id2 != MG_PHY_DP83867) {
       phy->write_reg(phy_addr, MG_PHY_DP83x_REG_RCSR, MG_BIT(7) | MG_BIT(0));
     } else if (id1 == MG_PHY_KSZ8x) {
+      phy->write_reg(
+          phy_addr, MG_PHY_REG_BCR,  // Disable isolation (override hw)
+          phy->read_reg(phy_addr, MG_PHY_REG_BCR) & (uint16_t) ~MG_BIT(10));
       phy->write_reg(phy_addr, MG_PHY_KSZ8x_REG_PC2R,
                      MG_BIT(15) | MG_BIT(8) | MG_BIT(7));
     } else if (id1 == MG_PHY_LAN87x) {

--- a/src/drivers/phy.c
+++ b/src/drivers/phy.c
@@ -56,7 +56,7 @@ void mg_phy_init(struct mg_phy *phy, uint8_t phy_addr, uint8_t config) {
   MG_INFO(("PHY ID: %#04x %#04x (%s)", id1, id2, mg_phy_id_to_str(id1, id2)));
 
   if (id1 == MG_PHY_DP83x && id2 == MG_PHY_DP83867) {
-    phy->write_reg(phy_addr, 0x0d, 0x1f);    // write 0x10d to IO_MUX_CFG (0x0170)
+    phy->write_reg(phy_addr, 0x0d, 0x1f);  // write 0x10d to IO_MUX_CFG (0x0170)
     phy->write_reg(phy_addr, 0x0e, 0x170);
     phy->write_reg(phy_addr, 0x0d, 0x401f);
     phy->write_reg(phy_addr, 0x0e, 0x10d);
@@ -70,6 +70,9 @@ void mg_phy_init(struct mg_phy *phy, uint8_t phy_addr, uint8_t config) {
     if (id1 == MG_PHY_DP83x && id2 != MG_PHY_DP83867) {
       phy->write_reg(phy_addr, MG_PHY_DP83x_REG_RCSR, MG_BIT(7) | MG_BIT(0));
     } else if (id1 == MG_PHY_KSZ8x) {
+      phy->write_reg(
+          phy_addr, MG_PHY_REG_BCR,  // Disable isolation (override hw)
+          phy->read_reg(phy_addr, MG_PHY_REG_BCR) & (uint16_t) ~MG_BIT(10));
       phy->write_reg(phy_addr, MG_PHY_KSZ8x_REG_PC2R,
                      MG_BIT(15) | MG_BIT(8) | MG_BIT(7));
     } else if (id1 == MG_PHY_LAN87x) {


### PR DESCRIPTION
These PHYs have a strap to set the default value for the ISO (isolation) bit in the control register.
NXP documentation says default is to disable, but a closer look at the schematics reveals it is not. The respective pin is pulled-up, in spite of the text saying it defaults to pull-down.

This has been opaqued while we did not respect hw defaults (how the end user has designed the board to be strapped). Since this bit is useless to keep set, this PR overrides that setting

Unrelated fixes in comments also included