### PR TITLE
bound ServerHello record length in mg_tls_client_recv_hello

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -16617,6 +16617,7 @@ static int mg_tls_client_recv_hello(struct mg_connection *c) {
     return -1;
   }
 
+  if (rio->len < 5 + 39 + 32 + 3 + 2) goto fail;
   msgsz = MG_LOAD_BE16(rio->buf + 3);
   mg_sha256_update(&tls->sha256, rio->buf + 5, msgsz);
 

--- a/src/tls_builtin.c
+++ b/src/tls_builtin.c
@@ -1306,6 +1306,7 @@ static int mg_tls_client_recv_hello(struct mg_connection *c) {
     return -1;
   }
 
+  if (rio->len < 5 + 39 + 32 + 3 + 2) goto fail;
   msgsz = MG_LOAD_BE16(rio->buf + 3);
   mg_sha256_update(&tls->sha256, rio->buf + 5, msgsz);
 


### PR DESCRIPTION
mg_tls_client_recv_hello reads ext_len at a fixed offset (rio->buf+79) and walks the extension list at rio->buf+81, but mg_tls_got_record only guarantees rio->len >= 5 + msgsz. A server that sends a ServerHello record shorter than 81 bytes reaches those reads out of bounds, and since rio->len is size_t the guard ext_len > rio->len - 81 underflows and the loop runs off the buffer. The server-side mg_tls_server_recv_hello already guards with rio->len < 50; this adds the matching minimum-length check before the fixed offsets are read.