### PR TITLE
Fix packed_fs being always included

### DIFF
--- a/examples/device-dashboard/Makefile
+++ b/examples/device-dashboard/Makefile
@@ -3,12 +3,18 @@ PACK ?= ./pack          # Packing executable
 DELETE = rm -rf         # Command to remove files
 GZIP ?= gzip            # For compressing files in web_root/
 OUT ?= -o $(PROG)       # Compiler argument for output file
-SOURCES = main.c mongoose.c net.c packed_fs.c   # Source code files
+SOURCES = main.c mongoose.c net.c # Source code files
 CFLAGS = -W -Wall -Wextra -g -I.                # Build options
 NPX ?= npx
+HOSTCC ?= $(CC)         # Build host tools using same compiler by default
 
 # Mongoose build options. See https://mongoose.ws/documentation/#build-options
-CFLAGS_MONGOOSE += -DMG_ENABLE_PACKED_FS=1
+PACKED_FS ?= 1          # Use packed filesystem
+ifeq ($(strip $(PACKED_FS)),1)
+SOURCES += packed_fs.c
+endif
+# Mongoose build options. See https://mongoose.ws/documentation/#build-options
+CFLAGS_MONGOOSE += -DMG_ENABLE_PACKED_FS=$(PACKED_FS)
 
 ifeq ($(OS),Windows_NT)         # Windows settings. Assume MinGW compiler. To use VC: make CC=cl CFLAGS=/MD OUT=/Feprog.exe
   PROG = example.exe            # Use .exe suffix for the binary
@@ -38,7 +44,7 @@ web_root/main.css: web_root/index.html $(wildcard web_root/*.js)
 # Generate packed filesystem for serving Web UI
 packed_fs.c: $(wildcard web_root/*) $(wildcard certs/*) Makefile web_root/main.css web_root/bundle.js
 	$(GZIP) web_root/*
-	$(CC) ../../test/pack.c -o $(PACK)
+	$(HOSTCC) ../../test/pack.c -o $(PACK)
 	$(PACK) web_root/* certs/* > $@
 	$(GZIP) -d web_root/*
 

--- a/examples/device-dashboard/net.c
+++ b/examples/device-dashboard/net.c
@@ -283,11 +283,11 @@ static void fn(struct mg_connection *c, int ev, void *ev_data) {
     } else {
       struct mg_http_serve_opts opts;
       memset(&opts, 0, sizeof(opts));
-#if MG_ARCH == MG_ARCH_UNIX || MG_ARCH == MG_ARCH_WIN32
-      opts.root_dir = "web_root";  // On workstations, use filesystem
-#else
+#if MG_ENABLE_PACKED_FS
       opts.root_dir = "/web_root";  // On embedded, use packed files
       opts.fs = &mg_fs_packed;
+#else
+      opts.root_dir = "web_root";  // On workstations, use filesystem
 #endif
       mg_http_serve_dir(c, ev_data, &opts);
     }


### PR DESCRIPTION
packed_fs is always included in the build of device-dashboard example. If I try to use it on QNX, it does not bring any content to WebServer. Cross-compiling it under Linux also tries to us CC instead of HOSTCC to build _pack_ tool, that is used on the host.