### PR TITLE
Fix Risc-V assembly instruction in mg_picosdk_write

### DIFF
--- a/src/ota_picosdk.c
+++ b/src/ota_picosdk.c
@@ -89,7 +89,7 @@ static bool __no_inline_not_in_flash_func(mg_picosdk_write)(void *addr,
 #ifndef __riscv
     MG_ARM_ENABLE_IRQ();
 #else
-    asm volatile("csrrs mstatus, %0" : : "i"(1 << 3) : "memory");
+    asm volatile("csrs mstatus, %0" : : "i"(1 << 3) : "memory");
 #endif
   }
   MG_DEBUG(("Flash write %lu bytes @ %p.", len, dst));


### PR DESCRIPTION
I think that there is a typo here - `csrrs` is supposed to be `csrs`, as `csrrs` would need a register before `mstatus` (like the `csrrc` above)

Noticed in https://forums.raspberrypi.com/viewtopic.php?t=398792