### PR TITLE
Make logs colorful

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3072,11 +3072,12 @@ static void logs(const char *buf, size_t len) {
 // Let user define their own mg_log_prefix() and mg_log()
 #else
 void mg_log_prefix(int level, const char *file, int line, const char *fname) {
+  static const uint8_t color_tag[] = {0, 31, 32, 33, 0};
   const char *p = strrchr(file, '/');
   char buf[41];
   size_t n;
   if (p == NULL) p = strrchr(file, '\\');
-  n = mg_snprintf(buf, sizeof(buf), "%-6llx %d %s:%d:%s", mg_millis(), level,
+  n = mg_snprintf(buf, sizeof(buf), "\033[%dm%-6llx %d %s:%d:%s", color_tag[level], mg_millis(), level,
                   p == NULL ? file : p + 1, line, fname);
   if (n > sizeof(buf) - 2) n = sizeof(buf) - 2;
   while (n < sizeof(buf)) buf[n++] = ' ';
@@ -3088,7 +3089,7 @@ void mg_log(const char *fmt, ...) {
   va_start(ap, fmt);
   mg_vxprintf(s_log_func, s_log_func_param, fmt, &ap);
   va_end(ap);
-  logs("\r\n", 2);
+  logs("\r\n\033[0m", 7);
 }
 #endif
 


### PR DESCRIPTION
Users can redefine their display color in `color_tag` array