### PR TITLE
unify SPI helper APIs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -397,9 +397,12 @@ jobs:
           - path: nxp/nxp-lpcxpresso54628-lwip-freertos
           - path: nxp/nxp-twrk65f180m-lwip-freertos
           - path: nxp/nxp-twrkv58f220m-lwip-freertos
+          - path: pico-sdk/rm2-pico-picosdk-baremetal-builtin
           - path: pico-sdk/pico-rmii
           - path: stm32/nucleo-f429zi-make-baremetal-builtin-rndis
+          - path: stm32/rm2-nucleo-f429zi-make-baremetal-builtin
           - path: stm32/nucleo-f746zg-make-baremetal-builtin-rndis
+          - path: stm32/rm2-nucleo-f746zg-make-baremetal-builtin
           - path: stm32/nucleo-g031-make-baremetal-builtin
           - path: ti/ti-ek-tm4c1294xl-http-server
           - path: ti/ek-tm4c1294xl-make-baremetal-builtin-rndis

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -227,6 +227,9 @@ jobs:
       fail-fast: false
       matrix:
         example:
+          - path: pico-sdk/rm2-pico-picosdk-baremetal-builtin
+          - path: stm32/rm2-nucleo-f429zi-make-baremetal-builtin
+          - path: stm32/rm2-nucleo-f746zg-make-baremetal-builtin
           - path: stm32/nucleo-g031-make-baremetal-builtin
     name: ${{ matrix.example.path }}
     env:

