### PR TITLE
fix broken TCP closure

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -4338,6 +4338,7 @@ static void settmout(struct mg_connection *c, uint8_t type) {
                : type == MIP_TTYPE_SYN ? MIP_TCP_SYN_MS
                : type == MIP_TTYPE_FIN ? MIP_TCP_FIN_MS
                                        : MIP_TCP_KEEPALIVE_MS;
+  if (s->ttype == MIP_TTYPE_FIN) return; // skip if 3-way closing
   s->timer = ifp->now + n;
   s->ttype = type;
   MG_VERBOSE(("%lu %d -> %llx", c->id, type, s->timer));
@@ -5361,7 +5362,6 @@ void mg_mgr_poll(struct mg_mgr *mgr, int ms) {
     if (s->twclosure &&
         (!c->is_tls || (c->rtls.len == 0 && mg_tls_pending(c) == 0)))
       c->is_closing = 1;
-    if (c->is_draining && c->send.len == 0) c->is_closing = 1;
     if (c->is_closing) close_conn(c);
   }
   (void) ms;

--- a/src/net_builtin.c
+++ b/src/net_builtin.c
@@ -176,6 +176,7 @@ static void settmout(struct mg_connection *c, uint8_t type) {
                : type == MIP_TTYPE_SYN ? MIP_TCP_SYN_MS
                : type == MIP_TTYPE_FIN ? MIP_TCP_FIN_MS
                                        : MIP_TCP_KEEPALIVE_MS;
+  if (s->ttype == MIP_TTYPE_FIN) return; // skip if 3-way closing
   s->timer = ifp->now + n;
   s->ttype = type;
   MG_VERBOSE(("%lu %d -> %llx", c->id, type, s->timer));
@@ -1199,7 +1200,6 @@ void mg_mgr_poll(struct mg_mgr *mgr, int ms) {
     if (s->twclosure &&
         (!c->is_tls || (c->rtls.len == 0 && mg_tls_pending(c) == 0)))
       c->is_closing = 1;
-    if (c->is_draining && c->send.len == 0) c->is_closing = 1;
     if (c->is_closing) close_conn(c);
   }
   (void) ms;


### PR DESCRIPTION
041ec6e broke TLS handling and 3-way closure (see #3009 and 8de9699 (and prior related stuff, for that matter))
The closure logic is fine, the actual problem is that our TCP code is not formally a state machine and some things trigger others when they shouldn't, without us noticing.

In this case, **the uploading host attempted to POST a huge file, we tried to close, sent FIN and started our 3-way closure timer. The uploading host kept sending data, and each segment would incorrectly start an ACK timer, overwriting the FIN timer already in place. When this timer expired, we would ACK that data, so the uploading host would keep sending, and we trying to close, and restarting this until we run out of memory**.

_This fix ignores any attempts to set a new timeout once the FIN timeout has been set, a connection can not "unclose" nor "undo" a closure once it has been initiated._
With this fix in place, the uploading host is only able to fill our TCP window, as expected, but then it stalls powerless. Even if it ignores our FIN, we close the connection without (I hope) breaking anything.

This approach is perhaps cleaner / simpler than checking before requesting a timeout, at every possible place.
Perhaps we should have a state variable and check our actions based on the state we are in.

