### PR TITLE
fix UB and possible exception trigger

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -4731,7 +4731,7 @@ static void handle_tls_recv(struct mg_connection *c) {
     mg_error(c, "oom");
   } else {
     // Decrypt data directly into c->recv
-    long n = mg_tls_recv(c, &io->buf[io->len], io->size - io->len);
+    long n = mg_tls_recv(c, io->buf != NULL ? &io->buf[io->len] : io->buf, io->size - io->len);
     if (n == MG_IO_ERR) {
       mg_error(c, "TLS recv error");
     } else if (n > 0) {
@@ -11341,6 +11341,7 @@ long mg_tls_recv(struct mg_connection *c, void *buf, size_t len) {
     mg_tls_drop_record(c);
     return MG_IO_WAIT;
   }
+  if (buf == NULL || len == 0) return 0L;
   minlen = len < tls->recv_len ? len : tls->recv_len;
   memmove(buf, recv_buf, minlen);
   tls->recv_offset += minlen;

--- a/src/net_builtin.c
+++ b/src/net_builtin.c
@@ -651,7 +651,7 @@ static void handle_tls_recv(struct mg_connection *c) {
     mg_error(c, "oom");
   } else {
     // Decrypt data directly into c->recv
-    long n = mg_tls_recv(c, &io->buf[io->len], io->size - io->len);
+    long n = mg_tls_recv(c, io->buf != NULL ? &io->buf[io->len] : io->buf, io->size - io->len);
     if (n == MG_IO_ERR) {
       mg_error(c, "TLS recv error");
     } else if (n > 0) {

--- a/src/tls_builtin.c
+++ b/src/tls_builtin.c
@@ -1380,6 +1380,7 @@ long mg_tls_recv(struct mg_connection *c, void *buf, size_t len) {
     mg_tls_drop_record(c);
     return MG_IO_WAIT;
   }
+  if (buf == NULL || len == 0) return 0L;
   minlen = len < tls->recv_len ? len : tls->recv_len;
   memmove(buf, recv_buf, minlen);
   tls->recv_offset += minlen;


### PR DESCRIPTION
ASAN was reporting undefined behaviour (UB).
```
src/net_builtin.c:655:37: runtime error: applying zero offset to null pointer
```
Weird as it seems, `&io->buf[io->len]` is UB in C and in C++ < C++17 for a NULL pointer, even if the offset is 0. This condition happens at TLS receive start time, when TLS has not yet decrypted any record and hence no iobuf has been created for decrypted data.

Once this is fixed by eliminating the offset when the pointer is NULL, then the first time a record gets decrypted there is no buffer to hold data, it will be created at the next loop. when `mg_tls_avail()` will be called. We then pass a NULL destination pointer to `memmove()`, which, even though len is 0, will violate the specs and trigger ASAN again
```
src/tls_builtin.c:1385:11: runtime error: null pointer passed as argument 1, which is declared to never be null
/usr/include/string.h:48:14: note: nonnull attribute specified here
```
 So, now we just return 0 when either the buffer pointer is NULL or buffer length is 0