### PR TITLE
Fix MSVC build failure (C2061) caused by hardcoded __attribute__

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -9905,7 +9905,11 @@ void mg_tcpip_mapip(struct mg_connection *c, struct mg_addr *ip) {
 // Scannable version tag embedded in every firmware binary, for server-side
 // version extraction. __attribute__((used)) prevents --gc-sections from
 // stripping it. The version string starts after the 11-char "MG_VERSION:" prefix.
+#if defined(_WIN32)
+static const char mg_fw_version[] =
+#else
 static const char mg_fw_version[] __attribute__((used)) =
+#endif
     "MG_VERSION:" MG_OTA_FIRMWARE_VERSION;
 
 static bool s_autocommit_ok;  // True after OTA server confirms "same version"


### PR DESCRIPTION
**Description:**
When compiling `mongoose.c` on Windows using MSVC (`cl.exe`), the build fails because MSVC does not support the GCC-specific `__attribute__((used))` syntax. 

**Error logs:**
```text
mongoose.c(9908): error C2061: syntax error: identifier '__attribute__'
mongoose.c(9908): error C2059: syntax error: ';'
mongoose.c(9950): error C2065: 'mg_fw_version': undeclared identifier
```

**Fix:**
This PR adds a cross-platform `#if defined(_WIN32)` check around `__attribute__((used))` for `mg_fw_version`. This allows the library to compile cleanly under MSVC again while preserving the attribute for GCC/Clang environments.