### PR TITLE
fix SNTP through proper protocol handler setup

### DIFF
--- a/mongoose.h
+++ b/mongoose.h
@@ -1593,6 +1593,9 @@ bool mg_wakeup(struct mg_mgr *, unsigned long id, const void *buf, size_t len);
 bool mg_wakeup_init(struct mg_mgr *);
 struct mg_timer *mg_timer_add(struct mg_mgr *mgr, uint64_t milliseconds,
                               unsigned flags, void (*fn)(void *), void *arg);
+struct mg_connection *mg_connect_svc(struct mg_mgr *mgr, const char *url,
+                                     mg_event_handler_t fn, void *fn_data,
+                                     mg_event_handler_t pfn, void *pfn_data);
 
 
 

--- a/src/http.c
+++ b/src/http.c
@@ -1148,9 +1148,7 @@ void mg_hello(const char *url) {
 
 struct mg_connection *mg_http_connect(struct mg_mgr *mgr, const char *url,
                                       mg_event_handler_t fn, void *fn_data) {
-  struct mg_connection *c = mg_connect(mgr, url, fn, fn_data);
-  if (c != NULL) c->pfn = http_cb;
-  return c;
+  return mg_connect_svc(mgr, url, fn, fn_data, http_cb, NULL);
 }
 
 struct mg_connection *mg_http_listen(struct mg_mgr *mgr, const char *url,

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -529,12 +529,11 @@ void mg_mqtt_disconnect(struct mg_connection *c,
 struct mg_connection *mg_mqtt_connect(struct mg_mgr *mgr, const char *url,
                                       const struct mg_mqtt_opts *opts,
                                       mg_event_handler_t fn, void *fn_data) {
-  struct mg_connection *c = mg_connect(mgr, url, fn, fn_data);
+  struct mg_connection *c = mg_connect_svc(mgr, url, fn, fn_data, mqtt_cb, NULL);
   if (c != NULL) {
     struct mg_mqtt_opts empty;
     memset(&empty, 0, sizeof(empty));
     mg_mqtt_login(c, opts == NULL ? &empty : opts);
-    c->pfn = mqtt_cb;
   }
   return c;
 }

--- a/src/net.c
+++ b/src/net.c
@@ -156,8 +156,8 @@ void mg_close_conn(struct mg_connection *c) {
   mg_free(c);
 }
 
-struct mg_connection *mg_connect(struct mg_mgr *mgr, const char *url,
-                                 mg_event_handler_t fn, void *fn_data) {
+struct mg_connection *mg_connect_svc(struct mg_mgr *mgr, const char *url,
+                                 mg_event_handler_t fn, void *fn_data, mg_event_handler_t pfn, void *pfn_data) {
   struct mg_connection *c = NULL;
   if (url == NULL || url[0] == '\0') {
     MG_ERROR(("null url"));
@@ -171,11 +171,18 @@ struct mg_connection *mg_connect(struct mg_mgr *mgr, const char *url,
     c->is_client = true;
     c->fn_data = fn_data;
     c->is_tls = (mg_url_is_ssl(url) != 0);
+    c->pfn = pfn;
+    c->pfn_data = pfn_data;
     mg_call(c, MG_EV_OPEN, (void *) url);
     MG_DEBUG(("%lu %ld %s", c->id, c->fd, url));
     mg_resolve(c, url);
   }
   return c;
+}
+
+struct mg_connection *mg_connect(struct mg_mgr *mgr, const char *url,
+                                 mg_event_handler_t fn, void *fn_data) {
+  return mg_connect_svc(mgr, url, fn, fn_data, NULL, NULL);
 }
 
 struct mg_connection *mg_listen(struct mg_mgr *mgr, const char *url,

--- a/src/net.h
+++ b/src/net.h
@@ -105,3 +105,6 @@ bool mg_wakeup(struct mg_mgr *, unsigned long id, const void *buf, size_t len);
 bool mg_wakeup_init(struct mg_mgr *);
 struct mg_timer *mg_timer_add(struct mg_mgr *mgr, uint64_t milliseconds,
                               unsigned flags, void (*fn)(void *), void *arg);
+struct mg_connection *mg_connect_svc(struct mg_mgr *mgr, const char *url,
+                                     mg_event_handler_t fn, void *fn_data,
+                                     mg_event_handler_t pfn, void *pfn_data);

--- a/src/sntp.c
+++ b/src/sntp.c
@@ -82,12 +82,7 @@ void mg_sntp_request(struct mg_connection *c) {
 }
 
 struct mg_connection *mg_sntp_connect(struct mg_mgr *mgr, const char *url,
-                                      mg_event_handler_t fn, void *fnd) {
-  struct mg_connection *c = NULL;
+                                      mg_event_handler_t fn, void *fn_data) {
   if (url == NULL) url = "udp://time.google.com:123";
-  if ((c = mg_connect(mgr, url, fn, fnd)) != NULL) {
-    c->pfn = sntp_cb;
-    sntp_cb(c, MG_EV_OPEN, (void *) url);
-  }
-  return c;
+  return mg_connect_svc(mgr, url, fn, fn_data, sntp_cb, NULL);
 }

--- a/tutorials/udp/sntp-time-sync/main.c
+++ b/tutorials/udp/sntp-time-sync/main.c
@@ -44,8 +44,11 @@ static void sfn(struct mg_connection *c, int ev, void *ev_data) {
 // Called every 5 seconds. Increase that for production case.
 static void timer_fn(void *arg) {
   struct mg_mgr *mgr = (struct mg_mgr *) arg;
-  if (s_sntp_conn == NULL) s_sntp_conn = mg_sntp_connect(mgr, NULL, sfn, NULL);
-  if (s_sntp_conn != NULL) mg_sntp_request(s_sntp_conn);
+  if (s_sntp_conn == NULL) { // connection issues a request
+    s_sntp_conn = mg_sntp_connect(mgr, NULL, sfn, NULL);
+  } else {
+    mg_sntp_request(s_sntp_conn);
+  }
 }
 
 int main(void) {


### PR DESCRIPTION
Fixes #3157

The protocol handler is setup at the same time as the user handler, once the connection structure has been allocated. All events happen to both handlers.
This was masked by TCP nature in MQTT and HTTP handlers, because the socket does not become writable until the connection is established so the first event was firing after we had a chance to init the protocol handler.