### PR TITLE
add entropy to DNS txnid

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -376,8 +376,12 @@ static void mg_sendnsreq(struct mg_connection *c, struct mg_str *name, int ms,
     mg_error(c, "resolve OOM");
   } else {
     struct dns_data *reqs = (struct dns_data *) c->mgr->active_dns_requests;
-    d->txnid = reqs ? (uint16_t) (reqs->txnid + 1) : 1;
-    d->next = (struct dns_data *) c->mgr->active_dns_requests;
+    uint16_t id;
+    mg_random(&id, sizeof(uint16_t));
+    // TODO(): traverse reqs and check id != reqs->txnid; repeat otherwise
+    if (reqs != NULL) id = (uint16_t) (reqs->txnid + 1); // no collision
+    d->txnid = id;
+    d->next = reqs;
     c->mgr->active_dns_requests = d;
     d->expire = mg_millis() + (uint64_t) ms;
     d->c = c;

--- a/src/dns.c
+++ b/src/dns.c
@@ -255,8 +255,12 @@ static void mg_sendnsreq(struct mg_connection *c, struct mg_str *name, int ms,
     mg_error(c, "resolve OOM");
   } else {
     struct dns_data *reqs = (struct dns_data *) c->mgr->active_dns_requests;
-    d->txnid = reqs ? (uint16_t) (reqs->txnid + 1) : 1;
-    d->next = (struct dns_data *) c->mgr->active_dns_requests;
+    uint16_t id;
+    mg_random(&id, sizeof(uint16_t));
+    // TODO(): traverse reqs and check id != reqs->txnid; repeat otherwise
+    if (reqs != NULL) id = (uint16_t) (reqs->txnid + 1); // no collision
+    d->txnid = id;
+    d->next = reqs;
     c->mgr->active_dns_requests = d;
     d->expire = mg_millis() + (uint64_t) ms;
     d->c = c;


### PR DESCRIPTION
Transaction IDs in the DNS header are now random, instead of starting at 1
In case there are outstanding requests, the new request carries the former ID + 1; this is to avoid the (minimum but not zero) probability of generating two outstanding requests with the same transaction ID.
Should that not be enough, the requests list must be traversed and current ID compared to outstanding IDs:
```c
    uint16_t id;
    unsigned int tries = 3;
    while (tries--) {
      struct dns_data *cur;
      mg_random(&id, sizeof(uint16_t));
      for (cur = reqs; cur != NULL; cur = cur->next) {
        if (cur->txnid == id) break; // collision
      }
      if (cur == NULL) break; // no collision
    }
    d->txnid = id;
```
This seems a bit overkill, but is presented here for future's sake. See TODO()
