### PR TITLE
fix: trigger TLS handshake on synchronous connect success

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -12027,6 +12027,7 @@ void mg_connect_resolved(struct mg_connection *c) {
     if (rc == 0) {                       // Success
       setlocaddr(FD(c), &c->loc);
       mg_call(c, MG_EV_CONNECT, NULL);   // Send MG_EV_CONNECT to the user
+      if (c->is_tls_hs) mg_tls_handshake(c);  // Trigger TLS handshake immediately if user called mg_tls_init()
       if (!c->is_tls_hs) c->is_tls = 0;  // user did not call mg_tls_init()
     } else if (MG_SOCK_PENDING(rc)) {    // Need to wait for TCP handshake
       MG_DEBUG(("%lu %ld -> %M pend", c->id, c->fd, mg_print_ip_port, &c->rem));


### PR DESCRIPTION
Summary
This PR fixes a critical bug where the TLS handshake is never initiated if the TCP connection succeeds synchronously (e.g., connect() returns 0 immediately).
Background
This issue was identified while porting Mongoose to the Taixin 82x series (TS826/TS828) embedded platform. On this specific hardware/SDK, the network stack often completes the TCP handshake immediately for local or certain network conditions, causing connect() to return 0 instead of EINPROGRESS.
Problem
In mg_connect_resolved(), when a connection succeeds immediately, the MG_EV_CONNECT event is triggered. If the user calls mg_tls_init() inside this event, the is_tls_hs flag is correctly set to 1.
However, unlike the asynchronous path in connect_conn(), the current implementation of mg_connect_resolved() fails to check this flag or invoke mg_tls_handshake(). Consequently:
1. The client never sends the initial ClientHello packet.
2. The event loop remains idle, waiting for a read event from the server that will never occur.
3. The connection eventually hangs and leads to a timeout.
Solution
I have updated mg_connect_resolved() to include a check for c->is_tls_hs within the rc == 0 block, mirroring the established logic in connect_conn(). This ensures the first TLS handshake packet is dispatched immediately after a successful synchronous connection.
Impact
This fix ensures reliable TLS establishment across all platforms, especially on embedded systems where synchronous connection completion is a common occurrence.