### PR TITLE
bound session_id_len in mg_tls_server_recv_hello

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -15944,6 +15944,7 @@ static int mg_tls_server_recv_hello(struct mg_connection *c) {
   memmove(tls->random, rio->buf + 11, sizeof(tls->random));
   // store session_id
   session_id_len = rio->buf[43];
+  if (((uint32_t) session_id_len + 46) > rio->len) goto fail;
   if (session_id_len == sizeof(tls->session_id)) {
     memmove(tls->session_id, rio->buf + 44, session_id_len);
   } else if (session_id_len != 0) {

--- a/src/tls_builtin.c
+++ b/src/tls_builtin.c
@@ -666,6 +666,7 @@ static int mg_tls_server_recv_hello(struct mg_connection *c) {
   memmove(tls->random, rio->buf + 11, sizeof(tls->random));
   // store session_id
   session_id_len = rio->buf[43];
+  if (((uint32_t) session_id_len + 46) > rio->len) goto fail;
   if (session_id_len == sizeof(tls->session_id)) {
     memmove(tls->session_id, rio->buf + 44, session_id_len);
   } else if (session_id_len != 0) {


### PR DESCRIPTION
mg_tls_server_recv_hello() reads session_id_len from the ClientHello at offset 43 and uses it to locate cipher_suites_len at rio->buf[44 + session_id_len], with only a rio->len >= 50 check. A client sending session_id_len up to 255 in a short record reads past the buffer (ASAN flags a heap-buffer-overflow ~250 bytes out). Bound it against rio->len before use, the same way the later length fields are checked.