### PR TITLE
Add the ability to force/override mime content type.

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -522,7 +522,7 @@ static struct mg_str s_known_types[] = {
 
 static struct mg_str guess_content_type(struct mg_str path, const char *extra) {
   // Force mime content type.
-  if(extra != NULL && extra[0] == '\\') {
+  if(extra[0] == '\\') {
     // empty override string is empty so just fall back to default
     if(extra[1] == '\0') {
       return mg_str("text/plain; charset=utf-8");
@@ -598,12 +598,11 @@ void mg_http_serve_file(struct mg_connection *c, struct mg_http_message *hm,
   if (fd == NULL && opts->page404 != NULL) {
     fd = mg_fs_open(fs, opts->page404, MG_FS_READ);
     path = opts->page404;
-    // Don't use override mime type for 404.
-    const char* mime_list = opts->mime_types;
-    if(mime_list != NULL && mime_list[0] == '\\') {
-      mime_list = "";
-    }
-    mime = guess_content_type(mg_str(path), mime_list);
+    // Don't use over-ride mime type for 404.
+    mime = guess_content_type(
+      mg_str(path),
+      opts->mime_types[0] == '\\' ? "" : opts->mime_types
+    );
   }
 
   if (fd == NULL || fs->st(path, &size, &mtime) == 0) {

--- a/src/http.c
+++ b/src/http.c
@@ -521,14 +521,6 @@ static struct mg_str s_known_types[] = {
 // clang-format on
 
 static struct mg_str guess_content_type(struct mg_str path, const char *extra) {
-  // Force mime content type.
-  if(extra[0] == '\\') {
-    // empty override string is empty so just fall back to default
-    if(extra[1] == '\0') {
-      return mg_str("text/plain; charset=utf-8");
-    }
-    return mg_str(extra + 1);
-  }
   struct mg_str entry, k, v, s = mg_str(extra);
   size_t i = 0;
 
@@ -598,11 +590,7 @@ void mg_http_serve_file(struct mg_connection *c, struct mg_http_message *hm,
   if (fd == NULL && opts->page404 != NULL) {
     fd = mg_fs_open(fs, opts->page404, MG_FS_READ);
     path = opts->page404;
-    // Don't use over-ride mime type for 404.
-    mime = guess_content_type(
-      mg_str(path),
-      opts->mime_types[0] == '\\' ? "" : opts->mime_types
-    );
+    mime = guess_content_type(mg_str(path), opts->mime_types);
   }
 
   if (fd == NULL || fs->st(path, &size, &mtime) == 0) {

--- a/src/http.c
+++ b/src/http.c
@@ -521,6 +521,14 @@ static struct mg_str s_known_types[] = {
 // clang-format on
 
 static struct mg_str guess_content_type(struct mg_str path, const char *extra) {
+  // Force mime content type.
+  if(extra[0] == '\\') {
+    // empty override string is empty so just fall back to default
+    if(extra[1] == '\0') {
+      return mg_str("text/plain; charset=utf-8");
+    }
+    return mg_str(extra + 1);
+  }
   struct mg_str entry, k, v, s = mg_str(extra);
   size_t i = 0;
 
@@ -590,7 +598,11 @@ void mg_http_serve_file(struct mg_connection *c, struct mg_http_message *hm,
   if (fd == NULL && opts->page404 != NULL) {
     fd = mg_fs_open(fs, opts->page404, MG_FS_READ);
     path = opts->page404;
-    mime = guess_content_type(mg_str(path), opts->mime_types);
+    // Don't use over-ride mime type for 404.
+    mime = guess_content_type(
+      mg_str(path),
+      opts->mime_types[0] == '\\' ? "" : opts->mime_types
+    );
   }
 
   if (fd == NULL || fs->st(path, &size, &mtime) == 0) {

--- a/src/http.c
+++ b/src/http.c
@@ -522,7 +522,7 @@ static struct mg_str s_known_types[] = {
 
 static struct mg_str guess_content_type(struct mg_str path, const char *extra) {
   // Force mime content type.
-  if(extra[0] == '\\') {
+  if(extra != NULL && extra[0] == '\\') {
     // empty override string is empty so just fall back to default
     if(extra[1] == '\0') {
       return mg_str("text/plain; charset=utf-8");
@@ -598,11 +598,12 @@ void mg_http_serve_file(struct mg_connection *c, struct mg_http_message *hm,
   if (fd == NULL && opts->page404 != NULL) {
     fd = mg_fs_open(fs, opts->page404, MG_FS_READ);
     path = opts->page404;
-    // Don't use over-ride mime type for 404.
-    mime = guess_content_type(
-      mg_str(path),
-      opts->mime_types[0] == '\\' ? "" : opts->mime_types
-    );
+    // Don't use override mime type for 404.
+    const char* mime_list = opts->mime_types;
+    if(mime_list != NULL && mime_list[0] == '\\') {
+      mime_list = "";
+    }
+    mime = guess_content_type(mg_str(path), mime_list);
   }
 
   if (fd == NULL || fs->st(path, &size, &mtime) == 0) {


### PR DESCRIPTION
I needed a way to specify the mime type other than relying file extension for `mg_http_serve_file()`. I am inspecting magic numbers and headers of files before serving them. For example a file with `.jpg` file extension but really is a png when looking at the header and magic numbers. So originally I would just set `opts.mime_types` to like `jpg=image/png` in this case. However, not every file has an extension so this will not always work.

This uses `\` since it is a common escape character. I use it to indicate it is not a list of file extensions and content types, but instead is a mime_type that will be used instead of guessing based off file extension. Also `\` is unlikely to be a legal character for a file name on pretty much most filesystems so it would be extremely unlikely to be the start of a file extension so should not break the current use case of only being a list of extensions.

Then end result is if we go back to my simple example one can just set `opts.mime_types` to `\image/png`. 

I did think about maybe adding a field to `struct mg_http_serve_opts`, however after looking at how much it used in the code and being a part of the API. I figured something that this was less invasive would probably be the best approach. Although, I am all ears to any better suggestion. 

I also did submit a CLA at [https://cesanta.com/cla.html](https://cesanta.com/cla.html).