### PR TITLE
ci: Integrate MemBrowse

### DIFF
--- a/.github/membrowse-targets.json
+++ b/.github/membrowse-targets.json
@@ -1,0 +1,47 @@
+[
+  {
+    "target_name": "stm32-g031",
+    "setup_cmd": "sudo apt-get update && sudo apt-get install -y gcc-arm-none-eabi libnewlib-arm-none-eabi",
+    "build_cmd": "make -C tutorials/stm32/nucleo-g031-make-baremetal-builtin firmware.elf",
+    "elf": "tutorials/stm32/nucleo-g031-make-baremetal-builtin/firmware.elf",
+    "map_file": "tutorials/stm32/nucleo-g031-make-baremetal-builtin/firmware.elf.map",
+    "ld": "tutorials/stm32/nucleo-g031-make-baremetal-builtin/link.ld",
+    "linker_vars": ""
+  },
+  {
+    "target_name": "stm32-f429zi",
+    "setup_cmd": "sudo apt-get update && sudo apt-get install -y gcc-arm-none-eabi libnewlib-arm-none-eabi",
+    "build_cmd": "make -C tutorials/stm32/nucleo-f429zi-make-baremetal-builtin-rndis firmware.elf",
+    "elf": "tutorials/stm32/nucleo-f429zi-make-baremetal-builtin-rndis/firmware.elf",
+    "map_file": "tutorials/stm32/nucleo-f429zi-make-baremetal-builtin-rndis/firmware.elf.map",
+    "ld": "tutorials/stm32/nucleo-f429zi-make-baremetal-builtin-rndis/link.ld",
+    "linker_vars": ""
+  },
+  {
+    "target_name": "stm32-f746zg",
+    "setup_cmd": "sudo apt-get update && sudo apt-get install -y gcc-arm-none-eabi libnewlib-arm-none-eabi",
+    "build_cmd": "make -C tutorials/stm32/nucleo-f746zg-make-baremetal-builtin-rndis firmware.elf",
+    "elf": "tutorials/stm32/nucleo-f746zg-make-baremetal-builtin-rndis/firmware.elf",
+    "map_file": "tutorials/stm32/nucleo-f746zg-make-baremetal-builtin-rndis/firmware.elf.map",
+    "ld": "tutorials/stm32/nucleo-f746zg-make-baremetal-builtin-rndis/link.ld",
+    "linker_vars": ""
+  },
+  {
+    "target_name": "renesas-ra6m4",
+    "setup_cmd": "sudo apt-get update && sudo apt-get install -y gcc-arm-none-eabi libnewlib-arm-none-eabi",
+    "build_cmd": "make -C tutorials/renesas/ek-ra6m4-make-baremetal-builtin firmware.elf",
+    "elf": "tutorials/renesas/ek-ra6m4-make-baremetal-builtin/firmware.elf",
+    "map_file": "tutorials/renesas/ek-ra6m4-make-baremetal-builtin/firmware.elf.map",
+    "ld": "tutorials/renesas/ek-ra6m4-make-baremetal-builtin/link.ld",
+    "linker_vars": ""
+  },
+  {
+    "target_name": "ti-tm4c1294xl",
+    "setup_cmd": "sudo apt-get update && sudo apt-get install -y gcc-arm-none-eabi libnewlib-arm-none-eabi",
+    "build_cmd": "make -C tutorials/ti/ek-tm4c1294xl-make-baremetal-builtin-rndis firmware.elf",
+    "elf": "tutorials/ti/ek-tm4c1294xl-make-baremetal-builtin-rndis/firmware.elf",
+    "map_file": "tutorials/ti/ek-tm4c1294xl-make-baremetal-builtin-rndis/firmware.elf.map",
+    "ld": "tutorials/ti/ek-tm4c1294xl-make-baremetal-builtin-rndis/link.ld",
+    "linker_vars": ""
+  }
+]

