### PR TITLE
flush TLS buffer

### DIFF
--- a/mongoose.h
+++ b/mongoose.h
@@ -2424,6 +2424,7 @@ void mg_tls_free(struct mg_connection *);
 long mg_tls_send(struct mg_connection *, const void *buf, size_t len);
 long mg_tls_recv(struct mg_connection *, void *buf, size_t len);
 size_t mg_tls_pending(struct mg_connection *);
+void mg_tls_flush(struct mg_connection *);
 void mg_tls_handshake(struct mg_connection *);
 
 // Private

--- a/src/net_builtin.c
+++ b/src/net_builtin.c
@@ -1218,6 +1218,7 @@ void mg_mgr_poll(struct mg_mgr *mgr, int ms) {
     if (c->is_tls && (c->rtls.len > 0 || mg_tls_pending(c) > 0))
       handle_tls_recv(c);
     if (can_write(c)) write_conn(c);
+    if (!c->is_listening && c->is_tls && !c->is_tls_hs && c->send.len == 0) mg_tls_flush(c);
     if (c->is_draining && c->send.len == 0 && s->ttype != MIP_TTYPE_FIN)
       init_closure(c);
     // For non-TLS, close immediately upon completing the 3-way closure

--- a/src/sock.c
+++ b/src/sock.c
@@ -734,11 +734,10 @@ void mg_mgr_poll(struct mg_mgr *mgr, int ms) {
       if (c->is_readable) accept_conn(mgr, c);
     } else if (c->is_connecting) {
       if (c->is_readable || c->is_writable) connect_conn(c);
-      //} else if (c->is_tls_hs) {
-      //  if ((c->is_readable || c->is_writable)) mg_tls_handshake(c);
     } else {
       if (c->is_readable) read_conn(c);
       if (c->is_writable) write_conn(c);
+      if (c->is_tls && !c->is_tls_hs && c->send.len == 0) mg_tls_flush(c);
     }
 
     if (c->is_draining && c->send.len == 0) c->is_closing = 1;

--- a/src/tls.h
+++ b/src/tls.h
@@ -28,6 +28,7 @@ void mg_tls_free(struct mg_connection *);
 long mg_tls_send(struct mg_connection *, const void *buf, size_t len);
 long mg_tls_recv(struct mg_connection *, void *buf, size_t len);
 size_t mg_tls_pending(struct mg_connection *);
+void mg_tls_flush(struct mg_connection *);
 void mg_tls_handshake(struct mg_connection *);
 
 // Private

--- a/src/tls_dummy.c
+++ b/src/tls_dummy.c
@@ -21,6 +21,9 @@ size_t mg_tls_pending(struct mg_connection *c) {
   (void) c;
   return 0;
 }
+void mg_tls_flush(struct mg_connection *c) {
+  (void) c;
+}
 void mg_tls_ctx_init(struct mg_mgr *mgr) {
   (void) mgr;
 }

--- a/src/tls_mbed.c
+++ b/src/tls_mbed.c
@@ -204,9 +204,16 @@ long mg_tls_send(struct mg_connection *c, const void *buf, size_t len) {
     tls->throttled_buf = (unsigned char *)buf; // MbedTLS code actually ignores
     tls->throttled_len = len; //  these, but let's play API rules
     return (long) len;  // already encripted that when throttled
-  }
+  } // if last chunk fails to be sent, it needs to be flushed
   if (n <= 0) return MG_IO_ERR;
   return n;
+}
+
+void mg_tls_flush(struct mg_connection *c) {
+  if (c->is_tls_throttled) {
+    long n = mbedtls_ssl_write(&tls->ssl, tls->throttled_buf, tls->throttled_len);
+    c->is_tls_throttled = (n == MBEDTLS_ERR_SSL_WANT_READ || n == MBEDTLS_ERR_SSL_WANT_WRITE);
+  }
 }
 
 void mg_tls_ctx_init(struct mg_mgr *mgr) {

--- a/src/tls_openssl.c
+++ b/src/tls_openssl.c
@@ -270,6 +270,10 @@ long mg_tls_send(struct mg_connection *c, const void *buf, size_t len) {
   return n;
 }
 
+void mg_tls_flush(struct mg_connection *c) {
+  (void) c;
+}
+
 void mg_tls_ctx_init(struct mg_mgr *mgr) {
   (void) mgr;
 }


### PR DESCRIPTION
Follow up to #3143 
- In Mongoose built-in TLS, client handshake sends the FINISH record and clears `is_hs`. This avoids the need for implementing polls. This causes the manager to stop calling the handshake function and call the TLS data transfer function instead. If, for some reason (e.g.: the socket returns IO_WAIT or MSS/window stuff in MIP), this operation does not complete, outstanding data remains in `c->tls->send`. On a typical client, an application request will follow and c->send will be populated and this will trigger sending of that outstanding data. On applications where the server has to greet first, the server will remain waiting for the FINISH record, handshake will not complete, and connection will never establish.
- If the socket layer throttles TLS right at the last data block, `c->send.len = 0`, `is_tls_throttled = 1`, the connection is not ready to write because there is no more app data, so a piece of an encrypted record will stay either in `c->tls->send` or in the MbedTLS internal buffer

This PR adds a flush function to avoid the above situations, calling it when there is an established TLS connection and there is no outstanding application data to be sent. This new function will check if there is outstanding encrypted data and flush it to the transport layer.
