### PR TITLE
fix use of va_args in mg_queue_vprintf, fixes #3285

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -7812,7 +7812,9 @@ bool mg_ota_end(void) {
 
 
 size_t mg_queue_vprintf(struct mg_queue *q, const char *fmt, va_list *ap) {
-  size_t len = mg_snprintf(NULL, 0, fmt, ap);
+  va_list ap_copy;
+  va_copy(ap_copy, *ap);
+  size_t len = mg_vsnprintf(NULL, 0, fmt, &ap_copy);
   char *buf;
   if (len == 0 || mg_queue_book(q, &buf, len + 1) < len + 1) {
     len = 0;  // Nah. Not enough space

--- a/src/printf.c
+++ b/src/printf.c
@@ -3,7 +3,9 @@
 #include "util.h"
 
 size_t mg_queue_vprintf(struct mg_queue *q, const char *fmt, va_list *ap) {
-  size_t len = mg_snprintf(NULL, 0, fmt, ap);
+  va_list ap_copy;
+  va_copy(ap_copy, *ap);
+  size_t len = mg_vsnprintf(NULL, 0, fmt, &ap_copy);
   char *buf;
   if (len == 0 || mg_queue_book(q, &buf, len + 1) < len + 1) {
     len = 0;  // Nah. Not enough space


### PR DESCRIPTION
Implements spec compliant handling of va_args in `mg_queue_vprintf`.

See comments in #3285 for more details