### PR TITLE
Allow listeners to start before we have an address, close outstanding TCP connections on address change

### DIFF
--- a/mongoose.h
+++ b/mongoose.h
@@ -3135,17 +3135,20 @@ typedef void (*mg_tcpip_event_handler_t)(struct mg_tcpip_if *ifp, int ev,
                                          void *ev_data);
 
 enum {
-  MG_TCPIP_EV_ST_CHG,           // state change                   uint8_t * (&ifp->state)
-  MG_TCPIP_EV_DHCP_DNS,         // DHCP DNS assignment            uint32_t *ipaddr
-  MG_TCPIP_EV_DHCP_SNTP,        // DHCP SNTP assignment           uint32_t *ipaddr
-  MG_TCPIP_EV_ARP,              // Got ARP packet                 struct mg_str *
-  MG_TCPIP_EV_TIMER_1S,         // 1 second timer                 NULL
-  MG_TCPIP_EV_WIFI_SCAN_RESULT, // Wi-Fi scan results             struct mg_wifi_scan_bss_data *
-  MG_TCPIP_EV_WIFI_SCAN_END,    // Wi-Fi scan has finished        NULL
-  MG_TCPIP_EV_WIFI_CONNECT_ERR, // Wi-Fi connect has failed       driver and chip specific
-  MG_TCPIP_EV_DRIVER,           // Driver event                   driver specific
-  MG_TCPIP_EV_ST6_CHG,          // state6 change                  uint8_t * (&ifp->state6)
-  MG_TCPIP_EV_USER              // Starting ID for user events
+  MG_TCPIP_EV_ST_CHG,  // state change                   uint8_t * (&ifp->state)
+  MG_TCPIP_EV_DHCP_DNS,   // DHCP DNS assignment            uint32_t *ipaddr
+  MG_TCPIP_EV_DHCP_SNTP,  // DHCP SNTP assignment           uint32_t *ipaddr
+  MG_TCPIP_EV_ARP,        // Got ARP packet                 struct mg_str *
+  MG_TCPIP_EV_TIMER_1S,   // 1 second timer                 NULL
+  MG_TCPIP_EV_WIFI_SCAN_RESULT,  // Wi-Fi scan results             struct
+                                 // mg_wifi_scan_bss_data *
+  MG_TCPIP_EV_WIFI_SCAN_END,     // Wi-Fi scan has finished        NULL
+  MG_TCPIP_EV_WIFI_CONNECT_ERR,  // Wi-Fi connect has failed       driver and
+                                 // chip specific
+  MG_TCPIP_EV_DRIVER,   // Driver event                   driver specific
+  MG_TCPIP_EV_ST6_CHG,  // state6 change                  uint8_t *
+                        // (&ifp->state6)
+  MG_TCPIP_EV_USER      // Starting ID for user events
 };
 
 // Network interface