--- a/.github/workflows/membrowse-comment.yml
+++ b/.github/workflows/membrowse-comment.yml
@@ -1,0 +1,30 @@
+name: MemBrowse PR Comment
+
+on:
+  workflow_run:
+    workflows: [MemBrowse Memory Report]
+    types:
+      - completed
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Post combined PR comment
+        if: ${{ env.MEMBROWSE_API_KEY != '' }}
+        uses: membrowse/membrowse-action/comment-action@v1
+        with:
+          api_key: ${{ secrets.MEMBROWSE_API_KEY }}
+          commit: ${{ github.event.workflow_run.head_sha }}
+        env:
+          MEMBROWSE_API_KEY: ${{ secrets.MEMBROWSE_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/membrowse-onboard.yml
+++ b/.github/workflows/membrowse-onboard.yml
@@ -1,0 +1,54 @@
+name: Onboard to MemBrowse
+
+on:
+  workflow_dispatch:
+    inputs:
+      num_commits:
+        description: 'Number of commits to process'
+        required: true
+        default: '100'
+        type: string
+
+jobs:
+  load-targets:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Load target matrix
+        id: set-matrix
+        run: echo "matrix=$(jq -c '.' .github/membrowse-targets.json)" >> $GITHUB_OUTPUT
+
+  onboard:
+    needs: load-targets
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.load-targets.outputs.matrix) }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install packages
+        run: ${{ matrix.setup_cmd }}
+
+      - name: Run MemBrowse Onboard Action
+        uses: membrowse/membrowse-action/onboard-action@v1
+        with:
+          target_name: ${{ matrix.target_name }}
+          num_commits: ${{ github.event.inputs.num_commits }}
+          build_script: ${{ matrix.build_cmd }}
+          elf: ${{ matrix.elf }}
+          map_file: ${{ matrix.map_file }}
+          ld: ${{ matrix.ld }}
+          linker_vars: ${{ matrix.linker_vars }}
+          binary_search: 'true'
+          api_key: ${{ secrets.MEMBROWSE_API_KEY }}
+          api_url: ${{ vars.MEMBROWSE_API_URL }}

--- a/.github/workflows/membrowse-report.yml
+++ b/.github/workflows/membrowse-report.yml
@@ -1,0 +1,56 @@
+name: MemBrowse Memory Report
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  load-targets:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Load target matrix
+        id: set-matrix
+        run: echo "matrix=$(jq -c '.' .github/membrowse-targets.json)" >> $GITHUB_OUTPUT
+
+  analyze:
+    needs: load-targets
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.load-targets.outputs.matrix) }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install packages
+        run: ${{ matrix.setup_cmd }}
+
+      - name: Build
+        run: ${{ matrix.build_cmd }}
+
+      - name: Run MemBrowse analysis
+        uses: membrowse/membrowse-action@v1
+        with:
+          target_name: ${{ matrix.target_name }}
+          elf: ${{ matrix.elf }}
+          map_file: ${{ matrix.map_file }}
+          ld: ${{ matrix.ld }}
+          linker_vars: ${{ matrix.linker_vars }}
+          api_key: ${{ secrets.MEMBROWSE_API_KEY }}
+          api_url: ${{ vars.MEMBROWSE_API_URL }}
+          verbose: INFO

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![License: GPLv2/Commercial](https://img.shields.io/badge/License-GPLv2%20or%20Commercial-green.svg)](https://opensource.org/licenses/gpl-2.0.php)
 [![Build Status]( https://github.com/cesanta/mongoose/actions/workflows/quicktest.yml/badge.svg)](https://github.com/cesanta/mongoose/actions)
 [![Code Coverage](https://codecov.io/gh/cesanta/mongoose/branch/master/graph/badge.svg)](https://codecov.io/gh/cesanta/mongoose)
-[![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/mongoose.svg)](https://issues.oss-fuzz.com/issues?sort=-opened&can=1&q=proj:mongoose)
+[![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/cesanta/mongoose.svg)](https://issues.oss-fuzz.com/issues?sort=-opened&can=1&q=proj:mongoose)
+[![MemBrowse](https://membrowse.com/badge.svg)](https://membrowse.com/public/mongoose)
 
 <img src="https://mongoose.ws/images/logo.svg" width="48" height="48" align="left" style="float:left;" /> Mongoose is a network library for C/C++.  It provides event-driven non-blocking
 APIs for TCP, UDP, HTTP, WebSocket, MQTT, and other protocols.  It is designed


### PR DESCRIPTION
# Summary

Mongoose is used in memory-constrained embedded systems, where footprint directly affects which MCUs the library can target. There's currently no automated way to track how PRs affect code and data size over time, so regressions only surface when a user hits a limit.

This PR adds MemBrowse CI integration for automated memory footprint analysis on pull requests.
It creates a PR comment with size changes at the region, section, and library level, with links to the full build comparison page.

Here is an example of the dashboard: https://membrowse.com/public/michael-membrowse/mongoose

This includes:

membrowse-targets.json - configuration of the targets to be analyzed
Existing build workflows extended with a MemBrowse analysis step at the end of each build, plus pull_request trigger and concurrency settings where not already present
membrowse-comment.yml - posts consolidated memory results as PR comments (runs after build workflows complete)
membrowse-onboard.yml - one-off workflow for building the last N commits to populate historical data on day one
README badge linking to the MemBrowse dashboard

Currently the integration covers the following targets:

- renesas-ra6m4
- stm32-f429zi
- stm32-f746zg
- stm32-g031
- and ti-tm4c1294xl.

# Setup

1. Create account at https://membrowse.com/
2. Create a project and link it to this repo
3. Set the project as publicly available
4. Add MEMBROWSE_API_KEY as a GitHub Actions secret
5. Run the onboard workflow to populate the dashboard with historical data

I'm happy to chat and answer any questions.
Hope you find it useful.