### PR TITLE
Fix out-of-bounds read in mg_der_to_tlv() DER parser

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -12893,14 +12893,18 @@ static int mg_der_to_tlv(uint8_t *der, size_t dersz, struct mg_der_tlv *tlv) {
   tlv->value = der + 2;
   if (tlv->len > 0x7f) {
     uint32_t i, n = tlv->len - 0x80;
+    if (dersz < (size_t) (2 + n)) return -1;  // Bounds check for length bytes
     tlv->len = 0;
     for (i = 0; i < n; i++) {
       tlv->len = (tlv->len << 8) | (der[2 + i]);
     }
     tlv->value = der + 2 + n;
   }
-  if (der + dersz < tlv->value + tlv->len) {
-    return -1;
+  {
+    size_t header_len = (size_t) (tlv->value - der);
+    if (header_len > dersz || tlv->len > dersz - header_len) {
+      return -1;
+    }
   }
   return 0;
 }

--- a/src/tls_builtin.c
+++ b/src/tls_builtin.c
@@ -247,14 +247,18 @@ static int mg_der_to_tlv(uint8_t *der, size_t dersz, struct mg_der_tlv *tlv) {
   tlv->value = der + 2;
   if (tlv->len > 0x7f) {
     uint32_t i, n = tlv->len - 0x80;
+    if (dersz < (size_t) (2 + n)) return -1;  // Bounds check for length bytes
     tlv->len = 0;
     for (i = 0; i < n; i++) {
       tlv->len = (tlv->len << 8) | (der[2 + i]);
     }
     tlv->value = der + 2 + n;
   }
-  if (der + dersz < tlv->value + tlv->len) {
-    return -1;
+  {
+    size_t header_len = (size_t) (tlv->value - der);
+    if (header_len > dersz || tlv->len > dersz - header_len) {
+      return -1;
+    }
   }
   return 0;
 }


### PR DESCRIPTION
## Summary

`mg_der_to_tlv()` (tls_builtin.c) was missing a bounds check when parsing long-form DER length fields, allowing a heap-buffer-overflow read. The sister function `mg_der_parse()` already includes this check — this patch adds the equivalent guard to `mg_der_to_tlv()`.

## Problem

When the second byte of a DER TLV indicates N length-encoding bytes (value > 0x7F), the function reads `der[2]..der[2+N-1]` without verifying that the buffer contains at least `2+N` bytes. A malicious peer can trigger this via a crafted ECDSA signature in TLS CertificateVerify.

Additionally, the boundary check `der + dersz < tlv->value + tlv->len` can overflow on 32-bit systems when `tlv->len` is large, bypassing the safety check.

## Fix

1. Added bounds check before the length-byte loop: `if (dersz < (size_t)(2 + n)) return -1;` (matching `mg_der_parse`)
2. Replaced pointer-based boundary check with overflow-safe arithmetic

## Testing

- Unit tests pass (1521/1521)
- AddressSanitizer confirms the OOB read is fixed
- The pre-existing SSL=BUILTIN test failure (socket error on localhost:8443) is unrelated