### PR TITLE
fixes for C89 (remove mg_queue_vprintf())

### DIFF
--- a/mongoose.h
+++ b/mongoose.h
@@ -1211,7 +1211,6 @@ size_t mg_vsnprintf(char *buf, size_t len, const char *fmt, va_list *ap);
 size_t mg_snprintf(char *, size_t, const char *fmt, ...);
 char *mg_vmprintf(const char *fmt, va_list *ap);
 char *mg_mprintf(const char *fmt, ...);
-size_t mg_queue_vprintf(struct mg_queue *, const char *fmt, va_list *);
 size_t mg_queue_printf(struct mg_queue *, const char *fmt, ...);
 
 // %M print helper functions

--- a/src/net_builtin.c
+++ b/src/net_builtin.c
@@ -963,7 +963,7 @@ static void rx_ip(struct mg_tcpip_if *ifp, struct pkt *pkt) {
   if ((pkt->ip->ver >> 4) != 4) return;         // Not IP
   ihl = pkt->ip->ver & 0x0F;
   if (ihl < 5) return;                     // bad IHL
-  if (pkt->pay.len < (ihl * 4)) return;    // Truncated / malformed
+  if (pkt->pay.len < (uint16_t)(ihl * 4)) return;    // Truncated / malformed
   // There can be link padding, take length from IP header
   len = mg_ntohs(pkt->ip->len); // IP datagram length
   if (len < (ihl * 4) || len > pkt->pay.len) return; // malformed
@@ -1008,7 +1008,7 @@ static void rx_ip(struct mg_tcpip_if *ifp, struct pkt *pkt) {
     pkt->tcp = (struct tcp *) (pkt->pay.buf);
     if (pkt->pay.len < sizeof(*pkt->tcp)) return;
     off = pkt->tcp->off >> 4;  // account for opts
-    if (pkt->pay.len < (4 * off)) return;
+    if (pkt->pay.len < (uint16_t)(4 * off)) return;
     mkpay(pkt, (uint32_t *) pkt->tcp + off);
     MG_VERBOSE(("TCP %M:%hu -> %M:%hu len %u", mg_print_ip4, &pkt->ip->src,
                 mg_ntohs(pkt->tcp->sport), mg_print_ip4, &pkt->ip->dst,

--- a/src/printf.c
+++ b/src/printf.c
@@ -2,27 +2,19 @@
 #include "fmt.h"
 #include "util.h"
 
-size_t mg_queue_vprintf(struct mg_queue *q, const char *fmt, va_list *ap) {
+size_t mg_queue_printf(struct mg_queue *q, const char *fmt, ...) {
   char *buf;
   size_t len;
-  va_list ap_copy;
-  va_copy(ap_copy, *ap);
-  len = mg_vsnprintf(NULL, 0, fmt, &ap_copy);
-  if (len == 0 || mg_queue_book(q, &buf, len + 1) < len + 1) {
-    len = 0;  // Nah. Not enough space
-  } else {
-    len = mg_vsnprintf((char *) buf, len + 1, fmt, ap);
-    mg_queue_add(q, len);
-  }
-  return len;
-}
-
-size_t mg_queue_printf(struct mg_queue *q, const char *fmt, ...) {
-  va_list ap;
-  size_t len;
-  va_start(ap, fmt);
-  len = mg_queue_vprintf(q, fmt, &ap);
-  va_end(ap);
+  va_list ap1, ap2;
+  va_start(ap1, fmt);
+  len = mg_vsnprintf(NULL, 0, fmt, &ap1);
+  va_end(ap1);
+  if (len == 0 || mg_queue_book(q, &buf, len + 1) < len + 1)
+    return 0;  // Nah. Not enough space
+  va_start(ap2, fmt);
+  len = mg_vsnprintf(buf, len + 1, fmt, &ap2);
+  mg_queue_add(q, len);
+  va_end(ap2);
   return len;
 }
 

--- a/src/printf.h
+++ b/src/printf.h
@@ -9,7 +9,6 @@ size_t mg_vsnprintf(char *buf, size_t len, const char *fmt, va_list *ap);
 size_t mg_snprintf(char *, size_t, const char *fmt, ...);
 char *mg_vmprintf(const char *fmt, va_list *ap);
 char *mg_mprintf(const char *fmt, ...);
-size_t mg_queue_vprintf(struct mg_queue *, const char *fmt, va_list *);
 size_t mg_queue_printf(struct mg_queue *, const char *fmt, ...);
 
 // %M print helper functions

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -2265,6 +2265,15 @@ static void test_str(void) {
   ASSERT(sn("%s ", "a"));
   ASSERT(sn("%s %s", "a", "b"));
   ASSERT(sn("%2s %s", "a", "b"));
+  { // mg_queue_printf()
+	struct mg_queue q;
+	char buf[128];
+	mg_queue_init(&q, buf, sizeof(buf));
+	void *p = (void *) 0xffffffffffffffff;
+	size_t len = mg_queue_printf(&q, "A%p%p%pB", p, p, p);
+  ASSERT(len == 56);
+  ASSERT(memcmp(buf + 4, "A0xffffffffffffffff0xffffffffffffffff0xffffffffffffffffB", 56) == 0);
+  }
 
   // Non-standard formatting
   {


### PR DESCRIPTION
- Remove misc warnings in old compilers
- The fix introduced in #3289 requires C99, as `va_copy()` is not part of the C89 spec and that operation is in itself compiler-dependent.
So, here we remove `size_t mg_queue_vprintf(struct mg_queue *q, const char *fmt, va_list *ap)` and implement its functionality inside `mg_queue_printf()` with two `va_list`s created from the variadic arguments.
