### PR TITLE
H7 dual core OTA fix

### DIFF
--- a/mongoose.h
+++ b/mongoose.h
@@ -2651,7 +2651,8 @@ void mg_rpc_list(struct mg_rpc_req *r);
 #define MG_OTA_NONE 0       // No OTA support
 #define MG_OTA_STM32H5 1    // STM32 H5
 #define MG_OTA_STM32H7 2    // STM32 H7
-#define MG_OTA_STM32F  3    // STM32 F7/F4/F2
+#define MG_OTA_STM32H7_DUAL_CORE 3 // STM32 H7 dual core
+#define MG_OTA_STM32F  4    // STM32 F7/F4/F2
 #define MG_OTA_CH32V307 100 // WCH CH32V307
 #define MG_OTA_U2A 200      // Renesas U2A16, U2A8, U2A6
 #define MG_OTA_RT1020 300   // IMXRT1020

--- a/src/ota.h
+++ b/src/ota.h
@@ -8,7 +8,8 @@
 #define MG_OTA_NONE 0       // No OTA support
 #define MG_OTA_STM32H5 1    // STM32 H5
 #define MG_OTA_STM32H7 2    // STM32 H7
-#define MG_OTA_STM32F  3    // STM32 F7/F4/F2
+#define MG_OTA_STM32H7_DUAL_CORE 3 // STM32 H7 dual core
+#define MG_OTA_STM32F  4    // STM32 F7/F4/F2
 #define MG_OTA_CH32V307 100 // WCH CH32V307
 #define MG_OTA_U2A 200      // Renesas U2A16, U2A8, U2A6
 #define MG_OTA_RT1020 300   // IMXRT1020

--- a/src/ota_stm32h7.c
+++ b/src/ota_stm32h7.c
@@ -2,7 +2,7 @@
 #include "log.h"
 #include "ota.h"
 
-#if MG_OTA == MG_OTA_STM32H7
+#if MG_OTA == MG_OTA_STM32H7 || MG_OTA == MG_OTA_STM32H7_DUAL_CORE
 
 // - H723/735 RM 4.3.3: Note: The application can simultaneously request a read
 // and a write operation through the AXI interface.
@@ -35,7 +35,15 @@ static struct mg_flash s_mg_flash_stm32h7 = {
 #define FLASH_OPTSR_PRG 0x20
 #define FLASH_SIZE_REG 0x1ff1e880
 
+#define IS_DUALCORE() (MG_OTA == MG_OTA_STM32H7_DUAL_CORE)
+
 MG_IRAM static bool is_dualbank(void) {
+  if (IS_DUALCORE()) {
+    // H745/H755 and H747/H757 are running on dual core.
+    // Using only the 1st bank (mapped to CM7), in order not to interfere
+    // with the 2nd bank (CM4), possibly causing CM4 to boot unexpectedly.
+    return false;
+  }
   return (s_mg_flash_stm32h7.size < 2 * 1024 * 1024) ? false : true;
 }
 
@@ -172,6 +180,10 @@ MG_IRAM static void single_bank_swap(char *p1, char *p2, size_t s, size_t ss) {
 
 bool mg_ota_begin(size_t new_firmware_size) {
   s_mg_flash_stm32h7.size = MG_REG(FLASH_SIZE_REG) * 1024;
+  if (IS_DUALCORE()) {
+    // Using only the 1st bank (mapped to CM7)
+    s_mg_flash_stm32h7.size /= 2;
+  }
   return mg_ota_flash_begin(new_firmware_size, &s_mg_flash_stm32h7);
 }
 


### PR DESCRIPTION
I encountered an issue while testing that prevented OTA from working properly on dual core H7 devices (H755 and H745).

These devices normally boot from both cores. CM4 requires by default a firmware at address 0x08100000 and CM7 requires a firmware at address 0x08000000.

The issue is we are using address 0x08100000 to store the new firmware, which means that after the next reset, both cores will start executing their corresponding firmwares. I noticed this always leads to a crash and the board gets bricked after this...

I put up a fix to disable CM4 from executing before resetting.