### PR TITLE
workaround causing TLS libs to return zero

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -13619,6 +13619,7 @@ size_t mg_tls_pending(struct mg_connection *c) {
 long mg_tls_recv(struct mg_connection *c, void *buf, size_t len) {
   struct mg_tls *tls = (struct mg_tls *) c->tls;
   long n = mbedtls_ssl_read(&tls->ssl, (unsigned char *) buf, len);
+  if (!c->is_tls_hs && buf == NULL && n == 0) return 0; // TODO(): MIP
   if (n == MBEDTLS_ERR_SSL_WANT_READ || n == MBEDTLS_ERR_SSL_WANT_WRITE)
     return MG_IO_WAIT;
 #if defined(MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET)
@@ -13937,6 +13938,7 @@ size_t mg_tls_pending(struct mg_connection *c) {
 long mg_tls_recv(struct mg_connection *c, void *buf, size_t len) {
   struct mg_tls *tls = (struct mg_tls *) c->tls;
   int n = SSL_read(tls->ssl, buf, (int) len);
+  if (!c->is_tls_hs && buf == NULL && n == 0) return 0; // TODO(): MIP
   if (n < 0 && mg_tls_err(c, tls, n) == 0) return MG_IO_WAIT;
   if (n <= 0) return MG_IO_ERR;
   return n;

--- a/src/tls_mbed.c
+++ b/src/tls_mbed.c
@@ -177,6 +177,7 @@ size_t mg_tls_pending(struct mg_connection *c) {
 long mg_tls_recv(struct mg_connection *c, void *buf, size_t len) {
   struct mg_tls *tls = (struct mg_tls *) c->tls;
   long n = mbedtls_ssl_read(&tls->ssl, (unsigned char *) buf, len);
+  if (!c->is_tls_hs && buf == NULL && n == 0) return 0; // TODO(): MIP
   if (n == MBEDTLS_ERR_SSL_WANT_READ || n == MBEDTLS_ERR_SSL_WANT_WRITE)
     return MG_IO_WAIT;
 #if defined(MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET)

--- a/src/tls_openssl.c
+++ b/src/tls_openssl.c
@@ -256,6 +256,7 @@ size_t mg_tls_pending(struct mg_connection *c) {
 long mg_tls_recv(struct mg_connection *c, void *buf, size_t len) {
   struct mg_tls *tls = (struct mg_tls *) c->tls;
   int n = SSL_read(tls->ssl, buf, (int) len);
+  if (!c->is_tls_hs && buf == NULL && n == 0) return 0; // TODO(): MIP
   if (n < 0 && mg_tls_err(c, tls, n) == 0) return MG_IO_WAIT;
   if (n <= 0) return MG_IO_ERR;
   return n;


### PR DESCRIPTION
Closes #3098 

The MIP "buffer bootstrap" process causes a call to TLS functions (MbedTLS, OpenSSL) with NULL destination pointer and zero length. The intention is to pull data to start the process and have some data to size the initial buffer.
This causes these functions to return 0, thing that is correctly detected as an error condition (as per their doc, zero is an error condition) and the connection gets closed.

This PR provides a workaround for that, by catching this condition and returning 0 instead.