### PR TITLE
fix RA6M4

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -24735,7 +24735,7 @@ bool __attribute__((weak)) mg_wifi_ap_stop(void) {
 
 
 enum {                  // ID1  ID2
-  MG_PHY_KSZ8x = 0x22,  // 0022 1561 - KSZ8081RNB
+  MG_PHY_KSZ8x = 0x22,  // 0022 156x - KSZ8081RNB, KSZ8091RNB
   MG_PHY_DP83x = 0x2000,
   MG_PHY_DP83867 = 0xa231,  // 2000 a231 - TI DP83867I
   MG_PHY_DP83825 = 0xa140,  // 2000 a140 - TI DP83825I
@@ -25594,7 +25594,7 @@ static bool mg_tcpip_driver_ra_init(struct mg_tcpip_if *ifp) {
 
   MG_DEBUG(("PHY addr: %d, smispin: %d", d->phy_addr, s_smispin));
   struct mg_phy phy = {raeth_read_phy, raeth_write_phy};
-  mg_phy_init(&phy, d->phy_addr, 0);  // MAC clocks PHY
+  mg_phy_init(&phy, d->phy_addr, MG_PHY_CLOCKS_MAC);
 
   // Select RMII mode,
   ETHERC->ECMR = MG_BIT(2) | MG_BIT(1);  // 100M, Full-duplex, CRC

--- a/src/drivers/phy.c
+++ b/src/drivers/phy.c
@@ -1,7 +1,7 @@
 #include "phy.h"
 
 enum {                  // ID1  ID2
-  MG_PHY_KSZ8x = 0x22,  // 0022 1561 - KSZ8081RNB
+  MG_PHY_KSZ8x = 0x22,  // 0022 156x - KSZ8081RNB, KSZ8091RNB
   MG_PHY_DP83x = 0x2000,
   MG_PHY_DP83867 = 0xa231,  // 2000 a231 - TI DP83867I
   MG_PHY_DP83825 = 0xa140,  // 2000 a140 - TI DP83825I

--- a/src/drivers/ra.c
+++ b/src/drivers/ra.c
@@ -160,7 +160,7 @@ static bool mg_tcpip_driver_ra_init(struct mg_tcpip_if *ifp) {
 
   MG_DEBUG(("PHY addr: %d, smispin: %d", d->phy_addr, s_smispin));
   struct mg_phy phy = {raeth_read_phy, raeth_write_phy};
-  mg_phy_init(&phy, d->phy_addr, 0);  // MAC clocks PHY
+  mg_phy_init(&phy, d->phy_addr, MG_PHY_CLOCKS_MAC);
 
   // Select RMII mode,
   ETHERC->ECMR = MG_BIT(2) | MG_BIT(1);  // 100M, Full-duplex, CRC


### PR DESCRIPTION
The RA6 driver had an incorrect internal setting, so it was causing the phy code to catch the NXP settings.
NXP boards have the same PHY chip, but their MAC clocks the PHY at 50MHz
The EK-RA6M4 board has a 25MHz crystal and the PHY clocks the MAC.
The EK-RA8M1 board has a different PHY, and who clocks who is ambiguous, both PHY and MAC have an external clock. As the PHY does not require special settings, this change should be safe.

Please test:
EK-RA6M4
EK-RA8M1 (just in case)

Please remember to update Wizard code once this PR is merged.