### PR TITLE
Adds application/wasm to the list of known MIME types.

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -1888,6 +1888,7 @@ static struct mg_str s_known_types[] = {
     MG_C_STR("webp"), MG_C_STR("image/webp"),
     MG_C_STR("zip"), MG_C_STR("application/zip"),
     MG_C_STR("3gp"), MG_C_STR("video/3gpp"),
+    MG_C_STR("wasm"), MG_C_STR("application/wasm"),
     {0, 0},
 };
 // clang-format on

--- a/src/http.c
+++ b/src/http.c
@@ -529,6 +529,7 @@ static struct mg_str s_known_types[] = {
     MG_C_STR("webp"), MG_C_STR("image/webp"),
     MG_C_STR("zip"), MG_C_STR("application/zip"),
     MG_C_STR("3gp"), MG_C_STR("video/3gpp"),
+    MG_C_STR("wasm"), MG_C_STR("application/wasm"),
     {0, 0},
 };
 // clang-format on


### PR DESCRIPTION
As the title says, this basically adds support to mongoose to serve up WebAssembly files.