--- a/mongoose.c
+++ b/mongoose.c
@@ -24406,7 +24406,7 @@ static bool cyw_spi_write(unsigned int f, uint32_t addr, void *data,
                           uint16_t len) {
   struct mg_tcpip_driver_cyw_data *d =
       (struct mg_tcpip_driver_cyw_data *) s_ifp->driver_data;
-  struct mg_tcpip_spi_ *s = (struct mg_tcpip_spi_ *) d->bus;
+  struct mg_tcpip_spi *s = (struct mg_tcpip_spi *) d->bus;
   uint32_t hdr = CYW_SPID_WR | CYW_SPID_INC | CYW_SPID_FUNC(f) |
                  CYW_SPID_ADDR(addr) | CYW_SPID_LEN(len);  // gSPI header
   // TODO(scaprile): check spin in between and timeout values, return false
@@ -24436,7 +24436,7 @@ static void cyw_spi_read(unsigned int f, uint32_t addr, void *data,
                          uint16_t len) {
   struct mg_tcpip_driver_cyw_data *d =
       (struct mg_tcpip_driver_cyw_data *) s_ifp->driver_data;
-  struct mg_tcpip_spi_ *s = (struct mg_tcpip_spi_ *) d->bus;
+  struct mg_tcpip_spi *s = (struct mg_tcpip_spi *) d->bus;
   uint32_t padding =
       f == CYW_SPID_FUNC_CHIP
           ? 4
@@ -27003,7 +27003,7 @@ static size_t st67w6_spi_poll(uint8_t *write, uint8_t *read) {
   struct mg_tcpip_driver_st67w6_data *d =
       (struct mg_tcpip_driver_st67w6_data *) s_ifp->driver_data;
   struct spi_hdr *th, *rh = (struct spi_hdr *) read;
-  struct mg_tcpip_spi_ *s = (struct mg_tcpip_spi_ *) d->spi;
+  struct mg_tcpip_spi *s = (struct mg_tcpip_spi *) d->spi;
   size_t padded;
   unsigned int times;
 
@@ -28230,16 +28230,12 @@ struct mg_tcpip_driver mg_tcpip_driver_tms570 = {mg_tcpip_driver_tms570_init,
 
 static void w5100_txn(struct mg_tcpip_spi *s, uint16_t addr, bool wr, void *buf,
                       size_t len) {
-  size_t i;
-  uint8_t *p = (uint8_t *) buf;
   uint8_t control = wr ? 0xF0 : 0x0F;
   uint8_t cmd[] = {control, (uint8_t) (addr >> 8), (uint8_t) (addr & 255)};
   s->begin(s->spi);
-  for (i = 0; i < sizeof(cmd); i++) s->txn(s->spi, cmd[i]);
-  for (i = 0; i < len; i++) {
-    uint8_t r = s->txn(s->spi, p[i]);
-    if (!wr) p[i] = r;
-  }
+  s->txn(s->spi, cmd, NULL, sizeof(cmd));
+  if (wr) s->txn(s->spi, (uint8_t *) buf, NULL, len);
+  if (!wr) s->txn(s->spi, NULL, (uint8_t *) buf, len);
   s->end(s->spi);
 }
 
@@ -28343,16 +28339,12 @@ enum { W5500_CR = 0, W5500_S0 = 1, W5500_TX0 = 2, W5500_RX0 = 3 };
 
 static void w5500_txn(struct mg_tcpip_spi *s, uint8_t block, uint16_t addr,
                       bool wr, void *buf, size_t len) {
-  size_t i;
-  uint8_t *p = (uint8_t *) buf;
   uint8_t cmd[] = {(uint8_t) (addr >> 8), (uint8_t) (addr & 255),
                    (uint8_t) ((block << 3) | (wr ? 4 : 0))};
   s->begin(s->spi);
-  for (i = 0; i < sizeof(cmd); i++) s->txn(s->spi, cmd[i]);
-  for (i = 0; i < len; i++) {
-    uint8_t r = s->txn(s->spi, p[i]);
-    if (!wr) p[i] = r;
-  }
+  s->txn(s->spi, cmd, NULL, sizeof(cmd));
+  if (wr) s->txn(s->spi, (uint8_t *) buf, NULL, len);
+  if (!wr) s->txn(s->spi, NULL, (uint8_t *) buf, len);
   s->end(s->spi);
 }
 

--- a/mongoose.h
+++ b/mongoose.h
@@ -3361,10 +3361,11 @@ extern struct mg_tcpip_driver mg_tcpip_driver_st67w6;
 
 // Drivers that require SPI, can use this SPI abstraction
 struct mg_tcpip_spi {
-  void *spi;                        // Opaque SPI bus descriptor
-  void (*begin)(void *);            // SPI begin: slave select low
-  void (*end)(void *);              // SPI end: slave select high
-  uint8_t (*txn)(void *, uint8_t);  // SPI transaction: write 1 byte, read reply
+  void *spi;              // Opaque SPI bus descriptor
+  void (*begin)(void *);  // SPI begin: slave select active
+  void (*end)(void *);    // SPI end: slave select inactive
+  void (*txn)(void *, uint8_t *write, uint8_t *read,
+              size_t len);  // SPI transaction: write-read len bytes
 };
 
 // Alignment and memory section requirements
@@ -3418,14 +3419,6 @@ struct mg_tcpip_spi {
 #if MG_ENABLE_TCPIP &&                                          \
     ((defined(MG_ENABLE_DRIVER_CYW) && MG_ENABLE_DRIVER_CYW) || \
      (defined(MG_ENABLE_DRIVER_CYW_SDIO) && MG_ENABLE_DRIVER_CYW_SDIO))
-
-struct mg_tcpip_spi_ {
-  void *spi;              // Opaque SPI bus descriptor
-  void (*begin)(void *);  // SPI begin: slave select low
-  void (*end)(void *);    // SPI end: slave select high
-  void (*txn)(void *, uint8_t *, uint8_t *,
-              size_t len);  // SPI transaction: write-read len bytes
-};
 
 struct mg_tcpip_driver_cyw_firmware {
   const uint8_t *code_addr;
@@ -3767,14 +3760,6 @@ bool mg_sdio_transfer(struct mg_tcpip_sdio *sdio, bool write, unsigned int f,
 
 #if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_ST67W6) && \
     MG_ENABLE_DRIVER_ST67W6
-
-struct mg_tcpip_spi_ {
-  void *spi;              // Opaque SPI bus descriptor
-  void (*begin)(void *);  // SPI begin: slave select low
-  void (*end)(void *);    // SPI end: slave select high
-  void (*txn)(void *, uint8_t *, uint8_t *,
-              size_t len);  // SPI transaction: write-read len bytes
-};
 
 struct mg_tcpip_driver_st67w6_data {
   struct mg_wifi_data wifi;

--- a/src/drivers/cyw.c
+++ b/src/drivers/cyw.c
@@ -1178,7 +1178,7 @@ static bool cyw_spi_write(unsigned int f, uint32_t addr, void *data,
                           uint16_t len) {
   struct mg_tcpip_driver_cyw_data *d =
       (struct mg_tcpip_driver_cyw_data *) s_ifp->driver_data;
-  struct mg_tcpip_spi_ *s = (struct mg_tcpip_spi_ *) d->bus;
+  struct mg_tcpip_spi *s = (struct mg_tcpip_spi *) d->bus;
   uint32_t hdr = CYW_SPID_WR | CYW_SPID_INC | CYW_SPID_FUNC(f) |
                  CYW_SPID_ADDR(addr) | CYW_SPID_LEN(len);  // gSPI header
   // TODO(scaprile): check spin in between and timeout values, return false
@@ -1208,7 +1208,7 @@ static void cyw_spi_read(unsigned int f, uint32_t addr, void *data,
                          uint16_t len) {
   struct mg_tcpip_driver_cyw_data *d =
       (struct mg_tcpip_driver_cyw_data *) s_ifp->driver_data;
-  struct mg_tcpip_spi_ *s = (struct mg_tcpip_spi_ *) d->bus;
+  struct mg_tcpip_spi *s = (struct mg_tcpip_spi *) d->bus;
   uint32_t padding =
       f == CYW_SPID_FUNC_CHIP
           ? 4

--- a/src/drivers/cyw.h
+++ b/src/drivers/cyw.h
@@ -4,14 +4,6 @@
     ((defined(MG_ENABLE_DRIVER_CYW) && MG_ENABLE_DRIVER_CYW) || \
      (defined(MG_ENABLE_DRIVER_CYW_SDIO) && MG_ENABLE_DRIVER_CYW_SDIO))
 
-struct mg_tcpip_spi_ {
-  void *spi;              // Opaque SPI bus descriptor
-  void (*begin)(void *);  // SPI begin: slave select low
-  void (*end)(void *);    // SPI end: slave select high
-  void (*txn)(void *, uint8_t *, uint8_t *,
-              size_t len);  // SPI transaction: write-read len bytes
-};
-
 struct mg_tcpip_driver_cyw_firmware {
   const uint8_t *code_addr;
   size_t code_len;

--- a/src/drivers/st67w6.c
+++ b/src/drivers/st67w6.c
@@ -439,7 +439,7 @@ static size_t st67w6_spi_poll(uint8_t *write, uint8_t *read) {
   struct mg_tcpip_driver_st67w6_data *d =
       (struct mg_tcpip_driver_st67w6_data *) s_ifp->driver_data;
   struct spi_hdr *th, *rh = (struct spi_hdr *) read;
-  struct mg_tcpip_spi_ *s = (struct mg_tcpip_spi_ *) d->spi;
+  struct mg_tcpip_spi *s = (struct mg_tcpip_spi *) d->spi;
   size_t padded;
   unsigned int times;
 

--- a/src/drivers/st67w6.h
+++ b/src/drivers/st67w6.h
@@ -3,14 +3,6 @@
 #if MG_ENABLE_TCPIP && defined(MG_ENABLE_DRIVER_ST67W6) && \
     MG_ENABLE_DRIVER_ST67W6
 
-struct mg_tcpip_spi_ {
-  void *spi;              // Opaque SPI bus descriptor
-  void (*begin)(void *);  // SPI begin: slave select low
-  void (*end)(void *);    // SPI end: slave select high
-  void (*txn)(void *, uint8_t *, uint8_t *,
-              size_t len);  // SPI transaction: write-read len bytes
-};
-
 struct mg_tcpip_driver_st67w6_data {
   struct mg_wifi_data wifi;
   void *spi;

--- a/src/drivers/w5100.c
+++ b/src/drivers/w5100.c
@@ -4,16 +4,12 @@
 
 static void w5100_txn(struct mg_tcpip_spi *s, uint16_t addr, bool wr, void *buf,
                       size_t len) {
-  size_t i;
-  uint8_t *p = (uint8_t *) buf;
   uint8_t control = wr ? 0xF0 : 0x0F;
   uint8_t cmd[] = {control, (uint8_t) (addr >> 8), (uint8_t) (addr & 255)};
   s->begin(s->spi);
-  for (i = 0; i < sizeof(cmd); i++) s->txn(s->spi, cmd[i]);
-  for (i = 0; i < len; i++) {
-    uint8_t r = s->txn(s->spi, p[i]);
-    if (!wr) p[i] = r;
-  }
+  s->txn(s->spi, cmd, NULL, sizeof(cmd));
+  if (wr) s->txn(s->spi, (uint8_t *) buf, NULL, len);
+  if (!wr) s->txn(s->spi, NULL, (uint8_t *) buf, len);
   s->end(s->spi);
 }
 

--- a/src/drivers/w5500.c
+++ b/src/drivers/w5500.c
@@ -6,16 +6,12 @@ enum { W5500_CR = 0, W5500_S0 = 1, W5500_TX0 = 2, W5500_RX0 = 3 };
 
 static void w5500_txn(struct mg_tcpip_spi *s, uint8_t block, uint16_t addr,
                       bool wr, void *buf, size_t len) {
-  size_t i;
-  uint8_t *p = (uint8_t *) buf;
   uint8_t cmd[] = {(uint8_t) (addr >> 8), (uint8_t) (addr & 255),
                    (uint8_t) ((block << 3) | (wr ? 4 : 0))};
   s->begin(s->spi);
-  for (i = 0; i < sizeof(cmd); i++) s->txn(s->spi, cmd[i]);
-  for (i = 0; i < len; i++) {
-    uint8_t r = s->txn(s->spi, p[i]);
-    if (!wr) p[i] = r;
-  }
+  s->txn(s->spi, cmd, NULL, sizeof(cmd));
+  if (wr) s->txn(s->spi, (uint8_t *) buf, NULL, len);
+  if (!wr) s->txn(s->spi, NULL, (uint8_t *) buf, len);
   s->end(s->spi);
 }
 

--- a/src/net_builtin.h
+++ b/src/net_builtin.h
@@ -120,10 +120,11 @@ extern struct mg_tcpip_driver mg_tcpip_driver_st67w6;
 
 // Drivers that require SPI, can use this SPI abstraction
 struct mg_tcpip_spi {
-  void *spi;                        // Opaque SPI bus descriptor
-  void (*begin)(void *);            // SPI begin: slave select low
-  void (*end)(void *);              // SPI end: slave select high
-  uint8_t (*txn)(void *, uint8_t);  // SPI transaction: write 1 byte, read reply
+  void *spi;              // Opaque SPI bus descriptor
+  void (*begin)(void *);  // SPI begin: slave select active
+  void (*end)(void *);    // SPI end: slave select inactive
+  void (*txn)(void *, uint8_t *write, uint8_t *read,
+              size_t len);  // SPI transaction: write-read len bytes
 };
 
 // Alignment and memory section requirements

--- a/tutorials/http/http-server/arduino/w5500-http/w5500-http.ino
+++ b/tutorials/http/http-server/arduino/w5500-http/w5500-http.ino
@@ -8,7 +8,13 @@ struct mg_tcpip_spi spi = {
     NULL,  // SPI metadata
     [](void *) { digitalWrite(SS_PIN, LOW); SPI.beginTransaction(SPISettings()); },
     [](void *) { digitalWrite(SS_PIN, HIGH); SPI.endTransaction(); },
-    [](void *, uint8_t c) { return SPI.transfer(c); }, // Execute transaction
+    [](void *, uint8_t *w, uint8_t *r, size_t n) {  // Execute transaction
+        while (n--) {
+          uint8_t c = (w != NULL) ? *w++ : 0xFF;
+          uint8_t d = SPI.transfer(c);
+          if (r != NULL) *r++ = d;
+        }       
+      },
 };
 struct mg_mgr mgr;                                     // Mongoose event manager
 struct mg_tcpip_if mif = {.mac = {2, 0, 1, 2, 3, 5}};  // Network interface

--- a/tutorials/mqtt/mqtt-client/arduino/w5500-mqtt/w5500-mqtt.ino
+++ b/tutorials/mqtt/mqtt-client/arduino/w5500-mqtt/w5500-mqtt.ino
@@ -12,7 +12,13 @@ struct mg_tcpip_spi spi = {
     NULL,  // SPI metadata
     [](void *) { digitalWrite(SS_PIN, LOW); SPI.beginTransaction(SPISettings()); },
     [](void *) { digitalWrite(SS_PIN, HIGH); SPI.endTransaction(); },
-    [](void *, uint8_t c) { return SPI.transfer(c); }, // Execute transaction
+    [](void *, uint8_t *w, uint8_t *r, size_t n) {  // Execute transaction
+        while (n--) {
+          uint8_t c = (w != NULL) ? *w++ : 0xFF;
+          uint8_t d = SPI.transfer(c);
+          if (r != NULL) *r++ = d;
+        }       
+      },
 };
 struct mg_mgr mgr;                                     // Mongoose event manager
 struct mg_tcpip_if mif = {.mac = {2, 0, 1, 2, 3, 5}};  // Network interface

--- a/tutorials/pico-sdk/rm2-pico-picosdk-baremetal-builtin/main.c
+++ b/tutorials/pico-sdk/rm2-pico-picosdk-baremetal-builtin/main.c
@@ -9,7 +9,7 @@
 #define WIFI_PASS "YOUR_WIFI_PASSWORD"      // SET THIS!
 
 
-static const struct mg_tcpip_spi_ spi = {NULL, hwspecific_spi_begin, hwspecific_spi_end, hwspecific_spi_txn};
+static const struct mg_tcpip_spi spi = {NULL, hwspecific_spi_begin, hwspecific_spi_end, hwspecific_spi_txn};
 
 #ifndef CYW43_RESOURCE_ATTRIBUTE
 #define CYW43_RESOURCE_ATTRIBUTE
@@ -24,7 +24,6 @@ static const struct mg_tcpip_driver_cyw_firmware fw = {
 // mif user states
 enum {AP, SCANNING, STOPPING_AP, CONNECTING, READY};
 static unsigned int state;
-static uint32_t s_ip, s_mask;
 
 
 static void mif_fn(struct mg_tcpip_if *ifp, int ev, void *ev_data) {
@@ -34,13 +33,7 @@ static void mif_fn(struct mg_tcpip_if *ifp, int ev, void *ev_data) {
   }
   switch(state) {
     case AP: // we are in AP mode, wait for a user connection to trigger a scan or a connection to a network
-      if (ev == MG_TCPIP_EV_ST_CHG && *(uint8_t *) ev_data == MG_TCPIP_STATE_UP) {
-        MG_INFO(("Access Point started"));
-        s_ip = ifp->ip, ifp->ip = MG_IPV4(192, 168, 169, 1);
-        s_mask = ifp->mask, ifp->mask = MG_IPV4(255, 255, 255, 0);
-        ifp->enable_dhcp_client = false;
-        ifp->enable_dhcp_server = true;
-      } else if (ev == MG_TCPIP_EV_ST_CHG && *(uint8_t *) ev_data == MG_TCPIP_STATE_READY) {
+      if (ev == MG_TCPIP_EV_ST_CHG && *(uint8_t *) ev_data == MG_TCPIP_STATE_READY) {
         MG_INFO(("Access Point READY !"));
 
         // simulate user request to scan for networks
@@ -54,7 +47,7 @@ static void mif_fn(struct mg_tcpip_if *ifp, int ev, void *ev_data) {
         struct mg_wifi_scan_bss_data *bss = (struct mg_wifi_scan_bss_data *) ev_data;
         MG_INFO(("BSS: %.*s (%u) (%M) %d dBm %u", bss->SSID.len, bss->SSID.buf, bss->channel, mg_print_mac, bss->BSSID, (int) bss->RSSI, bss->security));
       } else if (ev == MG_TCPIP_EV_WIFI_SCAN_END) {
-        struct mg_tcpip_driver_cyw_data *d = (struct mg_tcpip_driver_cyw_data *) ifp->driver_data;
+        //struct mg_tcpip_driver_cyw_data *d = (struct mg_tcpip_driver_cyw_data *) ifp->driver_data;
         MG_INFO(("Wi-Fi scan finished"));
 
         // simulate user selection of a network (1/2: stop AP)
@@ -66,18 +59,14 @@ static void mif_fn(struct mg_tcpip_if *ifp, int ev, void *ev_data) {
       break;
     case STOPPING_AP:
       if (ev == MG_TCPIP_EV_ST_CHG && *(uint8_t *) ev_data == MG_TCPIP_STATE_DOWN) {
-        struct mg_tcpip_driver_cyw_data *d = (struct mg_tcpip_driver_cyw_data *) ifp->driver_data;
-        d->apmode = false;
+        struct mg_wifi_data *wifi = &((struct mg_tcpip_driver_cyw_data *) ifp->driver_data)->wifi;
+        wifi->apmode = false;
 
         // simulate user selection of a network (2/2: actual connect)
-        bool res = mg_wifi_connect(d->ssid, d->pass);
+        bool res = mg_wifi_connect(wifi);
         MG_INFO(("Manually connecting: %s", res ? "OK":"FAIL"));
         if (res) {
           state = CONNECTING;
-          ifp->ip = s_ip;
-          ifp->mask = s_mask;
-          if (ifp->ip == 0) ifp->enable_dhcp_client = true;
-          ifp->enable_dhcp_server = false;
         } // else manually start AP as below
       }
       break;
@@ -97,13 +86,13 @@ static void mif_fn(struct mg_tcpip_if *ifp, int ev, void *ev_data) {
     case READY:
       // go back to AP mode after a disconnection (simulation 2/2), you could retry
       if (ev == MG_TCPIP_EV_ST_CHG && *(uint8_t *) ev_data == MG_TCPIP_STATE_DOWN) {
-        struct mg_tcpip_driver_cyw_data *d = (struct mg_tcpip_driver_cyw_data *) ifp->driver_data;
-        bool res = mg_wifi_ap_start(d->apssid, d->appass, d->apchannel);
+        struct mg_wifi_data *wifi = &((struct mg_tcpip_driver_cyw_data *) ifp->driver_data)->wifi;
+        bool res = mg_wifi_ap_start(wifi);
         MG_INFO(("Disconnected"));
         MG_INFO(("Manually starting AP: %s", res ? "OK":"FAIL"));
         if (res) {
           state = AP;
-          d->apmode = true;
+          wifi->apmode = true;
         }
       }
       break;
@@ -112,7 +101,7 @@ static void mif_fn(struct mg_tcpip_if *ifp, int ev, void *ev_data) {
 
 
 static struct mg_tcpip_driver_cyw_data d = {
-  (struct mg_tcpip_spi_ *)&spi, (struct mg_tcpip_driver_cyw_firmware *)&fw, WIFI_SSID, WIFI_PASS, "mongoose", "mongoose", 0, 0, 10, true, true};
+  {WIFI_SSID, WIFI_PASS, "mongoose", "mongoose", 0, 0, 0, 0, 10, true}, (struct mg_tcpip_spi *)&spi, (struct mg_tcpip_driver_cyw_firmware *)&fw, false};
 
 int main(void) {
   // initialize stdio
@@ -120,7 +109,9 @@ int main(void) {
 
   hwspecific_spi_init();
 
-  state = d.apmode ? AP : CONNECTING;
+  d.wifi.apip = MG_IPV4(192, 168, 169, 1),
+  d.wifi.apmask = MG_IPV4(255, 255, 255, 0),
+  state = d.wifi.apmode ? AP : CONNECTING;
 
   struct mg_mgr mgr;        // Initialise Mongoose event manager
   mg_mgr_init(&mgr);        // and attach it to the interface

--- a/tutorials/stm32/nucleo-g031-make-baremetal-builtin/hal.h
+++ b/tutorials/stm32/nucleo-g031-make-baremetal-builtin/hal.h
@@ -159,7 +159,7 @@ static inline void spi_init(struct spi *spi) {
 }
 
 // Send a byte, and return a received byte
-static inline uint8_t spi_txn(struct spi *spi, uint8_t write_byte) {
+static inline uint8_t spi_1byte(struct spi *spi, uint8_t write_byte) {
   unsigned count = spi->spin <= 0 ? 9 : (unsigned) spi->spin;
   uint8_t rx = 0, tx = write_byte;
   for (int i = 0; i < 8; i++) {
@@ -174,6 +174,14 @@ static inline uint8_t spi_txn(struct spi *spi, uint8_t write_byte) {
   }
   // printf("%s %02x %02x\n", __func__, (int) write_byte, (int) rx);
   return rx;  // Return the received byte
+}
+
+static inline void spi_txn(struct spi *spi, uint8_t *w, uint8_t *r, size_t n) {
+  while (n--) {
+    uint8_t c = (w != NULL) ? *w++ : 0xFF;
+    uint8_t d = spi_1byte(spi, c);
+    if (r != NULL) *r++ = d;
+  }       
 }
 
 #define UUID ((uint32_t *) UID_BASE)  // Unique 96-bit chip ID. TRM 59.1

--- a/tutorials/stm32/nucleo-g031-make-baremetal-builtin/main.c
+++ b/tutorials/stm32/nucleo-g031-make-baremetal-builtin/main.c
@@ -86,7 +86,7 @@ int main(void) {
   struct mg_tcpip_spi spi = {
       .begin = (void (*)(void *)) spi_begin,
       .end = (void (*)(void *)) spi_end,
-      .txn = (uint8_t(*)(void *, uint8_t)) spi_txn,
+      .txn = (void (*)(void *, uint8_t *, uint8_t *, size_t)) spi_txn,
       .spi = &spi_pins,
   };
   struct mg_tcpip_if mif = {.mac = GENERATE_LOCALLY_ADMINISTERED_MAC(),

--- a/tutorials/stm32/rm2-nucleo-f429zi-make-baremetal-builtin/main.c
+++ b/tutorials/stm32/rm2-nucleo-f429zi-make-baremetal-builtin/main.c
@@ -66,7 +66,7 @@ static void hwspecific_spi_init(void) {
   mg_delayms(50);
 }
 
-static const struct mg_tcpip_spi_ spi = {NULL, hwspecific_spi_begin, hwspecific_spi_end, hwspecific_spi_txn};
+static const struct mg_tcpip_spi spi = {NULL, hwspecific_spi_begin, hwspecific_spi_end, hwspecific_spi_txn};
 
 #ifndef CYW43_RESOURCE_ATTRIBUTE
 #define CYW43_RESOURCE_ATTRIBUTE
@@ -162,7 +162,7 @@ static void mif_fn(struct mg_tcpip_if *ifp, int ev, void *ev_data) {
 
 
 static struct mg_tcpip_driver_cyw_data d = {
-  {WIFI_SSID, WIFI_PASS, "mongoose", "mongoose", 0, 0, 0, 0, 10, true}, (struct mg_tcpip_spi_ *)&spi, (struct mg_tcpip_driver_cyw_firmware *)&fw, false};
+  {WIFI_SSID, WIFI_PASS, "mongoose", "mongoose", 0, 0, 0, 0, 10, true}, (struct mg_tcpip_spi *)&spi, (struct mg_tcpip_driver_cyw_firmware *)&fw, false};
 
 int main(void) {
   uart_init(UART_DEBUG, 115200);  // Initialise debug printf

--- a/tutorials/stm32/rm2-nucleo-f746zg-make-baremetal-builtin/main.c
+++ b/tutorials/stm32/rm2-nucleo-f746zg-make-baremetal-builtin/main.c
@@ -66,7 +66,7 @@ static void hwspecific_spi_init(void) {
   mg_delayms(50);
 }
 
-static const struct mg_tcpip_spi_ spi = {NULL, hwspecific_spi_begin, hwspecific_spi_end, hwspecific_spi_txn};
+static const struct mg_tcpip_spi spi = {NULL, hwspecific_spi_begin, hwspecific_spi_end, hwspecific_spi_txn};
 
 #ifndef CYW43_RESOURCE_ATTRIBUTE
 #define CYW43_RESOURCE_ATTRIBUTE
@@ -162,7 +162,7 @@ static void mif_fn(struct mg_tcpip_if *ifp, int ev, void *ev_data) {
 
 
 static struct mg_tcpip_driver_cyw_data d = {
-  {WIFI_SSID, WIFI_PASS, "mongoose", "mongoose", 0, 0, 0, 0, 10, true}, (struct mg_tcpip_spi_ *)&spi, (struct mg_tcpip_driver_cyw_firmware *)&fw, false};
+  {WIFI_SSID, WIFI_PASS, "mongoose", "mongoose", 0, 0, 0, 0, 10, true}, (struct mg_tcpip_spi *)&spi, (struct mg_tcpip_driver_cyw_firmware *)&fw, false};
 
 int main(void) {
   uart_init(UART_DEBUG, 115200);  // Initialise debug printf


### PR DESCRIPTION
- Replaces `mg_tcpip_spi` with the multi-byte transaction API used for the Wi-Fi modules (`mg_tcpip_spi_`, which gets renamed) 
- Updates W5500 and W5100 drivers to this new API
- Updates W5500 examples in this repo, and struct name change in Wi-Fi examples

@robertc2000 Arduino tests pass, can you please check these tutorials also run ?
@cpq G031 test passes, can you please check it works ?

**When this PR is merged, Wizard-related tests will likely fail, and code won't work. Wizard templates have to be modified to work with this new API, and tested.**
