### PR TITLE
Fix: Use mg_ppp_poll instead of mg_ppp_up in ppp driver

### DIFF
--- a/src/drivers/ppp.c
+++ b/src/drivers/ppp.c
@@ -323,6 +323,6 @@ static size_t mg_ppp_rx(void *ethbuf, size_t ethlen, struct mg_tcpip_if *ifp) {
 }
 
 struct mg_tcpip_driver mg_tcpip_driver_ppp = {mg_ppp_init, mg_ppp_tx, mg_ppp_rx,
-                                              mg_ppp_up};
+                                              mg_ppp_poll};
 
 #endif


### PR DESCRIPTION
This PR fixes a build break introduced by https://github.com/cesanta/mongoose/commit/065027843e52b09a8b5bc8429c1f8ed1da7c10ac