### PR TITLE
Added Fix for WolfSSL not working correctly as server

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -19835,8 +19835,10 @@ void mg_tls_free(struct mg_connection *c) {
   struct mg_tls *tls = (struct mg_tls *) c->tls;
   if (tls == NULL) return;
   SSL_free(tls->ssl);
+#if MG_TLS != MG_TLS_WOLFSSL
   SSL_CTX_free(tls->ctx);
   BIO_meth_free(tls->bm);
+#endif
   mg_free(tls);
   c->tls = NULL;
 }
@@ -19867,6 +19869,25 @@ void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
 #ifdef MG_TLS_SSLKEYLOGFILE
   SSL_CTX_set_keylog_callback(tls->ctx, ssl_keylog_cb);
 #endif
+
+#if MG_TLS == MG_TLS_WOLFSSL
+  rc = wolfSSL_CTX_use_certificate_buffer(tls->ctx, (unsigned char *) opts->cert.buf,
+    (int) opts->cert.len, WOLFSSL_FILETYPE_PEM);
+
+  if (rc != WOLFSSL_SUCCESS) {
+    mg_error(c, "CERT err %d", mg_tls_err(c, tls, rc));
+    goto fail;
+  }
+
+  rc = wolfSSL_CTX_use_PrivateKey_buffer(tls->ctx, (unsigned char *) opts->key.buf,
+    (int) opts->key.len, WOLFSSL_FILETYPE_PEM);
+
+  if (rc != WOLFSSL_SUCCESS) {
+    mg_error(c, "KEY err %d", mg_tls_err(c, tls, rc));
+    goto fail;
+  }
+#endif
+
   if ((tls->ssl = SSL_new(tls->ctx)) == NULL) {
     mg_error(c, "SSL_new");
     goto fail;
@@ -19917,6 +19938,7 @@ void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
 #endif
   }
 
+#if MG_TLS != MG_TLS_WOLFSSL
   if (opts->cert.buf != NULL && opts->cert.buf[0] != '\0') {
     rc = load_cert(tls->ssl, opts->cert);
     if (rc != 1) {
@@ -19933,6 +19955,7 @@ void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
       goto fail;
     }
   }
+#endif
 
   SSL_set_mode(tls->ssl, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
 #if MG_TLS == MG_TLS_OPENSSL && OPENSSL_VERSION_NUMBER > 0x10002000L

--- a/src/tls_openssl.c
+++ b/src/tls_openssl.c
@@ -136,8 +136,10 @@ void mg_tls_free(struct mg_connection *c) {
   struct mg_tls *tls = (struct mg_tls *) c->tls;
   if (tls == NULL) return;
   SSL_free(tls->ssl);
+#if MG_TLS != MG_TLS_WOLFSSL
   SSL_CTX_free(tls->ctx);
   BIO_meth_free(tls->bm);
+#endif
   mg_free(tls);
   c->tls = NULL;
 }
@@ -168,6 +170,25 @@ void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
 #ifdef MG_TLS_SSLKEYLOGFILE
   SSL_CTX_set_keylog_callback(tls->ctx, ssl_keylog_cb);
 #endif
+
+#if MG_TLS == MG_TLS_WOLFSSL
+  rc = wolfSSL_CTX_use_certificate_buffer(tls->ctx, (unsigned char *) opts->cert.buf,
+    (int) opts->cert.len, WOLFSSL_FILETYPE_PEM);
+
+  if (rc != WOLFSSL_SUCCESS) {
+    mg_error(c, "CERT err %d", mg_tls_err(c, tls, rc));
+    goto fail;
+  }
+
+  rc = wolfSSL_CTX_use_PrivateKey_buffer(tls->ctx, (unsigned char *) opts->key.buf,
+    (int) opts->key.len, WOLFSSL_FILETYPE_PEM);
+
+  if (rc != WOLFSSL_SUCCESS) {
+    mg_error(c, "KEY err %d", mg_tls_err(c, tls, rc));
+    goto fail;
+  }
+#endif
+
   if ((tls->ssl = SSL_new(tls->ctx)) == NULL) {
     mg_error(c, "SSL_new");
     goto fail;
@@ -218,6 +239,7 @@ void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
 #endif
   }
 
+#if MG_TLS != MG_TLS_WOLFSSL
   if (opts->cert.buf != NULL && opts->cert.buf[0] != '\0') {
     rc = load_cert(tls->ssl, opts->cert);
     if (rc != 1) {
@@ -234,6 +256,7 @@ void mg_tls_init(struct mg_connection *c, const struct mg_tls_opts *opts) {
       goto fail;
     }
   }
+#endif
 
   SSL_set_mode(tls->ssl, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
 #if MG_TLS == MG_TLS_OPENSSL && OPENSSL_VERSION_NUMBER > 0x10002000L


### PR DESCRIPTION
Looks like there might be a bug in the TLS init and free functionality for WolfSSL. WolfSSL seams to require certificates and keys loaded into the **SSL_CTX**-object before calling **SSL_new** which the OpenSSL compatability layer doesn't provide. Thus SSL_new will always fail as the **SSL**-object pointer is NULL. This fix provides WolfSSL-specific function calls to set the certificate and key before calling **SSL_new** with the context.

The second problem is with the way OpenSSL and WolfSSL free their **SSL**-objects. WolfSSL frees the **BIO_METHOD** and the **SSL_CTX** internally via a function for resource freeing. OpenSSL does not do that and requires additional function calls for resource freeing. These function calls freeze/crash Mongoose when using WolfSSL. The fix simply checks that **MG_TLS** is not set to **MG_TLS_WOLFSSL** and only frees the resources manually on not-WolfSSL.

Fix has been manually tested on:

- Microsoft Windows 11 using WolfSSL, OpenSSL and Builtin TLS
- Linux (Ubuntu) via WSL using WolfSSL, OpenSSL and Builtin TLS
- macOS using WolfSSL, OpenSSL and Builtin TLS

Testing was only done with HTTP server and not client.