### PR TITLE
Add MG_OTA_{ROLLBACK,STATE_SET,STATE_GET}

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -1431,7 +1431,7 @@ bool mg_ota_flash_begin(size_t new_firmware_size, struct mg_flash *flash) {
       s_size = new_firmware_size;
       MG_INFO(("Starting OTA, firmware size %lu", s_size));
     } else {
-      MG_ERROR(("Firmware %lu is too big to fit %lu", new_firmware_size, half));
+      MG_ERROR(("Firmware %lu is too big to fit %lu", new_firmware_size, half - flash->align));
     }
   }
   return ok;
@@ -1480,6 +1480,7 @@ bool mg_ota_flash_end(struct mg_flash *flash) {
     }
 #endif
     s_size = 0;
+    if (ok) MG_OTA_STATE_SET(MG_OTA_TESTING);
     if (ok) ok = flash->swap_fn();
   }
   MG_INFO(("Finishing OTA: %s", ok ? "ok" : "fail"));
@@ -3402,6 +3403,11 @@ static void mg_upload_handler(struct mg_connection *c, int ev, void *ev_data) {
   (void) ev_data;
 }
 
+static void mg_upload_default_cb(struct mg_connection *c, const char *status) {
+  MG_INFO(("%lu %s", c->id, status ? status : "ok"));
+  mg_http_reply(c, status ? 500 : 200, "", "%s\n", status ? status : "ok");
+}
+
 void mg_http_start_upload(struct mg_connection *c, struct mg_http_message *hm,
                           struct mg_str name, struct mg_str dir,
                           struct mg_fs *fs,
@@ -3409,6 +3415,7 @@ void mg_http_start_upload(struct mg_connection *c, struct mg_http_message *hm,
   struct mg_upload_priv *p = (struct mg_upload_priv *) c->data;
   char path[MG_PATH_MAX];
   struct mg_fd *fd;
+  if (fn == NULL) fn = mg_upload_default_cb;
   if (sizeof(*p) > sizeof(c->data)) { fn(c, "data too small"); return; }
   if (!mg_path_is_sane(name)) { fn(c, "bad name"); return; }
   mg_snprintf(path, sizeof(path), "%.*s%c%.*s", (int) dir.len, dir.buf,
@@ -3428,6 +3435,7 @@ void mg_http_start_upload(struct mg_connection *c, struct mg_http_message *hm,
 void mg_http_start_ota(struct mg_connection *c, struct mg_http_message *hm,
                        void (*fn)(struct mg_connection *, const char *)) {
   struct mg_upload_priv *p = (struct mg_upload_priv *) c->data;
+  if (fn == NULL) fn = mg_upload_default_cb;
   if (sizeof(*p) > sizeof(c->data)) { fn(c, "data too small"); return; }
   if (!mg_ota_begin(hm->body.len)) { fn(c, "ota begin failed"); return; }
   p->expected = hm->body.len;
@@ -11058,10 +11066,8 @@ static bool mg_stm32h5_swap(void) {
   uint32_t desired = flash_bank_is_swapped() ? 0 : MG_BIT(31);
   flash_unlock();
   flash_clear_err();
-  // printf("OPTSR_PRG 1 %#lx\n", FLASH->OPTSR_PRG);
   MG_SET_BITS(MG_REG(FLASH_OPTSR_PRG), MG_BIT(31), desired);
-  // printf("OPTSR_PRG 2 %#lx\n", FLASH->OPTSR_PRG);
-  MG_REG(FLASH_OPTCR) |= MG_BIT(1);  // OPTSTART
+  MG_REG(FLASH_OPTCR) |= MG_BIT(1);  // OPTSTART; triggers auto-reset on H5
   while ((MG_REG(FLASH_OPTSR_CUR) & MG_BIT(31)) != desired) (void) 0;
   return true;
 }
@@ -11108,10 +11114,9 @@ bool mg_ota_write(const void *buf, size_t len) {
   return mg_ota_flash_write(buf, len, &s_mg_flash_stm32h5);
 }
 
-// Actual bank swap is deferred until reset, it is safe to execute in flash
 bool mg_ota_end(void) {
-  if(!mg_ota_flash_end(&s_mg_flash_stm32h5)) return false;
-  *(volatile unsigned long *) 0xe000ed0c = 0x5fa0004;
+  if (!mg_ota_flash_end(&s_mg_flash_stm32h5)) return false;
+  *(volatile uint32_t *) 0xe000ed0c = 0x5fa0004U;  // NVIC_SystemReset()
   return true;
 }
 struct mg_flash *mg_flash = &s_mg_flash_stm32h5;
@@ -11234,6 +11239,7 @@ MG_IRAM static bool mg_stm32h7_erase(void *addr) {
     MG_REG(bank + FLASH_CR) |= (sector & 7U) << 8U;  // Sector to erase
     MG_REG(bank + FLASH_CR) |= MG_BIT(2);            // Sector erase bit
     MG_REG(bank + FLASH_CR) |= MG_BIT(7);            // Start erasing
+    flash_wait(bank);
     ok = !flash_is_err(bank);
     MG_DEBUG(("Erase sector %lu @ %p %s. CR %#lx SR %#lx", sector, addr,
               ok ? "ok" : "fail", MG_REG(bank + FLASH_CR),
@@ -11249,9 +11255,7 @@ MG_IRAM static bool mg_stm32h7_swap(void) {
   uint32_t desired = flash_bank_is_swapped(bank) ? 0 : MG_BIT(31);
   flash_unlock();
   flash_clear_err(bank);
-  // printf("OPTSR_PRG 1 %#lx\n", FLASH->OPTSR_PRG);
   MG_SET_BITS(MG_REG(bank + FLASH_OPTSR_PRG), MG_BIT(31), desired);
-  // printf("OPTSR_PRG 2 %#lx\n", FLASH->OPTSR_PRG);
   MG_REG(bank + FLASH_OPTCR) |= MG_BIT(1);  // OPTSTART
   while ((MG_REG(bank + FLASH_OPTSR_CUR) & MG_BIT(31)) != desired) (void) 0;
   return true;
@@ -11284,7 +11288,7 @@ MG_IRAM static bool mg_stm32h7_write(void *addr, const void *buf, size_t len) {
     if (flash_is_err(bank)) ok = false;
   }
   if (!s_flash_irq_disabled) MG_ARM_ENABLE_IRQ();
-  MG_DEBUG(("Flash write %lu bytes @ %p: %s. CR %#lx SR %#lx", len, dst,
+  MG_DEBUG(("Flash write %lu bytes @ %p: %s. CR %#lx SR %#lx", len, addr,
             ok ? "ok" : "fail", MG_REG(bank + FLASH_CR),
             MG_REG(bank + FLASH_SR)));
   MG_REG(bank + FLASH_CR) &= ~MG_BIT(1);  // Clear programming flag
@@ -11297,7 +11301,7 @@ MG_IRAM static void single_bank_swap(char *p1, char *p2, size_t s, size_t ss) {
   for (size_t ofs = 0; ofs < s; ofs += ss) {
     mg_stm32h7_write(p1 + ofs, p2 + ofs, ss);
   }
-  *(volatile unsigned long *) 0xe000ed0c = 0x5fa0004;
+  *(volatile uint32_t *) 0xe000ed0cU = 0x5fa0004U;  // NVIC_SystemReset()
 }
 
 bool mg_ota_begin(size_t new_firmware_size) {
@@ -11307,8 +11311,8 @@ bool mg_ota_begin(size_t new_firmware_size) {
     s_mg_flash_stm32h7.size /= 2;
   }
 #ifdef __ZEPHYR__
-  *((uint32_t *)0xE000ED94) = 0;
-  MG_DEBUG(("Jailbreak %s", *((uint32_t *)0xE000ED94) == 0 ? "successful" : "failed"));
+  *((uint32_t *) 0xE000ED94) = 0;
+  MG_DEBUG(("Jailbreak %s", *((uint32_t *) 0xE000ED94) == 0 ? "ok" : "failed"));
 #endif
   return mg_ota_flash_begin(new_firmware_size, &s_mg_flash_stm32h7);
 }
@@ -11321,7 +11325,7 @@ bool mg_ota_end(void) {
   if (mg_ota_flash_end(&s_mg_flash_stm32h7)) {
     if (is_dualbank()) {
       // Bank swap is deferred until reset, been executing in flash, reset
-      *(volatile unsigned long *) 0xe000ed0c = 0x5fa0004;
+      *(volatile uint32_t *) 0xe000ed0cU = 0x5fa0004U;  // NVIC_SystemReset()
     } else {
       // Swap partitions. Pray power does not go away
       MG_INFO(("Swapping partitions, size %u (%u sectors)",
@@ -11339,6 +11343,7 @@ bool mg_ota_end(void) {
   }
   return false;
 }
+
 struct mg_flash *mg_flash = &s_mg_flash_stm32h7;
 #endif
 
@@ -20375,7 +20380,7 @@ done:
 
 
 
-#if MG_TLS == MG_TLS_BUILTIN
+#if MG_TLS == MG_TLS_BUILTIN || defined(MG_OTA_PUBLIC_KEY)
 
 #ifndef MG_UECC_RNG_MAX_TRIES
 #define MG_UECC_RNG_MAX_TRIES 64

--- a/mongoose.h
+++ b/mongoose.h
@@ -3256,24 +3256,24 @@ extern void mg_mqtt_poll(struct mg_mgr *);
 
 
 
-#define MG_OTA_NONE 0       // No OTA support
-#define MG_OTA_STM32H5 1    // STM32 H5
-#define MG_OTA_STM32H7 2    // STM32 H7
-#define MG_OTA_STM32H7_DUAL_CORE 3 // STM32 H7 dual core
-#define MG_OTA_STM32F  4    // STM32 F7/F4/F2
-#define MG_OTA_CH32V307 100 // WCH CH32V307
-#define MG_OTA_U2A 200      // Renesas U2A16, U2A8, U2A6
-#define MG_OTA_RT1020 300   // IMXRT1020
-#define MG_OTA_RT1050 301   // IMXRT1050
-#define MG_OTA_RT1060 302   // IMXRT1060
-#define MG_OTA_RT1064 303   // IMXRT1064
-#define MG_OTA_RT1170 304   // IMXRT1170
-#define MG_OTA_MCXN 310 	// MCXN947
-#define MG_OTA_RW612 320    // FRDM-RW612
-#define MG_OTA_FLASH 900    // OTA via an internal flash
-#define MG_OTA_ESP32 910    // ESP32 OTA implementation
-#define MG_OTA_PICOSDK 920  // RP2040/2350 using Pico-SDK hardware_flash
-#define MG_OTA_CUSTOM 1000  // Custom implementation
+#define MG_OTA_NONE 0               // No OTA support
+#define MG_OTA_STM32H5 1            // STM32 H5
+#define MG_OTA_STM32H7 2            // STM32 H7
+#define MG_OTA_STM32H7_DUAL_CORE 3  // STM32 H7 dual core
+#define MG_OTA_STM32F 4             // STM32 F7/F4/F2
+#define MG_OTA_CH32V307 100         // WCH CH32V307
+#define MG_OTA_U2A 200              // Renesas U2A16, U2A8, U2A6
+#define MG_OTA_RT1020 300           // IMXRT1020
+#define MG_OTA_RT1050 301           // IMXRT1050
+#define MG_OTA_RT1060 302           // IMXRT1060
+#define MG_OTA_RT1064 303           // IMXRT1064
+#define MG_OTA_RT1170 304           // IMXRT1170
+#define MG_OTA_MCXN 310             // MCXN947
+#define MG_OTA_RW612 320            // FRDM-RW612
+#define MG_OTA_FLASH 900            // OTA via an internal flash
+#define MG_OTA_ESP32 910            // ESP32 OTA implementation
+#define MG_OTA_PICOSDK 920          // RP2040/2350 using Pico-SDK hardware_flash
+#define MG_OTA_CUSTOM 1000          // Custom implementation
 
 #ifndef MG_OTA
 #define MG_OTA MG_OTA_NONE
@@ -3283,18 +3283,73 @@ extern void mg_mqtt_poll(struct mg_mgr *);
 #define MG_IRAM __attribute__((noinline, section(".iram")))
 #else
 #define MG_IRAM
-#endif // compiler
-#endif // IRAM
-#endif // OTA
+#endif  // compiler
+#endif  // IRAM
+#endif  // OTA
 
 // Firmware update API
 bool mg_ota_begin(size_t new_firmware_size);     // Start writing
 bool mg_ota_write(const void *buf, size_t len);  // Write chunk, aligned to 1k
 bool mg_ota_end(void);                           // Stop writing
-void mg_ota_url_check(struct mg_mgr *mgr,
-                      const char *current_version,
-                      const char *metadata_url,
-                      void (*fn)(const char *status));
+
+// MG_OTA_ROLLBACK: swap firmware banks and reset. On flash-based OTA the
+// default calls swap_fn() (no-op on single-bank) then resets. Override in
+// mongoose_config.h for platforms without mg_flash (ESP32, PicoSDK, etc.).
+#ifndef MG_OTA_ROLLBACK
+#define MG_OTA_ROLLBACK() \
+  do {                    \
+    mg_flash->swap_fn();  \
+    NVIC_SystemReset();   \
+  } while (0)
+#endif
+
+// MG_OTA_ROLLBACK_TIMER_START(seconds): arm a hardware watchdog as the rollback
+// deadline. If it fires before MG_OTA_STATE_SET(MG_OTA_CONFIRMED), the device
+// resets and MG_OTA_STATE_GET() == MG_OTA_FAILED triggers MG_OTA_ROLLBACK().
+#ifndef MG_OTA_ROLLBACK_TIMER_START
+#define MG_OTA_ROLLBACK_TIMER_START(seconds) (void) (seconds)
+#endif
+
+// OTA state values for MG_OTA_STATE_GET / MG_OTA_STATE_SET.
+// MG_OTA_CONFIRMED: firmware is committed, normal operation.
+// MG_OTA_TESTING:   new firmware booted for the first time; IWDG is armed.
+//                   If the device reboots while in this state, it transitions
+//                   to MG_OTA_FAILED and rolls back on the next boot.
+// MG_OTA_FAILED:    previous boot did not commit in time; rollback on next
+// boot.
+enum { MG_OTA_CONFIRMED = 0, MG_OTA_TESTING = 1, MG_OTA_FAILED = 2 };
+
+// Persistent OTA state storage. Define in mongoose_config.h to use a
+// location that survives resets
+#ifndef MG_OTA_STATE_GET
+#define MG_OTA_STATE_GET() 0
+#endif
+#ifndef MG_OTA_STATE_SET
+#define MG_OTA_STATE_SET(val) (void) (val)
+#endif
+
+// Call once at boot. Arms the rollback watchdog for (seconds) seconds when
+// the new firmware is in TESTING state. Rolls back immediately if FAILED.
+// boot (TESTING) → set FAILED → arm IWDG → run firmware
+//  ├── commit called → set CONFIRMED → NVIC_SystemReset() → clean boot
+//  └── IWDG fires → hard reset → boot → state is still FAILED → rollback
+#define MG_OTA_BOOT_CHECK(seconds)                                 \
+  do {                                                             \
+    if (MG_OTA_STATE_GET() == MG_OTA_FAILED) {                     \
+      MG_OTA_STATE_SET(MG_OTA_CONFIRMED);                          \
+      MG_INFO(("Commit deadline expired, rolling back"));          \
+      MG_OTA_ROLLBACK();                                           \
+    } else if (MG_OTA_STATE_GET() == MG_OTA_TESTING) {             \
+      MG_OTA_STATE_SET(MG_OTA_FAILED);                             \
+      MG_INFO(("New firmware: commit within %u sec or rolls back", \
+               (unsigned) (seconds)));                             \
+      MG_OTA_ROLLBACK_TIMER_START(seconds);                        \
+    }                                                              \
+  } while (0)
+
+// Pull based OTA over HTTP
+void mg_ota_url_check(struct mg_mgr *mgr, const char *current_version,
+                      const char *metadata_url, void (*fn)(const char *status));
 
 
 

--- a/src/flash.c
+++ b/src/flash.c
@@ -27,7 +27,7 @@ bool mg_ota_flash_begin(size_t new_firmware_size, struct mg_flash *flash) {
       s_size = new_firmware_size;
       MG_INFO(("Starting OTA, firmware size %lu", s_size));
     } else {
-      MG_ERROR(("Firmware %lu is too big to fit %lu", new_firmware_size, half));
+      MG_ERROR(("Firmware %lu is too big to fit %lu", new_firmware_size, half - flash->align));
     }
   }
   return ok;
@@ -76,6 +76,7 @@ bool mg_ota_flash_end(struct mg_flash *flash) {
     }
 #endif
     s_size = 0;
+    if (ok) MG_OTA_STATE_SET(MG_OTA_TESTING);
     if (ok) ok = flash->swap_fn();
   }
   MG_INFO(("Finishing OTA: %s", ok ? "ok" : "fail"));

--- a/src/http.c
+++ b/src/http.c
@@ -1041,6 +1041,11 @@ static void mg_upload_handler(struct mg_connection *c, int ev, void *ev_data) {
   (void) ev_data;
 }
 
+static void mg_upload_default_cb(struct mg_connection *c, const char *status) {
+  MG_INFO(("%lu %s", c->id, status ? status : "ok"));
+  mg_http_reply(c, status ? 500 : 200, "", "%s\n", status ? status : "ok");
+}
+
 void mg_http_start_upload(struct mg_connection *c, struct mg_http_message *hm,
                           struct mg_str name, struct mg_str dir,
                           struct mg_fs *fs,
@@ -1048,6 +1053,7 @@ void mg_http_start_upload(struct mg_connection *c, struct mg_http_message *hm,
   struct mg_upload_priv *p = (struct mg_upload_priv *) c->data;
   char path[MG_PATH_MAX];
   struct mg_fd *fd;
+  if (fn == NULL) fn = mg_upload_default_cb;
   if (sizeof(*p) > sizeof(c->data)) { fn(c, "data too small"); return; }
   if (!mg_path_is_sane(name)) { fn(c, "bad name"); return; }
   mg_snprintf(path, sizeof(path), "%.*s%c%.*s", (int) dir.len, dir.buf,
@@ -1067,6 +1073,7 @@ void mg_http_start_upload(struct mg_connection *c, struct mg_http_message *hm,
 void mg_http_start_ota(struct mg_connection *c, struct mg_http_message *hm,
                        void (*fn)(struct mg_connection *, const char *)) {
   struct mg_upload_priv *p = (struct mg_upload_priv *) c->data;
+  if (fn == NULL) fn = mg_upload_default_cb;
   if (sizeof(*p) > sizeof(c->data)) { fn(c, "data too small"); return; }
   if (!mg_ota_begin(hm->body.len)) { fn(c, "ota begin failed"); return; }
   p->expected = hm->body.len;

--- a/src/ota.h
+++ b/src/ota.h
@@ -6,24 +6,24 @@
 #include "arch.h"
 #include "net.h"
 
-#define MG_OTA_NONE 0       // No OTA support
-#define MG_OTA_STM32H5 1    // STM32 H5
-#define MG_OTA_STM32H7 2    // STM32 H7
-#define MG_OTA_STM32H7_DUAL_CORE 3 // STM32 H7 dual core
-#define MG_OTA_STM32F  4    // STM32 F7/F4/F2
-#define MG_OTA_CH32V307 100 // WCH CH32V307
-#define MG_OTA_U2A 200      // Renesas U2A16, U2A8, U2A6
-#define MG_OTA_RT1020 300   // IMXRT1020
-#define MG_OTA_RT1050 301   // IMXRT1050
-#define MG_OTA_RT1060 302   // IMXRT1060
-#define MG_OTA_RT1064 303   // IMXRT1064
-#define MG_OTA_RT1170 304   // IMXRT1170
-#define MG_OTA_MCXN 310 	// MCXN947
-#define MG_OTA_RW612 320    // FRDM-RW612
-#define MG_OTA_FLASH 900    // OTA via an internal flash
-#define MG_OTA_ESP32 910    // ESP32 OTA implementation
-#define MG_OTA_PICOSDK 920  // RP2040/2350 using Pico-SDK hardware_flash
-#define MG_OTA_CUSTOM 1000  // Custom implementation
+#define MG_OTA_NONE 0               // No OTA support
+#define MG_OTA_STM32H5 1            // STM32 H5
+#define MG_OTA_STM32H7 2            // STM32 H7
+#define MG_OTA_STM32H7_DUAL_CORE 3  // STM32 H7 dual core
+#define MG_OTA_STM32F 4             // STM32 F7/F4/F2
+#define MG_OTA_CH32V307 100         // WCH CH32V307
+#define MG_OTA_U2A 200              // Renesas U2A16, U2A8, U2A6
+#define MG_OTA_RT1020 300           // IMXRT1020
+#define MG_OTA_RT1050 301           // IMXRT1050
+#define MG_OTA_RT1060 302           // IMXRT1060
+#define MG_OTA_RT1064 303           // IMXRT1064
+#define MG_OTA_RT1170 304           // IMXRT1170
+#define MG_OTA_MCXN 310             // MCXN947
+#define MG_OTA_RW612 320            // FRDM-RW612
+#define MG_OTA_FLASH 900            // OTA via an internal flash
+#define MG_OTA_ESP32 910            // ESP32 OTA implementation
+#define MG_OTA_PICOSDK 920          // RP2040/2350 using Pico-SDK hardware_flash
+#define MG_OTA_CUSTOM 1000          // Custom implementation
 
 #ifndef MG_OTA
 #define MG_OTA MG_OTA_NONE
@@ -33,15 +33,70 @@
 #define MG_IRAM __attribute__((noinline, section(".iram")))
 #else
 #define MG_IRAM
-#endif // compiler
-#endif // IRAM
-#endif // OTA
+#endif  // compiler
+#endif  // IRAM
+#endif  // OTA
 
 // Firmware update API
 bool mg_ota_begin(size_t new_firmware_size);     // Start writing
 bool mg_ota_write(const void *buf, size_t len);  // Write chunk, aligned to 1k
 bool mg_ota_end(void);                           // Stop writing
-void mg_ota_url_check(struct mg_mgr *mgr,
-                      const char *current_version,
-                      const char *metadata_url,
-                      void (*fn)(const char *status));
+
+// MG_OTA_ROLLBACK: swap firmware banks and reset. On flash-based OTA the
+// default calls swap_fn() (no-op on single-bank) then resets. Override in
+// mongoose_config.h for platforms without mg_flash (ESP32, PicoSDK, etc.).
+#ifndef MG_OTA_ROLLBACK
+#define MG_OTA_ROLLBACK() \
+  do {                    \
+    mg_flash->swap_fn();  \
+    NVIC_SystemReset();   \
+  } while (0)
+#endif
+
+// MG_OTA_ROLLBACK_TIMER_START(seconds): arm a hardware watchdog as the rollback
+// deadline. If it fires before MG_OTA_STATE_SET(MG_OTA_CONFIRMED), the device
+// resets and MG_OTA_STATE_GET() == MG_OTA_FAILED triggers MG_OTA_ROLLBACK().
+#ifndef MG_OTA_ROLLBACK_TIMER_START
+#define MG_OTA_ROLLBACK_TIMER_START(seconds) (void) (seconds)
+#endif
+
+// OTA state values for MG_OTA_STATE_GET / MG_OTA_STATE_SET.
+// MG_OTA_CONFIRMED: firmware is committed, normal operation.
+// MG_OTA_TESTING:   new firmware booted for the first time; IWDG is armed.
+//                   If the device reboots while in this state, it transitions
+//                   to MG_OTA_FAILED and rolls back on the next boot.
+// MG_OTA_FAILED:    previous boot did not commit in time; rollback on next
+// boot.
+enum { MG_OTA_CONFIRMED = 0, MG_OTA_TESTING = 1, MG_OTA_FAILED = 2 };
+
+// Persistent OTA state storage. Define in mongoose_config.h to use a
+// location that survives resets
+#ifndef MG_OTA_STATE_GET
+#define MG_OTA_STATE_GET() 0
+#endif
+#ifndef MG_OTA_STATE_SET
+#define MG_OTA_STATE_SET(val) (void) (val)
+#endif
+
+// Call once at boot. Arms the rollback watchdog for (seconds) seconds when
+// the new firmware is in TESTING state. Rolls back immediately if FAILED.
+// boot (TESTING) → set FAILED → arm IWDG → run firmware
+//  ├── commit called → set CONFIRMED → NVIC_SystemReset() → clean boot
+//  └── IWDG fires → hard reset → boot → state is still FAILED → rollback
+#define MG_OTA_BOOT_CHECK(seconds)                                 \
+  do {                                                             \
+    if (MG_OTA_STATE_GET() == MG_OTA_FAILED) {                     \
+      MG_OTA_STATE_SET(MG_OTA_CONFIRMED);                          \
+      MG_INFO(("Commit deadline expired, rolling back"));          \
+      MG_OTA_ROLLBACK();                                           \
+    } else if (MG_OTA_STATE_GET() == MG_OTA_TESTING) {             \
+      MG_OTA_STATE_SET(MG_OTA_FAILED);                             \
+      MG_INFO(("New firmware: commit within %u sec or rolls back", \
+               (unsigned) (seconds)));                             \
+      MG_OTA_ROLLBACK_TIMER_START(seconds);                        \
+    }                                                              \
+  } while (0)
+
+// Pull based OTA over HTTP
+void mg_ota_url_check(struct mg_mgr *mgr, const char *current_version,
+                      const char *metadata_url, void (*fn)(const char *status));

--- a/src/ota_stm32h5.c
+++ b/src/ota_stm32h5.c
@@ -96,10 +96,8 @@ static bool mg_stm32h5_swap(void) {
   uint32_t desired = flash_bank_is_swapped() ? 0 : MG_BIT(31);
   flash_unlock();
   flash_clear_err();
-  // printf("OPTSR_PRG 1 %#lx\n", FLASH->OPTSR_PRG);
   MG_SET_BITS(MG_REG(FLASH_OPTSR_PRG), MG_BIT(31), desired);
-  // printf("OPTSR_PRG 2 %#lx\n", FLASH->OPTSR_PRG);
-  MG_REG(FLASH_OPTCR) |= MG_BIT(1);  // OPTSTART
+  MG_REG(FLASH_OPTCR) |= MG_BIT(1);  // OPTSTART; triggers auto-reset on H5
   while ((MG_REG(FLASH_OPTSR_CUR) & MG_BIT(31)) != desired) (void) 0;
   return true;
 }
@@ -146,10 +144,9 @@ bool mg_ota_write(const void *buf, size_t len) {
   return mg_ota_flash_write(buf, len, &s_mg_flash_stm32h5);
 }
 
-// Actual bank swap is deferred until reset, it is safe to execute in flash
 bool mg_ota_end(void) {
-  if(!mg_ota_flash_end(&s_mg_flash_stm32h5)) return false;
-  *(volatile unsigned long *) 0xe000ed0c = 0x5fa0004;
+  if (!mg_ota_flash_end(&s_mg_flash_stm32h5)) return false;
+  *(volatile uint32_t *) 0xe000ed0c = 0x5fa0004U;  // NVIC_SystemReset()
   return true;
 }
 struct mg_flash *mg_flash = &s_mg_flash_stm32h5;

--- a/src/ota_stm32h7.c
+++ b/src/ota_stm32h7.c
@@ -112,6 +112,7 @@ MG_IRAM static bool mg_stm32h7_erase(void *addr) {
     MG_REG(bank + FLASH_CR) |= (sector & 7U) << 8U;  // Sector to erase
     MG_REG(bank + FLASH_CR) |= MG_BIT(2);            // Sector erase bit
     MG_REG(bank + FLASH_CR) |= MG_BIT(7);            // Start erasing
+    flash_wait(bank);
     ok = !flash_is_err(bank);
     MG_DEBUG(("Erase sector %lu @ %p %s. CR %#lx SR %#lx", sector, addr,
               ok ? "ok" : "fail", MG_REG(bank + FLASH_CR),
@@ -127,9 +128,7 @@ MG_IRAM static bool mg_stm32h7_swap(void) {
   uint32_t desired = flash_bank_is_swapped(bank) ? 0 : MG_BIT(31);
   flash_unlock();
   flash_clear_err(bank);
-  // printf("OPTSR_PRG 1 %#lx\n", FLASH->OPTSR_PRG);
   MG_SET_BITS(MG_REG(bank + FLASH_OPTSR_PRG), MG_BIT(31), desired);
-  // printf("OPTSR_PRG 2 %#lx\n", FLASH->OPTSR_PRG);
   MG_REG(bank + FLASH_OPTCR) |= MG_BIT(1);  // OPTSTART
   while ((MG_REG(bank + FLASH_OPTSR_CUR) & MG_BIT(31)) != desired) (void) 0;
   return true;
@@ -162,7 +161,7 @@ MG_IRAM static bool mg_stm32h7_write(void *addr, const void *buf, size_t len) {
     if (flash_is_err(bank)) ok = false;
   }
   if (!s_flash_irq_disabled) MG_ARM_ENABLE_IRQ();
-  MG_DEBUG(("Flash write %lu bytes @ %p: %s. CR %#lx SR %#lx", len, dst,
+  MG_DEBUG(("Flash write %lu bytes @ %p: %s. CR %#lx SR %#lx", len, addr,
             ok ? "ok" : "fail", MG_REG(bank + FLASH_CR),
             MG_REG(bank + FLASH_SR)));
   MG_REG(bank + FLASH_CR) &= ~MG_BIT(1);  // Clear programming flag
@@ -175,7 +174,7 @@ MG_IRAM static void single_bank_swap(char *p1, char *p2, size_t s, size_t ss) {
   for (size_t ofs = 0; ofs < s; ofs += ss) {
     mg_stm32h7_write(p1 + ofs, p2 + ofs, ss);
   }
-  *(volatile unsigned long *) 0xe000ed0c = 0x5fa0004;
+  *(volatile uint32_t *) 0xe000ed0cU = 0x5fa0004U;  // NVIC_SystemReset()
 }
 
 bool mg_ota_begin(size_t new_firmware_size) {
@@ -185,8 +184,8 @@ bool mg_ota_begin(size_t new_firmware_size) {
     s_mg_flash_stm32h7.size /= 2;
   }
 #ifdef __ZEPHYR__
-  *((uint32_t *)0xE000ED94) = 0;
-  MG_DEBUG(("Jailbreak %s", *((uint32_t *)0xE000ED94) == 0 ? "successful" : "failed"));
+  *((uint32_t *) 0xE000ED94) = 0;
+  MG_DEBUG(("Jailbreak %s", *((uint32_t *) 0xE000ED94) == 0 ? "ok" : "failed"));
 #endif
   return mg_ota_flash_begin(new_firmware_size, &s_mg_flash_stm32h7);
 }
@@ -199,7 +198,7 @@ bool mg_ota_end(void) {
   if (mg_ota_flash_end(&s_mg_flash_stm32h7)) {
     if (is_dualbank()) {
       // Bank swap is deferred until reset, been executing in flash, reset
-      *(volatile unsigned long *) 0xe000ed0c = 0x5fa0004;
+      *(volatile uint32_t *) 0xe000ed0cU = 0x5fa0004U;  // NVIC_SystemReset()
     } else {
       // Swap partitions. Pray power does not go away
       MG_INFO(("Swapping partitions, size %u (%u sectors)",
@@ -217,5 +216,6 @@ bool mg_ota_end(void) {
   }
   return false;
 }
+
 struct mg_flash *mg_flash = &s_mg_flash_stm32h7;
 #endif

--- a/src/tls_uecc.c
+++ b/src/tls_uecc.c
@@ -3,7 +3,7 @@
 #include "tls_uecc.h"
 #include "tls.h"
 
-#if MG_TLS == MG_TLS_BUILTIN
+#if MG_TLS == MG_TLS_BUILTIN || defined(MG_OTA_PUBLIC_KEY)
 
 #ifndef MG_UECC_RNG_MAX_TRIES
 #define MG_UECC_RNG_MAX_TRIES 64

--- a/tutorials/stm32/nucleo-h563zi/minimal/Makefile
+++ b/tutorials/stm32/nucleo-h563zi/minimal/Makefile
@@ -12,7 +12,7 @@ SOURCES = main.c hal.c
 SOURCES += cmsis_h5/Source/Templates/gcc/startup_stm32h563xx.s
 SOURCES += mongoose/mongoose.c
 
-all build example: firmware.bin
+all build example: firmware.signed.bin
 
 mongoose/mongoose.c mongoose/mongoose.h:
 	cp ../../../../mongoose.[ch] mongoose/

--- a/tutorials/stm32/nucleo-h563zi/minimal/hal.h
+++ b/tutorials/stm32/nucleo-h563zi/minimal/hal.h
@@ -126,7 +126,7 @@ static inline bool hal_uart_init(USART_TypeDef *uart, uint16_t tx_pin,
 }
 static inline void hal_uart_write_byte(USART_TypeDef *uart, uint8_t byte) {
   uart->TDR = byte;
-  while ((uart->ISR & BIT(7)) == 0) spin(1);
+  while ((uart->ISR & USART_ISR_TXE_TXFNF) == 0) (void) 0;
 }
 static inline void hal_uart_write_buf(USART_TypeDef *uart, char *buf, size_t len) {
   while (len-- > 0) hal_uart_write_byte(uart, *(uint8_t *) buf++);
@@ -144,7 +144,7 @@ static inline void hal_rng_init(void) {
   RNG->CR |= RNG_CR_RNGEN;             // Enable RNG
 }
 static inline uint32_t hal_rng_read(void) {
-  while ((RNG->SR & RNG_SR_DRDY) == 0) spin(1);
+  while ((RNG->SR & RNG_SR_DRDY) == 0) (void) 0;
   return RNG->DR;
 }
 
@@ -181,7 +181,23 @@ static inline void hal_system_init(void) {
   __ISB();
 }
 
+// Enable TAMP/RTC APB clock, backup domain write access, and RTC/TAMP kernel
+// clock (LSI). Idempotent: skips RTC init if already enabled after a reset.
+// Must be called before accessing TAMP backup registers or IWDG.
+static inline void hal_backup_domain_init(void) {
+  RCC->APB3ENR |= RCC_APB3ENR_RTCAPBEN;  // enable TAMP/RTC APB clock
+  PWR->DBPCR |= PWR_DBPCR_DBP;           // enable backup domain write access
+  if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {  // init only once (not warm reset)
+    RCC->BDCR |= RCC_BDCR_LSION;                           // enable LSI
+    while ((RCC->BDCR & RCC_BDCR_LSIRDY) == 0) (void) 0;  // wait ready
+    RCC->BDCR |= (2U << RCC_BDCR_RTCSEL_Pos);              // LSI as clock source
+    RCC->BDCR |= RCC_BDCR_RTCEN;                           // enable RTC/TAMP clock
+  }
+}
+
 static inline void hal_clock_init(void) {
+  hal_backup_domain_init();
+
   // Set flash latency. RM0481, section 7.11.1, section 7.3.4 table 37
   CLRSET(FLASH->ACR, (FLASH_ACR_WRHIGHFREQ_Msk | FLASH_ACR_LATENCY_Msk),
          FLASH_ACR_LATENCY_5WS | FLASH_ACR_WRHIGHFREQ_1);
@@ -192,10 +208,10 @@ static inline void hal_clock_init(void) {
     PWR->VOSCR = PWR_VOSCR_VOS_1;  // Select VOS1
   }
   uint32_t f = PWR->VOSCR;  // fake read to wait for bus clocking
-  while ((PWR->VOSSR & PWR_VOSSR_ACTVOSRDY) == 0) spin(1);
+  while ((PWR->VOSSR & PWR_VOSSR_ACTVOSRDY) == 0) (void) 0;
   (void) f;
   RCC->CR = RCC_CR_HSION;                          // Clear HSI clock divisor
-  while ((RCC->CR & RCC_CR_HSIRDY) == 0) spin(1);  // Wait until done
+  while ((RCC->CR & RCC_CR_HSIRDY) == 0) (void) 0;  // Wait until done
   RCC->CFGR2 = (HAL_PPRE3 << 12) | (HAL_PPRE2 << 8) | (HAL_PPRE1 << 4) | (HAL_HPRE << 0);
   RCC->PLL1DIVR =
       ((PLL1_P - 1) << 9) | ((PLL1_N - 1) << 0);  // Set PLL1_P PLL1_N
@@ -204,9 +220,9 @@ static inline void hal_clock_init(void) {
   RCC->PLL1CFGR =
       RCC_PLL1CFGR_PLL1QEN | RCC_PLL1CFGR_PLL1PEN | (PLL1_M << 8) | (1 << 0);
   RCC->CR |= RCC_CR_PLL1ON;                         // Enable PLL1
-  while ((RCC->CR & RCC_CR_PLL1RDY) == 0) spin(1);  // Wait until done
+  while ((RCC->CR & RCC_CR_PLL1RDY) == 0) (void) 0;  // Wait until done
   RCC->CFGR1 |= (3 << 0);                           // Set clock source to PLL1
-  while ((RCC->CFGR1 & (7 << 3)) != (3 << 3)) spin(1);  // Wait until done
+  while ((RCC->CFGR1 & (7 << 3)) != (3 << 3)) (void) 0;  // Wait until done
 
   SystemCoreClock = SYS_FREQUENCY;
 }

--- a/tutorials/stm32/nucleo-h563zi/minimal/main.c
+++ b/tutorials/stm32/nucleo-h563zi/minimal/main.c
@@ -43,17 +43,36 @@ bool mg_random(void *buf, size_t len) {
 }
 
 static void http_ev_handler(struct mg_connection *c, int ev, void *ev_data) {
-  if (ev == MG_EV_HTTP_MSG) {  // New HTTP request received
+  if (ev == MG_EV_HTTP_HDRS) {
+    struct mg_http_message *hm = (struct mg_http_message *) ev_data;
+    // Start OTA on headers so body chunks stream directly to flash (no RAM buffer)
+    if (mg_match(hm->uri, mg_str("/api/ota/update"), NULL)) {
+      mg_http_start_ota(c, hm, NULL);
+    }
+  } else if (ev == MG_EV_HTTP_MSG) {
     struct mg_http_message *hm = (struct mg_http_message *) ev_data;
     if (mg_match(hm->uri, mg_str("/api/tick"), NULL)) {
       mg_http_reply(c, 200, "", "{%m:%llu}\n", MG_ESC("tick"), hal_get_tick());
+    } else if (mg_match(hm->uri, mg_str("/api/ota/commit"), NULL)) {
+      c->data[0] = 1;
+      mg_http_reply(c, 200, "", "ok\n");
+    } else if (mg_match(hm->uri, mg_str("/api/ota/rollback"), NULL)) {
+      c->data[0] = 2;
+      mg_http_reply(c, 200, "", "ok\n");
     } else {
       mg_http_reply(c, 200, "", "Hi from Mongoose, tick %llu\n", hal_get_tick());
     }
+  } else if (ev == MG_EV_CLOSE && c->data[0] == 1) {
+    MG_OTA_STATE_SET(MG_OTA_CONFIRMED);
+    NVIC_SystemReset();
+  } else if (ev == MG_EV_CLOSE && c->data[0] == 2) {
+    MG_OTA_STATE_SET(MG_OTA_CONFIRMED);
+    MG_OTA_ROLLBACK();
   }
 }
 
 int main(void) {
+  hal_clock_init();
   hal_uart_init(UART_DEBUG, UART_DEBUG_TX_PIN, UART_DEBUG_RX_PIN, 115200);
   hal_rng_init();
   hal_gpio_output(LED_1);
@@ -62,7 +81,11 @@ int main(void) {
 
   hal_ethernet_init();
 
-  // Start a minimal web server
+  MG_INFO(("Initialised. CPU clock: %lu MHz", SystemCoreClock / 1000000));
+
+  // Max delay 131 seconds
+  MG_OTA_BOOT_CHECK(30);
+
   struct mg_mgr mgr;
   mg_mgr_init(&mgr);
   mg_http_listen(&mgr, "http://0.0.0.0", http_ev_handler, NULL);

--- a/tutorials/stm32/nucleo-h563zi/minimal/mongoose/mongoose_config.h
+++ b/tutorials/stm32/nucleo-h563zi/minimal/mongoose/mongoose_config.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "hal.h"
 
 // See https://mongoose.ws/documentation/#build-options
 #define MG_ARCH MG_ARCH_ARMGCC
@@ -12,16 +13,34 @@
 #define MG_ENABLE_PACKED_FS 1
 #define MG_ENABLE_DRIVER_STM32H 1
 
-#define MG_OTA_PUBLIC_KEY { \
-  0x19, 0x7f, 0xed, 0x81, 0x8b, 0xb7, 0xb2, 0xa5, \
-  0xde, 0xe0, 0xde, 0x04, 0x83, 0x60, 0xc8, 0x69, \
-  0x61, 0x39, 0x30, 0x1f, 0xc1, 0x52, 0x11, 0x4b, \
-  0xb7, 0xa4, 0xd7, 0x52, 0x03, 0x36, 0xc6, 0xc1, \
-  0xbf, 0x22, 0x75, 0x04, 0x49, 0xf8, 0x46, 0x47, \
-  0xec, 0x20, 0xd6, 0x8d, 0x48, 0x29, 0x7d, 0x63, \
-  0xb3, 0xf7, 0x1f, 0x58, 0x44, 0x82, 0xcc, 0x7a, \
-  0x4b, 0x5e, 0x68, 0x98, 0x24, 0x1f, 0x86, 0xf4, \
-}
+#define MG_OTA_PUBLIC_KEY                                               \
+  {                                                                     \
+      0x19, 0x7f, 0xed, 0x81, 0x8b, 0xb7, 0xb2, 0xa5, 0xde, 0xe0, 0xde, \
+      0x04, 0x83, 0x60, 0xc8, 0x69, 0x61, 0x39, 0x30, 0x1f, 0xc1, 0x52, \
+      0x11, 0x4b, 0xb7, 0xa4, 0xd7, 0x52, 0x03, 0x36, 0xc6, 0xc1, 0xbf, \
+      0x22, 0x75, 0x04, 0x49, 0xf8, 0x46, 0x47, 0xec, 0x20, 0xd6, 0x8d, \
+      0x48, 0x29, 0x7d, 0x63, 0xb3, 0xf7, 0x1f, 0x58, 0x44, 0x82, 0xcc, \
+      0x7a, 0x4b, 0x5e, 0x68, 0x98, 0x24, 0x1f, 0x86, 0xf4,             \
+  }
+
+// OTA rollback timer via IWDG. PR=8 → /1024 on H563 (RM0481 §52.4.2).
+// Max timeout: 4095 * 1024 / 32000 = 131 s. PVU/RVU must clear before
+// writing RLR/starting, otherwise the write is ignored (RM0481 §52.4.3).
+#define MG_OTA_ROLLBACK_TIMER_START(seconds)                                   \
+  do {                                                                         \
+    IWDG->KR = 0x5555U;                               /* unlock        */     \
+    IWDG->PR = 8U;                                    /* /1024         */     \
+    while (IWDG->SR & IWDG_SR_PVU) (void) 0;          /* wait PVU      */     \
+    IWDG->RLR = (uint32_t) ((seconds) * 32000 / 1024);                        \
+    while (IWDG->SR & IWDG_SR_RVU) (void) 0;          /* wait RVU      */     \
+    IWDG->KR = 0xCCCCU;                               /* start         */     \
+    IWDG->KR = 0xAAAAU;                               /* reload RLR    */     \
+  } while (0)
+
+// OTA state in TAMP backup register 0 (survives all resets, clears on POR).
+// Requires hal_backup_domain_init() (called from hal_clock_init) to have run.
+#define MG_OTA_STATE_GET()    (TAMP->BKP0R)
+#define MG_OTA_STATE_SET(v)   (TAMP->BKP0R = (uint32_t) (v))
 
 // #define MG_DRIVER_MDC_CR 4   // RMII MDC clock divider, from 0 to 4
 // #define MG_TCPIP_PHY_ADDR 0  // PHY address
@@ -33,17 +52,8 @@
 // #define MG_TCPIP_GW MG_IPV4(192, 168, 0, 1)
 // #define MG_TCPIP_MASK MG_IPV4(255, 255, 255, 0)
 
-// Set custom MAC address. By default, it is randomly generated
-// Using a build-time constant:
-// #define MG_SET_MAC_ADDRESS(mac) do { mac[0] = 2; mac[1] = 3; mac[2] = 4; mac[3] = 5; mac[4] = 6; mac[5] = 7; } while (0)
-//
-// Using custom function:
-// extern void my_function(unsigned char *mac);
-// #define MG_SET_MAC_ADDRESS(mac) my_function(mac)
-
-// Construct MAC address from the MCU unique ID. It is defined in the
-// ST CMSIS header as UID_BASE
-#define MGUID ((uint32_t *) 0x08fff800)  // Unique 96-bit chip ID
+// Construct MAC address from the MCU unique ID
+#define MGUID ((uint32_t *) UID_BASE)
 #define MG_SET_MAC_ADDRESS(mac)      \
   do {                               \
     mac[0] = 2;                      \

--- a/tutorials/stm32/nucleo-h723zg/minimal/Makefile
+++ b/tutorials/stm32/nucleo-h723zg/minimal/Makefile
@@ -27,7 +27,7 @@ firmware.bin: firmware.elf
 	@echo "To flash, run 'make flash', or use STM32CubeProgrammer"
 
 flash: firmware.bin
-	STM32_Programmer_CLI -c port=swd -e all -w firmware.elf -hardRst
+	STM32_Programmer_CLI -c port=swd -w firmware.elf -hardRst
 
 cmsis_core:
 	git clone -q -c advice.detachedHead=false --depth 1 -b 5.9.0 https://github.com/ARM-software/CMSIS_5 $@

--- a/tutorials/stm32/nucleo-h723zg/minimal/hal.h
+++ b/tutorials/stm32/nucleo-h723zg/minimal/hal.h
@@ -51,9 +51,6 @@ enum { PLL1_HSI = 64, PLL1_M = 32, PLL1_N = 225, PLL1_P = 1 };
 #define APB2_FREQUENCY (AHB_FREQUENCY / (BIT(HAL_D2PPRE2 - 3)))
 #define APB1_FREQUENCY (AHB_FREQUENCY / (BIT(HAL_D2PPRE1 - 3)))
 
-static inline void hal_spin(volatile uint32_t n) {
-  while (n--) (void) 0;
-}
 
 enum { HAL_GPIO_MODE_INPUT, HAL_GPIO_MODE_OUTPUT, HAL_GPIO_MODE_AF, HAL_GPIO_MODE_ANALOG };
 enum { HAL_GPIO_OTYPE_PUSH_PULL, HAL_GPIO_OTYPE_OPEN_DRAIN };
@@ -124,7 +121,7 @@ static inline void hal_uart_init(USART_TypeDef *uart, uint16_t tx,
 }
 static inline void hal_uart_write_byte(USART_TypeDef *uart, uint8_t byte) {
   uart->TDR = byte;
-  while ((uart->ISR & BIT(7)) == 0) hal_spin(1);
+  while ((uart->ISR & USART_ISR_TXE_TXFNF) == 0) (void) 0;
 }
 static inline void hal_uart_write_buf(USART_TypeDef *uart, char *buf, size_t len) {
   while (len-- > 0) hal_uart_write_byte(uart, *(uint8_t *) buf++);
@@ -146,7 +143,7 @@ static inline void hal_rng_init(void) {
   RNG->HTCR = 0x17590abc;
   RNG->HTCR = 0xaa74;
   RNG->CR &= ~RNG_CR_CONDRST ;
-  while(RNG->CR & RNG_CR_CONDRST) hal_spin(1); // 39.7.1
+  while (RNG->CR & RNG_CR_CONDRST) (void) 0;  // 39.7.1
   RNG->CR |= RNG_CR_RNGEN;  // Enable RNG
 }
 
@@ -184,11 +181,19 @@ static inline unsigned int hal_pllrge(unsigned int f) {
   return val - 1;
 }
 
+// Enable RTC/BKP APB clock and backup domain write access.
+// Must be called before accessing RTC backup registers or IWDG.
+static inline void hal_backup_domain_init(void) {
+  RCC->APB4ENR |= RCC_APB4ENR_RTCAPBEN;  // enable RTC/BKP APB clock
+  PWR->CR1 |= PWR_CR1_DBP;               // enable backup domain write access
+}
+
 static inline void hal_clock_init(void) {
-  PWR->CR3 |= BIT(1);                          // select LDO (reset value)
-  while ((PWR->CSR1 & BIT(13)) == 0) hal_spin(1);  // ACTVOSRDY
-  PWR->D3CR &= ~(BIT(15) | BIT(14));           // Select VOS0
-  while ((PWR->D3CR & BIT(13)) == 0) hal_spin(1);  // VOSRDY
+  hal_backup_domain_init();
+  PWR->CR3 |= PWR_CR3_LDOEN;                   // select LDO (reset value)
+  while ((PWR->CSR1 & PWR_CSR1_ACTVOSRDY) == 0) (void) 0;  // ACTVOSRDY
+  PWR->D3CR &= ~PWR_D3CR_VOS_Msk;              // Select VOS0
+  while ((PWR->D3CR & PWR_D3CR_VOSRDY) == 0) (void) 0;  // VOSRDY
   CLRSET(
       RCC->D1CFGR, (0x0F << 8) | (7 << 4) | (0x0F << 0),
       (hal_div2prescval(HAL_D1CPRE) << 8) | (HAL_D1PPRE << 4) | (hal_div2prescval(HAL_HPRE) << 0));
@@ -201,16 +206,17 @@ static inline void hal_clock_init(void) {
           ((PLL1_P - 1) << 9) | ((PLL1_N - 1) << 0));  // Set PLL1_P PLL1_N
   CLRSET(RCC->PLLCKSELR, 0x3F << 4,
           PLL1_M << 4);          // Set PLL1_M (source defaults to HSI)
-  RCC->CR |= BIT(24) | BIT(12);  // Enable PLL1 and HSI48 (for RNG)
-  while ((RCC->CR & BIT(25)) == 0) hal_spin(1);  // Wait until done
-  RCC->CFGR |= (3 << 0);                     // Set clock source to PLL1
-  while ((RCC->CFGR & (7 << 3)) != (3 << 3)) hal_spin(1);  // Wait until done
-  FLASH->ACR = HAL_FLASH_LATENCY;                          // default is larger
-  RCC->APB4ENR |= RCC_APB4ENR_SYSCFGEN;      // Enable SYSCFG
-  while ((RCC->CR & BIT(13)) == 0) hal_spin(1);  // Make sure HSI48 is ready
+  RCC->CR |= RCC_CR_PLL1ON | RCC_CR_HSI48ON;  // Enable PLL1 and HSI48 (for RNG)
+  while ((RCC->CR & RCC_CR_PLL1RDY) == 0) (void) 0;  // Wait until done
+  RCC->CFGR |= (3 << 0);                      // Set clock source to PLL1
+  while ((RCC->CFGR & (7 << 3)) != (3 << 3)) (void) 0;  // Wait until done
+  FLASH->ACR = HAL_FLASH_LATENCY;             // default is larger
+  RCC->APB4ENR |= RCC_APB4ENR_SYSCFGEN;       // Enable SYSCFG
+  while ((RCC->CR & RCC_CR_HSI48RDY) == 0) (void) 0;  // Make sure HSI48 is ready
   SystemCoreClock = SYS_FREQUENCY;         // Update SystemCoreClock global var
   SysTick_Config(SystemCoreClock / 1000);  // Sys tick every 1ms
 }
+
 
 static inline void hal_system_init(void) {
   SCB->CPACR |= ((3UL << 10 * 2) | (3UL << 11 * 2));  // Enable FPU

--- a/tutorials/stm32/nucleo-h723zg/minimal/main.c
+++ b/tutorials/stm32/nucleo-h723zg/minimal/main.c
@@ -43,13 +43,30 @@ bool mg_random(void *buf, size_t len) {
 }
 
 static void http_ev_handler(struct mg_connection *c, int ev, void *ev_data) {
-  if (ev == MG_EV_HTTP_MSG) {  // New HTTP request received
+  if (ev == MG_EV_HTTP_HDRS) {
+    struct mg_http_message *hm = (struct mg_http_message *) ev_data;
+    if (mg_match(hm->uri, mg_str("/api/ota/update"), NULL)) {
+      mg_http_start_ota(c, hm, NULL);
+    }
+  } else if (ev == MG_EV_HTTP_MSG) {
     struct mg_http_message *hm = (struct mg_http_message *) ev_data;
     if (mg_match(hm->uri, mg_str("/api/tick"), NULL)) {
       mg_http_reply(c, 200, "", "{%m:%llu}\n", MG_ESC("tick"), hal_get_tick());
+    } else if (mg_match(hm->uri, mg_str("/api/ota/commit"), NULL)) {
+      c->data[0] = 1;
+      mg_http_reply(c, 200, "", "ok\n");
+    } else if (mg_match(hm->uri, mg_str("/api/ota/rollback"), NULL)) {
+      c->data[0] = 2;
+      mg_http_reply(c, 200, "", "ok\n");
     } else {
       mg_http_reply(c, 200, "", "Hi from Mongoose, tick %llu\n", hal_get_tick());
     }
+  } else if (ev == MG_EV_CLOSE && c->data[0] == 1) {
+    MG_OTA_STATE_SET(MG_OTA_CONFIRMED);
+    NVIC_SystemReset();
+  } else if (ev == MG_EV_CLOSE && c->data[0] == 2) {
+    MG_OTA_STATE_SET(MG_OTA_CONFIRMED);
+    MG_OTA_ROLLBACK();
   }
 }
 
@@ -62,9 +79,11 @@ int main(void) {
   hal_gpio_output(LED2);
   hal_gpio_output(LED3);
 
-  printf("Initialised. CPU clock: %lu MHz\r\n", SystemCoreClock / 1000000);
+  MG_INFO(("Initialised. CPU clock: %lu MHz", SystemCoreClock / 1000000));
 
-  // Start a minimal web server
+  // Max delay 65 seconds
+  MG_OTA_BOOT_CHECK(30);
+
   struct mg_mgr mgr;
   mg_mgr_init(&mgr);
   mg_http_listen(&mgr, "http://0.0.0.0", http_ev_handler, NULL);

--- a/tutorials/stm32/nucleo-h723zg/minimal/mongoose/mongoose_config.h
+++ b/tutorials/stm32/nucleo-h723zg/minimal/mongoose/mongoose_config.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "hal.h"
 
 // See https://mongoose.ws/docs/getting-started/build-options/
 #define MG_ARCH MG_ARCH_ARMGCC
@@ -22,8 +23,27 @@
 // #define MG_TCPIP_GW MG_IPV4(192, 168, 0, 1)      // Gateway
 // #define MG_TCPIP_MASK MG_IPV4(255, 255, 255, 0)  // Netmask
 
+// OTA rollback timer via IWDG1. PR=7 → /512 on H723 (RM0468 §54.4.2).
+// Max timeout: 4095 * 512 / 32000 = 65 s.
+// RM0468 §54.4 sequence: 0xCCCC first (starts LSI), then 0x5555 to unlock,
+// write PR+RLR, wait SR=0 (PVU|RVU), then 0xAAAA to reload the counter.
+#define MG_OTA_ROLLBACK_TIMER_START(seconds)                                    \
+  do {                                                                          \
+    IWDG1->KR = 0xCCCCU;                               /* start/LSI     */    \
+    IWDG1->KR = 0x5555U;                               /* unlock        */    \
+    IWDG1->PR = 7U;                                    /* /512          */    \
+    IWDG1->RLR = (uint32_t) ((seconds) * 32000 / 512);                        \
+    while (IWDG1->SR & (IWDG_SR_PVU | IWDG_SR_RVU)) (void) 0; /* wait SR=0 */ \
+    IWDG1->KR = 0xAAAAU;                               /* reload        */    \
+  } while (0)
+
+// OTA state in RTC backup register 0 (survives all resets, clears on POR).
+// Requires hal_backup_domain_init() (called from hal_clock_init) to have run.
+#define MG_OTA_STATE_GET()    (RTC->BKP0R)
+#define MG_OTA_STATE_SET(v)   (RTC->BKP0R = (uint32_t) (v))
+
 // Construct MAC address from the MCU unique ID
-#define MGUID ((uint32_t *) 0x1ff1e800)  // Unique 96-bit chip ID
+#define MGUID ((uint32_t *) UID_BASE)
 #define MG_SET_MAC_ADDRESS(mac)      \
   do {                               \
     mac[0] = 2;                      \


### PR DESCRIPTION
This gives us the possibility of rollback if the new firmware hangs or crashes.

Manually tested on nucleo-h723zg and nucleo-h563zi

Added documentation for everything
https://mongoose.ws/docs/guides/firmware-ota-updates/

Please conduct a manual test for these two boards as well