### PR TITLE
Fix #3226: WolfSSL/OpenSSL connections close after handshake with built-in TCP

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -14781,6 +14781,11 @@ void mg_tls_handshake(struct mg_connection *c) {
   if (rc == 1) {
     MG_DEBUG(("%lu success", c->id));
     c->is_tls_hs = 0;
+    // Check if SSL has buffered application data after handshake
+    if (mg_tls_pending(c) > 0) {
+      c->is_readable = 1;
+      MG_DEBUG(("%lu has %lu pending bytes", c->id, mg_tls_pending(c)));
+    }
     mg_call(c, MG_EV_TLS_HS, NULL);
   } else {
     int code = mg_tls_err(c, tls, rc);
@@ -14799,6 +14804,11 @@ long mg_tls_recv(struct mg_connection *c, void *buf, size_t len) {
   if (!c->is_tls_hs && buf == NULL && n == 0) return 0; // TODO(): MIP
   if (n < 0 && mg_tls_err(c, tls, n) == 0) return MG_IO_WAIT;
   if (n <= 0) return MG_IO_ERR;
+  // After successful read, check if more data is buffered
+  if (n > 0 && mg_tls_pending(c) > 0) {
+    c->is_readable = 1;
+    MG_VERBOSE(("%lu still has %lu bytes buffered", c->id, mg_tls_pending(c)));
+  }
   return n;
 }
 


### PR DESCRIPTION
 Summary
Fixes issue #3226 where connections close immediately after TLS handshake when using WolfSSL or OpenSSL with Mongoose's built-in TCP/IP stack (MIP).

 Problem
- TLS handshake completes successfully
- Connection closes immediately after handshake
- No application data is transferred
- HTTP requests never receive responses

 Root Cause
SSL may read and buffer multiple TLS records internally during handshake or read operations. Mongoose was not checking `SSL_pending()` to detect this buffered data, causing the event loop to think the connection was idle and close it prematurely.

 Solution
Added `mg_tls_pending()` checks at two critical points:

1. **After successful handshake** (`mg_tls_handshake`): Check if SSL buffered application data during handshake and set `c->is_readable` to signal the event loop
2. **After successful read** (`mg_tls_recv`): Check if more data remains buffered after `SSL_read()` and keep `c->is_readable` set to continue processing

This ensures the event loop continues processing buffered SSL data even when the underlying socket has no new data available.

 Impact
- Affects both WolfSSL and OpenSSL implementations (both use `src/tls_openssl.c`)
- Resolves connection closure issues with built-in TCP stack
- No changes to API or behavior for standard TCP stack usage

 Testing
- Code compiles successfully with GCC
- Changes follow existing patterns in codebase
- Uses existing `mg_tls_pending()` helper function
- GitHub Actions will run full test suite including `mip_tap_test`

 Files Changed
- `src/tls_openssl.c`: Added SSL_pending() checks
- `mongoose.c`: Amalgamated version auto-updated

Before Fixing:
<img width="1020" height="120" alt="Screenshot 2025-10-14 230608" src="https://github.com/user-attachments/assets/c665b2dc-aa5b-4ed3-b03c-9a97bec2f701" />


After Fixing:
<img width="997" height="722" alt="Screenshot 2025-10-14 233335" src="https://github.com/user-attachments/assets/9f4c9ab7-7ac5-4236-8240-263e45e08b54" />
