### PR TITLE
do not serve files when closing

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -2272,10 +2272,10 @@ void mg_http_serve_file(struct mg_connection *c, struct mg_http_message *hm,
               status, mg_http_status_code_str(status), (int) mime.len, mime.buf,
               etag, (uint64_t) cl, gzip ? "Content-Encoding: gzip\r\n" : "",
               range, opts->extra_headers ? opts->extra_headers : "");
-    if (mg_strcasecmp(hm->method, mg_str("HEAD")) == 0) {
+    if (mg_strcasecmp(hm->method, mg_str("HEAD")) == 0 || c->is_closing) {
       c->is_resp = 0;
       mg_fs_close(fd);
-    } else {
+    } else { // start serving static content only if not closing, see #3354
       // Track to-be-sent content length at the end of c->data, aligned
       size_t *clp = (size_t *) &c->data[(sizeof(c->data) - sizeof(size_t)) /
                                         sizeof(size_t) * sizeof(size_t)];

--- a/src/http.c
+++ b/src/http.c
@@ -1,7 +1,7 @@
+#include "http.h"
 #include "arch.h"
 #include "base64.h"
 #include "fmt.h"
-#include "http.h"
 #include "json.h"
 #include "log.h"
 #include "net.h"
@@ -648,10 +648,10 @@ void mg_http_serve_file(struct mg_connection *c, struct mg_http_message *hm,
               status, mg_http_status_code_str(status), (int) mime.len, mime.buf,
               etag, (uint64_t) cl, gzip ? "Content-Encoding: gzip\r\n" : "",
               range, opts->extra_headers ? opts->extra_headers : "");
-    if (mg_strcasecmp(hm->method, mg_str("HEAD")) == 0) {
+    if (mg_strcasecmp(hm->method, mg_str("HEAD")) == 0 || c->is_closing) {
       c->is_resp = 0;
       mg_fs_close(fd);
-    } else {
+    } else { // start serving static content only if not closing, see #3354
       // Track to-be-sent content length at the end of c->data, aligned
       size_t *clp = (size_t *) &c->data[(sizeof(c->data) - sizeof(size_t)) /
                                         sizeof(size_t) * sizeof(size_t)];


### PR DESCRIPTION
Client requests may not have explicit Content-length. To handle this, we deliver a last call when receiving a connection close indication.
If this request is to serve a file, then we swap the protocol callback for one to handle the file we just opened. Then we close. This file remains open and its structure allocated, as there is no call to mg_fs_close. This is because the user event handler is called from within the protocol handler handling the CLOSE event, so the new protocol handler (swapped) does not receive a CLOSE event, thing that happens with closures during file serving.
The cause here is the final closure starting a file serve operation.

This PR fixes this by only allowing to serve a file when this connection is not already been closed. We try to do as much as possible, but if that involves start serving a file, we give up.

