### PR TITLE
fix error logs not uploading on test failure

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,8 +41,11 @@ jobs:
       with:
             ssh-private-key: ${{ secrets.HEALTH_TESTS_SSH_KEY }}
     - run: sudo apt -y update ; sudo apt -y install libmbedtls-dev libwolfssl-dev && test/setup_mqtt_server.sh && make -C test ${{ matrix.target }} > log
-    - run: test/health.awk < log > json
-    - run: scp -o "StrictHostKeyChecking=no" json "root@176.9.217.245:/data/downloads/health/linux_${{ matrix.target }}_${{ matrix.cc }}_${{ matrix.ssl }}_${{ matrix.select }}_$(date +"%Y%m%d").json"
+    - if: success() || failure()
+      run: |
+        cat log
+        test/health.awk < log > json
+        scp -o "StrictHostKeyChecking=no" json "root@176.9.217.245:/data/downloads/health/linux_${{ matrix.target }}_${{ matrix.cc }}_${{ matrix.ssl }}_${{ matrix.select }}_$(date +"%Y%m%d").json"
   mip:
     runs-on: ubuntu-latest
     strategy:
@@ -67,8 +70,11 @@ jobs:
       with:
             ssh-private-key: ${{ secrets.HEALTH_TESTS_SSH_KEY }}
     - run: if [ "${{ matrix.target }}" == "mip_tap_test" ]; then ./test/setup_ga_network.sh ; fi && sudo apt -y update ; sudo apt -y install libmbedtls-dev libwolfssl-dev && make -C test ${{ matrix.target }} IPV6=0 > log
-    - run: test/health.awk < log > json
-    - run: scp -o "StrictHostKeyChecking=no" json "root@176.9.217.245:/data/downloads/health/${{ matrix.target }}_${{ matrix.cc }}_${{ matrix.ssl }}_$(date +"%Y%m%d").json"
+    - if: success() || failure()
+      run: |
+        cat log
+        test/health.awk < log > json
+        scp -o "StrictHostKeyChecking=no" json "root@176.9.217.245:/data/downloads/health/${{ matrix.target }}_${{ matrix.cc }}_${{ matrix.ssl }}_$(date +"%Y%m%d").json"
 
   mip89:
     runs-on: ubuntu-latest
@@ -168,8 +174,11 @@ jobs:
     - run: brew install mbedtls wolfssl mosquitto gawk # jq openssl already pre-installed
     - run: /opt/homebrew/opt/mosquitto/sbin/mosquitto -c /Users/runner/work/mongoose/mongoose/test/mosquitto.conf.macos &
     - run: make -C test test ASAN_OPTIONS= MBEDTLS=$(echo $(brew --cellar)/mbedtls*/*) OPENSSL=$(echo $(brew --cellar)/openssl*/*) WOLFSSL=$(echo $(brew --cellar)/wolfssl*/*) > log
-    - run: test/health.awk < log > json
-    - run: scp -o "StrictHostKeyChecking=no" json "root@176.9.217.245:/data/downloads/health/macos_test_cc_${{ matrix.ssl }}_${{ matrix.select }}_$(date +"%Y%m%d").json"
+    - if: success() || failure()
+      run: |
+        cat log
+        test/health.awk < log > json
+        scp -o "StrictHostKeyChecking=no" json "root@176.9.217.245:/data/downloads/health/macos_test_cc_${{ matrix.ssl }}_${{ matrix.select }}_$(date +"%Y%m%d").json"
 
   windows:
     runs-on: ubuntu-latest
@@ -194,8 +203,11 @@ jobs:
       with:
             ssh-private-key: ${{ secrets.HEALTH_TESTS_SSH_KEY }}
     - run: ./test/setup_mqtt_server.sh && make -C test ${{ matrix.target }} > log
-    - run: test/health.awk < log > json
-    - run: scp -o "StrictHostKeyChecking=no" json "root@176.9.217.245:/data/downloads/health/windows_${{ matrix.target }}_${{ matrix.cc }}_${{ matrix.ssl }}_${{ matrix.select }}_$(date +"%Y%m%d").json"
+    - if: success() || failure()
+      run: |
+        cat log
+        test/health.awk < log > json
+        scp -o "StrictHostKeyChecking=no" json "root@176.9.217.245:/data/downloads/health/windows_${{ matrix.target }}_${{ matrix.cc }}_${{ matrix.ssl }}_${{ matrix.select }}_$(date +"%Y%m%d").json"
  
   arm:
     runs-on: ubuntu-latest
@@ -232,8 +244,11 @@ jobs:
             ssh-private-key: ${{ secrets.HEALTH_TESTS_SSH_KEY }}
     - run: sudo apt -y install libpcap-dev
     - run: make -C test tutorials CFLAGS_EXTRA="${{ matrix.ssl }}" > log
-    - run: test/health.awk < log > json
-    - run: scp -o "StrictHostKeyChecking=no" json "root@176.9.217.245:/data/downloads/health/tutorials_${{ matrix.ssl }}_$(date +"%Y%m%d").json"
+    - if: success() || failure()
+      run: |
+        cat log
+        test/health.awk < log > json
+        scp -o "StrictHostKeyChecking=no" json "root@176.9.217.245:/data/downloads/health/tutorials_${{ matrix.ssl }}_$(date +"%Y%m%d").json"
     - run: make -C test clean_tutorials
 
   tutorials_win:


### PR DESCRIPTION
@robertc2000 This fix I added to a branch that suddenly bumped into a wall due to strange behavior in a vendor library. I switched to other tasks and it was never patched. Added now. Let me know if ALL tests upload now, no matter they pass or fail.
Logs should only fail to upload when that test is cancelled, which is correct, as the test did not actually run to completion