### PR TITLE
Built-in TCP/IP (re-)starts DNS connection on DHCP link up

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -353,19 +353,24 @@ static bool mg_dns_send(struct mg_connection *c, const struct mg_str *name,
   return mg_send(c, &pkt, sizeof(pkt.header) + n);
 }
 
+bool mg_dnsc_init(struct mg_mgr *mgr, struct mg_dns *dnsc);
+bool mg_dnsc_init(struct mg_mgr *mgr, struct mg_dns *dnsc) {
+  if (dnsc->url == NULL) {
+    mg_error(0, "DNS server URL is NULL. Call mg_mgr_init()");
+    return false;
+  }
+  if (dnsc->c == NULL) {
+    dnsc->c = mg_connect(mgr, dnsc->url, NULL, NULL);
+    if (dnsc->c == NULL) return false;
+    dnsc->c->pfn = dns_cb;
+  }
+  return true;
+}
+
 static void mg_sendnsreq(struct mg_connection *c, struct mg_str *name, int ms,
                          struct mg_dns *dnsc, bool ipv6) {
   struct dns_data *d = NULL;
-  if (dnsc->url == NULL) {
-    mg_error(c, "DNS server URL is NULL. Call mg_mgr_init()");
-  } else if (dnsc->c == NULL) {
-    dnsc->c = mg_connect(c->mgr, dnsc->url, NULL, NULL);
-    if (dnsc->c != NULL) {
-      dnsc->c->pfn = dns_cb;
-      // dnsc->c->is_hexdumping = 1;
-    }
-  }
-  if (dnsc->c == NULL) {
+  if (!mg_dnsc_init(c->mgr, dnsc)) {
     mg_error(c, "resolver");
   } else if ((d = (struct dns_data *) mg_calloc(1, sizeof(*d))) == NULL) {
     mg_error(c, "resolve OOM");
@@ -466,6 +471,7 @@ struct mg_connection *mg_mdns_listen(struct mg_mgr *mgr, char *name) {
   if (c != NULL) mg_multicast_add(c, (char *)"224.0.0.251");
   return c;
 }
+
 
 #ifdef MG_ENABLE_LINES
 #line 1 "src/event.c"
@@ -4577,6 +4583,8 @@ static void rx_icmp(struct mg_tcpip_if *ifp, struct pkt *pkt) {
   }
 }
 
+static void setdns4(struct mg_tcpip_if *ifp, uint32_t *ip);
+
 static void rx_dhcp_client(struct mg_tcpip_if *ifp, struct pkt *pkt) {
   uint32_t ip = 0, gw = 0, mask = 0, lease = 0, dns = 0, sntp = 0;
   uint8_t msgtype = 0, state = ifp->state;
@@ -4625,8 +4633,10 @@ static void rx_dhcp_client(struct mg_tcpip_if *ifp, struct pkt *pkt) {
       ifp->state = MG_TCPIP_STATE_IP;  // BOUND state
       mg_random(&rand, sizeof(rand));
       srand((unsigned int) (rand + mg_millis()));
-      if (ifp->enable_req_dns && dns != 0)
+      if (ifp->enable_req_dns && dns != 0) {
+        setdns4(ifp, &dns);
         mg_tcpip_call(ifp, MG_TCPIP_EV_DHCP_DNS, &dns);
+      }
       if (ifp->enable_req_sntp && sntp != 0)
         mg_tcpip_call(ifp, MG_TCPIP_EV_DHCP_SNTP, &sntp);
     } else if (ifp->state == MG_TCPIP_STATE_READY && ifp->ip == ip) {  // renew
@@ -5287,6 +5297,7 @@ void mg_tcpip_init(struct mg_mgr *mgr, struct mg_tcpip_if *ifp) {
 void mg_tcpip_free(struct mg_tcpip_if *ifp) {
   mg_free(ifp->recv_queue.buf);
   mg_free(ifp->tx.buf);
+  mg_free(ifp->dns4_url);
 }
 
 static void send_syn(struct mg_connection *c) {
@@ -5451,6 +5462,21 @@ void mg_multicast_add(struct mg_connection *c, char *ip) {
   (void) ip;  // ip4_mcastmac(mcast_mac, &ip);
   // TODO(): actual IP -> MAC; check database, update
   c->mgr->ifp->update_mac_hash_table = true;  // mark dirty
+}
+
+bool mg_dnsc_init(struct mg_mgr *mgr, struct mg_dns *dnsc);
+
+static void setdns4(struct mg_tcpip_if *ifp, uint32_t *ip) {
+  struct mg_dns *dnsc;
+  mg_free(ifp->dns4_url);
+  ifp->dns4_url = mg_mprintf("udp://%M:53", mg_print_ip4, ip);
+  dnsc = &ifp->mgr->dns4;
+  dnsc->url = (const char *) ifp->dns4_url;
+  MG_DEBUG(("Set DNS URL to %s", dnsc->url));
+  if (ifp->mgr->use_dns6) return;
+  if (dnsc->c != NULL) mg_close_conn(dnsc->c);
+  if (!mg_dnsc_init(ifp->mgr, dnsc)) // create DNS connection
+    MG_ERROR(("DNS connection creation failed"));
 }
 
 #endif  // MG_ENABLE_TCPIP
@@ -8600,10 +8626,8 @@ int64_t mg_sntp_parse(const unsigned char *buf, size_t len) {
 static void sntp_cb(struct mg_connection *c, int ev, void *ev_data) {
   uint64_t *expiration_time = (uint64_t *) c->data;
   if (ev == MG_EV_OPEN) {
-    MG_INFO(("%lu PFN OPEN", c->id));
     *expiration_time = mg_millis() + 3000;  // Store expiration time in 3s
   } else if (ev == MG_EV_CONNECT) {
-    MG_INFO(("%lu PFN CONNECT, sending request", c->id));
     mg_sntp_request(c);
   } else if (ev == MG_EV_READ) {
     int64_t milliseconds = mg_sntp_parse(c->recv.buf, c->recv.len);

--- a/mongoose.h
+++ b/mongoose.h
@@ -3003,6 +3003,7 @@ struct mg_tcpip_if {
 
   // Internal state, user can use it but should not change it
   uint8_t gwmac[6];             // Router's MAC
+  char *dns4_url;               // DNS server URL
   uint64_t now;                 // Current time
   uint64_t timer_1000ms;        // 1000 ms timer: for DHCP and link state
   uint64_t lease_expire;        // Lease expiration time, in ms

--- a/src/net_builtin.h
+++ b/src/net_builtin.h
@@ -57,6 +57,7 @@ struct mg_tcpip_if {
 
   // Internal state, user can use it but should not change it
   uint8_t gwmac[6];             // Router's MAC
+  char *dns4_url;               // DNS server URL
   uint64_t now;                 // Current time
   uint64_t timer_1000ms;        // 1000 ms timer: for DHCP and link state
   uint64_t lease_expire;        // Lease expiration time, in ms


### PR DESCRIPTION
Fixes  #3160 

Built-in TCP/IP now creates and manages a DNS URL when receiving a DNS IP from DHCP. Then, it tears down any DNS existing connection and creates a new one; this will fire an ARP lookup in the case of a local DNS, so that won't be necessary when issuing actual DNS queries.
