### PR TITLE
Fix URIs or header values containing tildes being unparsable.

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -1655,7 +1655,7 @@ static bool vcb(uint8_t c) {
 static size_t clen(const char *s, const char *end) {
   const unsigned char *u = (unsigned char *) s, c = *u;
   long n = (long) (end - s);
-  if (c > ' ' && c < '~') return 1;  // Usual ascii printed char
+  if (c > ' ' && c <= '~') return 1;  // Usual ascii printed char
   if ((c & 0xe0) == 0xc0 && n > 1 && vcb(u[1])) return 2;  // 2-byte UTF8
   if ((c & 0xf0) == 0xe0 && n > 2 && vcb(u[1]) && vcb(u[2])) return 3;
   if ((c & 0xf8) == 0xf0 && n > 3 && vcb(u[1]) && vcb(u[2]) && vcb(u[3]))


### PR DESCRIPTION
Currently if a URL being requested has a tilde in the path, the `clen()` of the tilde will be reported as 0, causing it to stop parsing.

Tildes are valid in URIs and don't have to be [percent-encoded](https://developer.mozilla.org/en-US/docs/Glossary/Percent-encoding). It's less clear to me on whether ~ is a valid symbol in header values, but it doesn't seem like any standards preclude it.