### PR TITLE
Fixed mdns bind issue on windows

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -461,8 +461,13 @@ static void mdns_cb(struct mg_connection *c, int ev, void *ev_data) {
 
 void mg_multicast_add(struct mg_connection *c, char *ip);
 struct mg_connection *mg_mdns_listen(struct mg_mgr *mgr, char *name) {
+#if MG_ARCH == MG_ARCH_WIN32
+  const char *mcast_url = "udp://0.0.0.0:5353";
+#else
+  const char *mcast_url = "udp://224.0.0.251:5353";
+#endif
   struct mg_connection *c =
-      mg_listen(mgr, "udp://224.0.0.251:5353", mdns_cb, name);
+      mg_listen(mgr, mcast_url, mdns_cb, name);
   if (c != NULL) mg_multicast_add(c, (char *)"224.0.0.251");
   return c;
 }
@@ -8418,27 +8423,33 @@ bool mg_open_listener(struct mg_connection *c, const char *url) {
     int rc, on = 1, af = c->loc.is_ip6 ? AF_INET6 : AF_INET;
     int type = strncmp(url, "udp:", 4) == 0 ? SOCK_DGRAM : SOCK_STREAM;
     int proto = type == SOCK_DGRAM ? IPPROTO_UDP : IPPROTO_TCP;
+    int sockopt = -1;
     (void) on;
+
+#if defined(SO_EXCLUSIVEADDRUSE)
+    // Using SO_REUSEADDR for UDP sockets on Windows (issue #3125)
+    sockopt = proto == IPPROTO_UDP ? SO_REUSEADDR : SO_EXCLUSIVEADDRUSE;
+    // "Using SO_REUSEADDR and SO_EXCLUSIVEADDRUSE"
+#elif defined(SO_REUSEADDR) && (!defined(LWIP_SOCKET) || SO_REUSE)
+    sockopt = SO_REUSEADDR;
+    // 1. SO_REUSEADDR semantics on UNIX and Windows is different.  On
+    // Windows, SO_REUSEADDR allows to bind a socket to a port without error
+    // even if the port is already open by another program. This is not the
+    // behavior SO_REUSEADDR was designed for, and leads to hard-to-track
+    // failure scenarios.
+    //
+    // 2. For LWIP, SO_REUSEADDR should be explicitly enabled by defining
+    // SO_REUSE = 1 in lwipopts.h, otherwise the code below will compile but
+    // won't work! (setsockopt will return EINVAL)
+#endif
 
     if ((fd = socket(af, type, proto)) == MG_INVALID_SOCKET) {
       MG_ERROR(("socket: %d", MG_SOCK_ERR(-1)));
-#if defined(SO_EXCLUSIVEADDRUSE)
-    } else if ((rc = setsockopt(fd, SOL_SOCKET, SO_EXCLUSIVEADDRUSE,
+    } else if ((sockopt != -1) && (rc = setsockopt(fd, SOL_SOCKET, sockopt,
                                 (char *) &on, sizeof(on))) != 0) {
-      // "Using SO_REUSEADDR and SO_EXCLUSIVEADDRUSE"
+#if defined(SO_EXCLUSIVEADDRUSE)
       MG_ERROR(("setsockopt(SO_EXCLUSIVEADDRUSE): %d %d", on, MG_SOCK_ERR(rc)));
-#elif defined(SO_REUSEADDR) && (!defined(LWIP_SOCKET) || SO_REUSE)
-    } else if ((rc = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char *) &on,
-                                sizeof(on))) != 0) {
-      // 1. SO_REUSEADDR semantics on UNIX and Windows is different.  On
-      // Windows, SO_REUSEADDR allows to bind a socket to a port without error
-      // even if the port is already open by another program. This is not the
-      // behavior SO_REUSEADDR was designed for, and leads to hard-to-track
-      // failure scenarios.
-      //
-      // 2. For LWIP, SO_REUSEADDR should be explicitly enabled by defining
-      // SO_REUSE = 1 in lwipopts.h, otherwise the code below will compile but
-      // won't work! (setsockopt will return EINVAL)
+#else
       MG_ERROR(("setsockopt(SO_REUSEADDR): %d", MG_SOCK_ERR(rc)));
 #endif
 #if MG_IPV6_V6ONLY

--- a/src/dns.c
+++ b/src/dns.c
@@ -340,8 +340,13 @@ static void mdns_cb(struct mg_connection *c, int ev, void *ev_data) {
 
 void mg_multicast_add(struct mg_connection *c, char *ip);
 struct mg_connection *mg_mdns_listen(struct mg_mgr *mgr, char *name) {
+#if MG_ARCH == MG_ARCH_WIN32
+  const char *mcast_url = "udp://0.0.0.0:5353";
+#else
+  const char *mcast_url = "udp://224.0.0.251:5353";
+#endif
   struct mg_connection *c =
-      mg_listen(mgr, "udp://224.0.0.251:5353", mdns_cb, name);
+      mg_listen(mgr, mcast_url, mdns_cb, name);
   if (c != NULL) mg_multicast_add(c, (char *)"224.0.0.251");
   return c;
 }

--- a/tutorials/udp/mdns-server/main.c
+++ b/tutorials/udp/mdns-server/main.c
@@ -12,6 +12,7 @@ int main(void) {
 
   // Desired name must NOT have any dots in it, nor a domain
   c = mg_mdns_listen(&mgr, "Mongoose");  // Start mDNS server
+  if (!c) return 1;
   // if not using our built-in TCP/IP stack, pass the IP address you want to
   // use as a response, this depends on your underlying TCP/IP stack and number
   // of interfaces available


### PR DESCRIPTION
I added a fix for Windows MDNS issue mentioned in #3125.

1. Using the multicast address 224.0.0.251 for Windows triggers WSAEADDRNOTAVAIL (Cannot assign requested address) when attempting to bind. It appears Windows does not recognize this as valid for the local computer. Therefore, I changed the address to 0.0.0.0 for Windows.

2. Typically there are multiple processes listening on 0.0.0.0:5353, which means that using SO_EXCLUSIVEADDRUSE (as the code logic does prior to this PR in sock.c mg_open_listener) will result in another failure when binding (WSAEADDRINUSE: Address already in use). For this case, I think we should use SO_REUSEADDR for UDP sockets on Windows, even if SO_EXCLUSIVEADDRUSE is defined by the SDK. WDYT?


