### PR TITLE
check DER long-form length bounds in mg_der_to_tlv

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -15526,6 +15526,7 @@ static int mg_der_to_tlv(uint8_t *der, size_t dersz, struct mg_der_tlv *tlv) {
   tlv->value = der + 2;
   if (tlv->len > 0x7f) {
     uint32_t i, n = tlv->len - 0x80;
+    if (dersz < (size_t) (2 + n)) return -1;
     tlv->len = 0;
     for (i = 0; i < n; i++) {
       tlv->len = (tlv->len << 8) | (der[2 + i]);

--- a/src/tls_builtin.c
+++ b/src/tls_builtin.c
@@ -249,6 +249,7 @@ static int mg_der_to_tlv(uint8_t *der, size_t dersz, struct mg_der_tlv *tlv) {
   tlv->value = der + 2;
   if (tlv->len > 0x7f) {
     uint32_t i, n = tlv->len - 0x80;
+    if (dersz < (size_t) (2 + n)) return -1;
     tlv->len = 0;
     for (i = 0; i < n; i++) {
       tlv->len = (tlv->len << 8) | (der[2 + i]);


### PR DESCRIPTION
mg_der_to_tlv() parses ASN.1 from an untrusted TLS peer (the ECDSA signature in CertificateVerify). On a long-form length it reads der[1]-0x80 length bytes without checking they fit in dersz, so der[2..128] can be read past the buffer. Add the same guard mg_der_parse already has.