### PR TITLE
fix built-in TLS not calling MG_EV_TLS_HS; uniformize mg_tls_init()

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -11154,6 +11154,7 @@ static void mg_tls_client_handshake(struct mg_connection *c) {
       }
       tls->state = MG_TLS_STATE_CLIENT_CONNECTED;
       c->is_tls_hs = 0;
+      mg_call(c, MG_EV_TLS_HS, NULL);
       break;
     default:
       mg_error(c, "unexpected client state: %d", tls->state);
@@ -12912,9 +12913,6 @@ void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
   c->is_tls_hs = 1;
   mbedtls_ssl_set_bio(&tls->ssl, c, mg_net_send, mg_net_recv, 0);
   MG_PROF_ADD(c, "mbedtls_init_end");
-  if (c->is_client && c->is_resolving == 0 && c->is_connecting == 0) {
-    mg_tls_handshake(c);
-  }
   return;
 fail:
   mg_tls_free(c);
@@ -13212,9 +13210,6 @@ void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
 
   c->is_tls = 1;
   c->is_tls_hs = 1;
-  if (c->is_client && c->is_resolving == 0 && c->is_connecting == 0) {
-    mg_tls_handshake(c);
-  }
   MG_DEBUG(("%lu SSL %s OK", c->id, c->is_accepted ? "accept" : "client"));
   return;
 fail:

--- a/src/tls_builtin.c
+++ b/src/tls_builtin.c
@@ -1193,6 +1193,7 @@ static void mg_tls_client_handshake(struct mg_connection *c) {
       }
       tls->state = MG_TLS_STATE_CLIENT_CONNECTED;
       c->is_tls_hs = 0;
+      mg_call(c, MG_EV_TLS_HS, NULL);
       break;
     default:
       mg_error(c, "unexpected client state: %d", tls->state);

--- a/src/tls_mbed.c
+++ b/src/tls_mbed.c
@@ -164,9 +164,6 @@ void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
   c->is_tls_hs = 1;
   mbedtls_ssl_set_bio(&tls->ssl, c, mg_net_send, mg_net_recv, 0);
   MG_PROF_ADD(c, "mbedtls_init_end");
-  if (c->is_client && c->is_resolving == 0 && c->is_connecting == 0) {
-    mg_tls_handshake(c);
-  }
   return;
 fail:
   mg_tls_free(c);

--- a/src/tls_openssl.c
+++ b/src/tls_openssl.c
@@ -229,9 +229,6 @@ void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
 
   c->is_tls = 1;
   c->is_tls_hs = 1;
-  if (c->is_client && c->is_resolving == 0 && c->is_connecting == 0) {
-    mg_tls_handshake(c);
-  }
   MG_DEBUG(("%lu SSL %s OK", c->id, c->is_accepted ? "accept" : "client"));
   return;
 fail:

--- a/tutorials/smtp/smtp-client/main.c
+++ b/tutorials/smtp/smtp-client/main.c
@@ -31,6 +31,7 @@ static void fn(struct mg_connection *c, int ev, void *ev_data) {
         struct mg_tls_opts opts = {.ca = mg_unpacked("/certs/ca.pem"),
                                    .name = mg_url_host(server)};
         mg_tls_init(c, &opts);
+        mg_tls_handshake(c);  // speed up, not strictly necessary
         *state = AUTH;
       } else if (*state == AUTH) {
         char a[100], b[300] = "";


### PR DESCRIPTION
`mg_tls_handshake()` from built-in TLS was not firing the `MG_EV_TLS_HS` event; the SMTP example was not working because of this. Fixed

We seem to have leftovers from our attempt to make TLS start automagically:
`mg_tls_init()` in both MbedTLS and OpenSSL had `if (c->is_client && c->is_resolving == 0 && c->is_connecting == 0) mg_tls_handshake(c);`. Built.in TLS did not do this. Obviously c->is_resolving = 0 and c->is_connecting = 0 at client connect, when mg_tls_init() is called. Besides that, connect_conn and its MIP equivalent call mg_tls_handshake(c) right after the event call to EV_CONNECT returns.
Removed