### PR TITLE
Use mg_log_set_fn instead of _write override

### DIFF
--- a/resources/downloads/integrate_mongoose_cubemx.sh
+++ b/resources/downloads/integrate_mongoose_cubemx.sh
@@ -38,8 +38,9 @@ patch_linker_script() {
 }
 HUART=`perl -nle 'print \$1 if /^UART_HandleTypeDef (.+);/' $MAIN_C`
 grep -q mongoose.h $MAIN_C || perl -i -ne 'print; print "#include \"mongoose.h\"\n" if /BEGIN Includes/' $MAIN_C
-grep -q '^int _write' $MAIN_C || perl -i -ne "print; print \"int _write(int fd, unsigned char *buf, int len) {\n  HAL_UART_Transmit(&${HUART}, buf, len, HAL_MAX_DELAY);\n  return len;\n}\n\" if /USER CODE BEGIN 0/" $MAIN_C
-grep -q 'mg_mgr_init' $MAIN_C || perl -i -ne 'print; print "  struct mg_mgr mgr;\n  mg_mgr_init(&mgr);\n\n" if /USER CODE BEGIN WHILE/' $MAIN_C
+grep -q '^static void log_fn' $MAIN_C || perl -i -ne "print; print \"static void log_fn(char ch, void *param) {\n  HAL_UART_Transmit(param, (unsigned char *) &ch, 1, HAL_MAX_DELAY);\n}\n\" if /USER CODE BEGIN 0/" $MAIN_C
+grep -q 'mg_mgr_init' $MAIN_C || perl -i -ne 'print; print "  struct mg_mgr mgr;\n  mg_mgr_init(&mgr);\n  mg_log_set_fn(log_fn, &'"${HUART}"');\n\n" if /USER CODE BEGIN WHILE/' $MAIN_C
+grep -q 'mg_mgr_init' $MAIN_C && grep -q 'mg_log_set_fn' $MAIN_C || perl -i -ne 'print; print "  mg_log_set_fn(log_fn, &'"${HUART}"');\n" if /mg_mgr_init/' $MAIN_C
 grep -q 'mg_mgr_poll' $MAIN_C || perl -i -ne 'print "    mg_mgr_poll(&mgr, 0);\n" if /USER CODE END WHILE/; print;' $MAIN_C
 patch_linker_script $DIR/STM32H723XG_FLASH.ld
 patch_linker_script $DIR/STM32H743XX_FLASH.ld

--- a/tutorials/stm32/nucleo-f429zi/minimal/main.c
+++ b/tutorials/stm32/nucleo-f429zi/minimal/main.c
@@ -17,10 +17,8 @@
 #define LED2 PIN('B', 7)
 #define LED3 PIN('B', 14)
 