@@ -3161,6 +3164,7 @@ struct mg_tcpip_if {
   bool enable_crc32_check;         // Do a CRC check on RX frames and strip it
   bool enable_mac_check;           // Do a MAC check on RX frames
   bool update_mac_hash_table;      // Signal drivers to update MAC controller
+  bool is_ip_changed;              // IP address changed, close/restart conns
   struct mg_tcpip_driver *driver;  // Low level driver
   void *driver_data;               // Driver-specific data
   mg_tcpip_event_handler_t pfn;    // Driver-specific event handler function
@@ -3171,11 +3175,13 @@ struct mg_tcpip_if {
   uint16_t mtu;                            // Interface MTU
 #define MG_TCPIP_MTU_DEFAULT 1500
 #if MG_ENABLE_IPV6
-  uint64_t ip6ll[2], ip6[2];       // IPv6 link-local and global addresses
-  uint8_t prefix_len;              // Prefix length
-  uint64_t gw6[2];                 // Default gateway
-  bool enable_slaac;               // Enable IPv6 address autoconfiguration
-  bool enable_dhcp6_client;        // Enable DCHPv6 client
+  uint64_t ip6ll[2], ip6[2];  // IPv6 link-local and global addresses
+  uint8_t prefix[8];          // IPv6 global address prefix
+  uint8_t prefix_len;         // Prefix length
+  uint64_t gw6[2];            // Default gateway
+  bool enable_slaac;          // Enable IPv6 address autoconfiguration
+  bool enable_dhcp6_client;   // Enable DCHPv6 client
+  bool is_ip6_changed;        // IPv6 address changed, close/restart conns
 #endif
 
   // Internal state, user can use it but should not change it
@@ -3196,8 +3202,8 @@ struct mg_tcpip_if {
 #define MG_TCPIP_STATE_IP 3     // Interface is up and has an IP assigned
 #define MG_TCPIP_STATE_READY 4  // Interface has fully come up, ready to work
 #if MG_ENABLE_IPV6
-  uint8_t gw6mac[6];             // IPv6 Router's MAC
-  uint8_t state6;                // Current IPv6 state
+  uint8_t gw6mac[6];  // IPv6 Router's MAC
+  uint8_t state6;     // Current IPv6 state
 #endif
 };
 void mg_tcpip_init(struct mg_mgr *, struct mg_tcpip_if *);
@@ -3231,39 +3237,38 @@ struct mg_tcpip_spi {
   uint8_t (*txn)(void *, uint8_t);  // SPI transaction: write 1 byte, read reply
 };
 
-
 // Alignment and memory section requirements
 #ifndef MG_8BYTE_ALIGNED
 #if defined(__GNUC__)
 #define MG_8BYTE_ALIGNED __attribute__((aligned((8U))))
 #else
 #define MG_8BYTE_ALIGNED
-#endif // compiler
-#endif // 8BYTE_ALIGNED
+#endif  // compiler
+#endif  // 8BYTE_ALIGNED
 
 #ifndef MG_16BYTE_ALIGNED
 #if defined(__GNUC__)
 #define MG_16BYTE_ALIGNED __attribute__((aligned((16U))))
 #else
 #define MG_16BYTE_ALIGNED
-#endif // compiler
-#endif // 16BYTE_ALIGNED
+#endif  // compiler
+#endif  // 16BYTE_ALIGNED
 
 #ifndef MG_32BYTE_ALIGNED
 #if defined(__GNUC__)
 #define MG_32BYTE_ALIGNED __attribute__((aligned((32U))))
 #else
 #define MG_32BYTE_ALIGNED
-#endif // compiler
-#endif // 32BYTE_ALIGNED
+#endif  // compiler
+#endif  // 32BYTE_ALIGNED
 
 #ifndef MG_64BYTE_ALIGNED
 #if defined(__GNUC__)
 #define MG_64BYTE_ALIGNED __attribute__((aligned((64U))))
 #else
 #define MG_64BYTE_ALIGNED
-#endif // compiler
-#endif // 64BYTE_ALIGNED
+#endif  // compiler
+#endif  // 64BYTE_ALIGNED
 
 #ifndef MG_ETH_RAM
 #define MG_ETH_RAM

--- a/src/drivers/tm4c.c
+++ b/src/drivers/tm4c.c
@@ -40,15 +40,11 @@ enum {
   EPHYSTS = 16
 };  // PHY constants
 
-static inline void tm4cspin(volatile uint32_t count) {
-  while (count--) (void) 0;
-}
-
 static uint32_t emac_read_phy(uint8_t addr, uint8_t reg) {
   EMAC->EMACMIIADDR &= (0xf << 2);
   EMAC->EMACMIIADDR |= ((uint32_t) addr << 11) | ((uint32_t) reg << 6);
   EMAC->EMACMIIADDR |= MG_BIT(0);
-  while (EMAC->EMACMIIADDR & MG_BIT(0)) tm4cspin(1);
+  while (EMAC->EMACMIIADDR & MG_BIT(0)) (void) 0;
   return EMAC->EMACMIIDATA;
 }
 
@@ -58,7 +54,7 @@ static void emac_write_phy(uint8_t addr, uint8_t reg, uint32_t val) {
   EMAC->EMACMIIADDR |=
       ((uint32_t) addr << 11) | ((uint32_t) reg << 6) | MG_BIT(1);
   EMAC->EMACMIIADDR |= MG_BIT(0);
-  while (EMAC->EMACMIIADDR & MG_BIT(0)) tm4cspin(1);
+  while (EMAC->EMACMIIADDR & MG_BIT(0)) (void) 0;
 }
 
 static uint32_t get_sysclk(void) {
@@ -150,9 +146,8 @@ static bool mg_tcpip_driver_tm4c_init(struct mg_tcpip_if *ifp) {
         (uint32_t) (uintptr_t) s_txdesc[(i + 1) % ETH_DESC_CNT];  // Chain
   }
 
-  EMAC->EMACDMABUSMOD |= MG_BIT(0);  // Software reset
-  while ((EMAC->EMACDMABUSMOD & MG_BIT(0)) != 0)
-    tm4cspin(1);  // Wait until done
+  EMAC->EMACDMABUSMOD |= MG_BIT(0);                         // Software reset
+  while ((EMAC->EMACDMABUSMOD & MG_BIT(0)) != 0) (void) 0;  // Wait until done
 
   // Set MDC clock divider. If user told us the value, use it. Otherwise, guess
   int cr = (d == NULL || d->mdc_cr < 0) ? guess_mdc_cr() : d->mdc_cr;

--- a/test/mip_test.c
+++ b/test/mip_test.c
@@ -56,12 +56,14 @@ static void mif_fn(struct mg_tcpip_if *ifp, int ev, void *ev_data) {
 }
 
 static void test_statechange(void) {
+  struct mg_mgr mgr;
   struct mg_tcpip_if iface;
   memset(&iface, 0, sizeof(iface));
   iface.ip = mg_htonl(0x01020304);
   iface.state = MG_TCPIP_STATE_READY;
   iface.driver = &mg_tcpip_driver_mock;
   iface.fn = mif_fn;
+  iface.mgr = &mgr;
   onstatechange(&iface);
   ASSERT(executed == true);
   executed = false;
@@ -76,6 +78,7 @@ static void mif6_fn(struct mg_tcpip_if *ifp, int ev, void *ev_data) {
 }
 
 static void test_state6change(void) {
+  struct mg_mgr mgr;
   struct mg_tcpip_if iface;
   memset(&iface, 0, sizeof(iface));
   iface.ip6[0] = (uint64_t) mg_htonl(0x01020304);
@@ -83,6 +86,7 @@ static void test_state6change(void) {
   iface.state6 = MG_TCPIP_STATE_READY;
   iface.driver = &mg_tcpip_driver_mock;
   iface.fn = mif6_fn;
+  iface.mgr = &mgr;
   onstate6change(&iface);
   ASSERT(executed == true);
   executed = false;


### PR DESCRIPTION
Main thing here is the update of `c->loc` when DCHP gives us the IP. It fixes this situation, when we request a web page from a device, but the response comes from IP address 0.0.0.0:

<img width="910" height="80" alt="Screenshot 2025-11-15 at 09 38 53" src="https://github.com/user-attachments/assets/2cd97f33-dfe7-451b-b080-d8c8791f0078" />

This is how 0.0.0.0 situation happens:

1. Firmware code does mg_mgr_init() and opens HTTP listener mg_http_listen(). The listener connection grabs the local IP address from the interface: c->loc.ip4 = ifp->ip. Since DHCP did not yet gave up the IP, it is 0.
2. DHCP gives up the IP. ifp->ip is now non-0, but all existing connections have c->loc.ip4 as 0.
3. Client makes a request. Listener accepts. Accepted connection inherits c->loc from the listener, which is 0.

So, this situation was there forever, but appeared in my tests with TM4C129 board. This PR fixes up the c->loc  when DHCP assigns us the IP.