### PR TITLE
Fix issuing 411 responses as a client

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -2417,8 +2417,8 @@ static void http_cb(struct mg_connection *c, int ev, void *ev_data) {
           require_content_len = status >= 200 && status != 204 && status != 304;
         }
         if (require_content_len) {
-          mg_http_reply(c, 411, "", "");
-          MG_ERROR(("%s", "Content length missing from request"));
+          if (!c->is_client) mg_http_reply(c, 411, "", "");
+          MG_ERROR(("Content length missing from %s", is_response ? "response" : "request"));
         }
       }
 

--- a/src/http.c
+++ b/src/http.c
@@ -1059,8 +1059,8 @@ static void http_cb(struct mg_connection *c, int ev, void *ev_data) {
           require_content_len = status >= 200 && status != 204 && status != 304;
         }
         if (require_content_len) {
-          mg_http_reply(c, 411, "", "");
-          MG_ERROR(("%s", "Content length missing from request"));
+          if (!c->is_client) mg_http_reply(c, 411, "", "");
+          MG_ERROR(("Content length missing from %s", is_response ? "response" : "request"));
         }
       }
 


### PR DESCRIPTION
15.5.12. 411 Length Required

The 411 (Length Required) status code indicates that **the server** refuses to accept the request without a defined Content-Length (Section 8.6). The client MAY repeat the request if it adds a valid Content-Length header field containing the length of the request content.

fixes #2969