-// Redirect stdout debug output to UART
-int _write(int fd, char *ptr, int len) {
-  if (fd == 1 || fd == 2) hal_uart_write_buf(UART_DEBUG, ptr, (size_t) len);
-  return len;
+static void log_fn(char ch, void *param) {
+  hal_uart_write_buf(param, &ch, 1);
 }
 
 static void blink_task(void) {
@@ -61,6 +59,7 @@ int main(void) {
   hal_gpio_output(LED2);
   hal_gpio_output(LED3);
   hal_uart_init(UART_DEBUG, UART_DEBUG_TX_PIN, UART_DEBUG_RX_PIN, 115200);
+  mg_log_set_fn(log_fn, UART_DEBUG);
 
   hal_ethernet_init();
 

--- a/tutorials/stm32/nucleo-f746zg/minimal/main.c
+++ b/tutorials/stm32/nucleo-f746zg/minimal/main.c
@@ -17,10 +17,8 @@
 #define LED2 PIN('B', 7)
 #define LED3 PIN('B', 14)
 
-// Redirect stdout debug output to UART
-int _write(int fd, char *ptr, int len) {
-  if (fd == 1 || fd == 2) hal_uart_write_buf(UART_DEBUG, ptr, (size_t) len);
-  return len;
+static void log_fn(char ch, void *param) {
+  hal_uart_write_buf(param, &ch, 1);
 }
 
 static void blink_task(void) {
@@ -61,6 +59,7 @@ int main(void) {
   hal_gpio_output(LED2);
   hal_gpio_output(LED3);
   hal_uart_init(UART_DEBUG, UART_DEBUG_TX_PIN, UART_DEBUG_RX_PIN, 115200);
+  mg_log_set_fn(log_fn, UART_DEBUG);
 
   hal_ethernet_init();
 

--- a/tutorials/stm32/nucleo-f756zg/minimal/main.c
+++ b/tutorials/stm32/nucleo-f756zg/minimal/main.c
@@ -17,10 +17,8 @@
 #define LED2 PIN('B', 7)
 #define LED3 PIN('B', 14)
 
-// Redirect stdout debug output to UART
-int _write(int fd, char *ptr, int len) {
-  if (fd == 1 || fd == 2) hal_uart_write_buf(UART_DEBUG, ptr, (size_t) len);
-  return len;
+static void log_fn(char ch, void *param) {
+  hal_uart_write_buf(param, &ch, 1);
 }
 
 static void blink_task(void) {
@@ -61,6 +59,7 @@ int main(void) {
   hal_gpio_output(LED2);
   hal_gpio_output(LED3);
   hal_uart_init(UART_DEBUG, UART_DEBUG_TX_PIN, UART_DEBUG_RX_PIN, 115200);
+  mg_log_set_fn(log_fn, UART_DEBUG);
 
   hal_ethernet_init();
 

--- a/tutorials/stm32/nucleo-g031k8/minimal-w5500/main.c
+++ b/tutorials/stm32/nucleo-g031k8/minimal-w5500/main.c
@@ -21,10 +21,8 @@ static struct spi spi_pins = {
     .cs = PIN('A', 4),
 };
 
-// Redirect stdout debug output to UART
-int _write(int fd, char *ptr, int len) {
-  if (fd == 1 || fd == 2) uart_write_buf(UART_DEBUG, ptr, (size_t) len);
-  return len;
+static void log_fn(char ch, void *param) {
+  uart_write_buf(param, &ch, 1);
 }
 
 bool mg_random(void *buf, size_t len) {  // Use on-board RNG
@@ -74,6 +72,7 @@ static void fn(struct mg_connection *c, int ev, void *ev_data) {
 int main(void) {
   gpio_output(LED);               // Setup green LED
   uart_init(UART_DEBUG, UART_DEBUG_TX_PIN, UART_DEBUG_RX_PIN, 115200);
+  mg_log_set_fn(log_fn, UART_DEBUG);
 
   // ethernet_init();                // Initialise ethernet pins
   MG_INFO(("Starting, CPU freq %g MHz", (double) SystemCoreClock / 1000000));

--- a/tutorials/stm32/nucleo-h563zi/minimal/main.c
+++ b/tutorials/stm32/nucleo-h563zi/minimal/main.c
@@ -17,10 +17,8 @@
 #define LED_2 PIN('F', 4)  // On-board LED pin (yellow)
 #define LED_3 PIN('G', 4)  // On-board LED pin (red)
 
-// Redirect stdout debug output to UART
-int _write(int fd, char *ptr, int len) {
-  if (fd == 1 || fd == 2) hal_uart_write_buf(UART_DEBUG, ptr, (size_t) len);
-  return len;
+static void log_fn(char ch, void *param) {
+  hal_uart_write_buf(param, &ch, 1);
 }
 
 static void blink_task(void) {
@@ -55,6 +53,7 @@ static void http_ev_handler(struct mg_connection *c, int ev, void *ev_data) {
 
 int main(void) {
   hal_uart_init(UART_DEBUG, UART_DEBUG_TX_PIN, UART_DEBUG_RX_PIN, 115200);
+  mg_log_set_fn(log_fn, UART_DEBUG);
   hal_rng_init();
   hal_gpio_output(LED_1);
   hal_gpio_output(LED_2);

--- a/tutorials/stm32/nucleo-h723zg/minimal/main.c
+++ b/tutorials/stm32/nucleo-h723zg/minimal/main.c
@@ -17,10 +17,8 @@
 #define LED2 PIN('E', 1)
 #define LED3 PIN('B', 14)
 
-// Redirect stdout debug output to UART
-int _write(int fd, char *ptr, int len) {
-  if (fd == 1) hal_uart_write_buf(UART_DEBUG, ptr, (size_t) len);
-  return len;
+static void log_fn(char ch, void *param) {
+  hal_uart_write_buf(param, &ch, 1);
 }
 
 static void blink_task(void) {
@@ -56,6 +54,7 @@ static void http_ev_handler(struct mg_connection *c, int ev, void *ev_data) {
 int main(void) {
   hal_clock_init();
   hal_uart_init(UART_DEBUG, UART_DEBUG_TX_PIN, UART_DEBUG_RX_PIN, 115200);
+  mg_log_set_fn(log_fn, UART_DEBUG);
   hal_rng_init();
   hal_ethernet_init();
   hal_gpio_output(LED1);

--- a/tutorials/stm32/nucleo-h743zi/minimal/main.c
+++ b/tutorials/stm32/nucleo-h743zi/minimal/main.c
@@ -17,10 +17,8 @@
 #define LED2 PIN('E', 1)   // On-board LED pin (yellow)
 #define LED3 PIN('B', 14)  // On-board LED pin (red)
 
-// Redirect stdout debug output to UART
-int _write(int fd, char *ptr, int len) {
-  if (fd == 1 || fd == 2) hal_uart_write_buf(UART_DEBUG, ptr, (size_t) len);
-  return len;
+static void log_fn(char ch, void *param) {
+  hal_uart_write_buf(param, &ch, 1);
 }
 
 static void blink_task(void) {
@@ -61,6 +59,7 @@ int main(void) {
   hal_gpio_output(LED2);
   hal_gpio_output(LED3);
   hal_uart_init(UART_DEBUG, UART_DEBUG_TX_PIN, UART_DEBUG_RX_PIN, 115200);
+  mg_log_set_fn(log_fn, UART_DEBUG);
 
   hal_ethernet_init();
 

--- a/tutorials/stm32/nucleo-n657x0-q/minimal/main.c
+++ b/tutorials/stm32/nucleo-n657x0-q/minimal/main.c
@@ -12,10 +12,8 @@
 #define LED_2 PIN('G', 8)   // Blue LED
 #define LED_3 PIN('G', 10)  // Red LED
 
-// Redirect stdout debug output to UART
-int _write(int fd, char *ptr, int len) {
-  if (fd == 1) hal_uart_write_buf(DEBUG_UART, ptr, (size_t) len);
-  return len;
+static void log_fn(char ch, void *param) {
+  hal_uart_write_buf(param, &ch, 1);
 }
 
 // Blink green LED every 500ms
@@ -52,6 +50,7 @@ static void http_ev_handler(struct mg_connection *c, int ev, void *ev_data) {
 
 int main(void) {
   hal_uart_init(DEBUG_UART, UART_TX, UART_RX, 115200);
+  mg_log_set_fn(log_fn, DEBUG_UART);
   hal_rng_init();
 
   // Initialise pins and turn them off: they are active high

--- a/tutorials/stm32/nucleo-u5a5zj-q/minimal/main.c
+++ b/tutorials/stm32/nucleo-u5a5zj-q/minimal/main.c
@@ -9,10 +9,8 @@
 #define LED2 PIN('B', 7) // On-board LED pin (blue)
 #define LED3 PIN('G', 2) // On-board LED pin (red)
 
-// Redirect stdout debug output to UART
-int _write(int fd, char *ptr, int len) {
-  if (fd == 1 || fd == 2) hal_uart_write_buf(DEBUG_UART, ptr, (size_t) len);
-  return len;
+static void log_fn(char ch, void *param) {
+  hal_uart_write_buf(param, &ch, 1);
 }
 
 static void blink_task(void) {
@@ -53,6 +51,7 @@ int main(void) {
   hal_gpio_output(LED2);
   hal_gpio_output(LED3);
   hal_uart_init(DEBUG_UART, 115200);
+  mg_log_set_fn(log_fn, DEBUG_UART);
 
   extern void hwspecific_spi_init();
   hwspecific_spi_init();

--- a/tutorials/stm32/portenta-h7/minimal/main.c
+++ b/tutorials/stm32/portenta-h7/minimal/main.c
@@ -17,10 +17,8 @@
 #define LED2 PIN('K', 6) // On-board LED pin (green)
 #define LED3 PIN('K', 7) // On-board LED pin (blue)
 
-// Redirect stdout debug output to UART
-int _write(int fd, char *ptr, int len) {
-  if (fd == 1 || fd == 2) hal_uart_write_buf(UART_DEBUG, ptr, (size_t) len);
-  return len;
+static void log_fn(char ch, void *param) {
+  hal_uart_write_buf(param, &ch, 1);
 }
 
 static void blink_task(void) {
@@ -61,6 +59,7 @@ int main(void) {
   hal_gpio_output(LED2);
   hal_gpio_output(LED3);
   hal_uart_init(UART_DEBUG, UART_DEBUG_TX_PIN, UART_DEBUG_RX_PIN, 115200);
+  mg_log_set_fn(log_fn, UART_DEBUG);
 
   extern void hwspecific_sdio_init(void);
   hwspecific_sdio_init();

--- a/tutorials/stm32/stm32h573i-dk/minimal/main.c
+++ b/tutorials/stm32/stm32h573i-dk/minimal/main.c
@@ -17,10 +17,8 @@
 #define LED2 PIN('I', 8)  // On-board LED pin (orange)
 #define LED3 PIN('F', 1)  // On-board LED pin (red)
 
-// Redirect stdout debug output to UART
-int _write(int fd, char *ptr, int len) {
-  if (fd == 1 || fd == 2) hal_uart_write_buf(UART_DEBUG, ptr, (size_t) len);
-  return len;
+static void log_fn(char ch, void *param) {
+  hal_uart_write_buf(param, &ch, 1);
 }
 
 static void blink_task(void) {
@@ -61,6 +59,7 @@ int main(void) {
   hal_gpio_output(LED2);
   hal_gpio_output(LED3);
   hal_uart_init(UART_DEBUG, UART_DEBUG_TX_PIN, UART_DEBUG_RX_PIN, 115200);
+  mg_log_set_fn(log_fn, UART_DEBUG);
 
   hal_ethernet_init();
 

--- a/tutorials/stm32/stm32h747i-disco/minimal/main.c
+++ b/tutorials/stm32/stm32h747i-disco/minimal/main.c
@@ -17,10 +17,8 @@
 #define LED2 PIN('I', 13)  // On-board LED pin (yellow)
 #define LED3 PIN('I', 14)  // On-board LED pin (red)
 
-// Redirect stdout debug output to UART
-int _write(int fd, char *ptr, int len) {
-  if (fd == 1 || fd == 2) hal_uart_write_buf(UART_DEBUG, ptr, (size_t) len);
-  return len;
+static void log_fn(char ch, void *param) {
+  hal_uart_write_buf(param, &ch, 1);
 }
 
 static void blink_task(void) {
@@ -61,6 +59,7 @@ int main(void) {
   hal_gpio_output(LED2);
   hal_gpio_output(LED3);
   hal_uart_init(UART_DEBUG, UART_DEBUG_TX_PIN, UART_DEBUG_RX_PIN, 115200);
+  mg_log_set_fn(log_fn, UART_DEBUG);
 
   hal_ethernet_init();
 


### PR DESCRIPTION
We may need _write to implement LFS / SPIFFS filesystem retargeting, so don't touch _write