### PR TITLE
Please revert using CLOCK_MONOTONIC and CLOCK_MONOTONIC_RAW.

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -185,18 +185,9 @@ uint64_t mg_millis(void) {
   return clock_gettime_nsec_np(CLOCK_UPTIME_RAW) / 1000000;
 #elif MG_ARCH == MG_ARCH_UNIX
   struct timespec ts = {0, 0};
-  // See #1615 - prefer monotonic clock
-#if defined(CLOCK_MONOTONIC_RAW)
-  // Raw hardware-based time that is not subject to NTP adjustment
-  clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
-#elif defined(CLOCK_MONOTONIC)
-  // Affected by the incremental adjustments performed by adjtime and NTP
-  clock_gettime(CLOCK_MONOTONIC, &ts);
-#else
   // Affected by discontinuous jumps in the system time and by the incremental
   // adjustments performed by adjtime and NTP
   clock_gettime(CLOCK_REALTIME, &ts);
-#endif
   return ((uint64_t) ts.tv_sec * 1000 + (uint64_t) ts.tv_nsec / 1000000);
 #elif defined(ARDUINO)
   return (uint64_t) millis();


### PR DESCRIPTION
CLOCK_MONOTONIC and CLOCK_MONOTONIC_RAW cannot be used to compare certificate date information.

For example:
Function mg_tls_parse_cert_der() calls mg_now() to get the current UTC timestamp and uses the value returned by mg_now() like:

	uint64_t now = mg_now() / 1000U;

That function then parses various date related fields from the certificate and compares them against that value.

The mg_now() function just calls mg_millis() like:

uint64_t mg_now(void) {
	return mg_millis() + mg_boot_timestamp_ms;
}

In #1615, the mg_millis() implementation for ARCH_UNIX has been changed to use clock_gettime(CLOCK_MONOTONIC..) or CLOCK_MONOTONIC_RAW only falling back to CLOCK_REALTIME.

Quoting POSIX: "For this clock, the value returned by clock_gettime() represents the amount of time (in seconds and nanoseconds) since an unspecified point in the past (for example, system start-up time, or the Epoch)."

Function mg_millis() must not use CLOCK_MONOTONIC or CLOCK_MONOTONIC_RAW if function mg_now() expects it to return a timestamp since the epoch.

This leads to various problems on systems where CLOCK_MONOTONIC does not represent a timestamp but an amount of time since an unspecified point in the past leading to debug output on e.g. OpenBSD like:

11f22288 1 mongoose.c:17406:mg_tls_pars cert is not yet valid: before=260517035651Z (1778990211), now=301081

This commit reverts the use of CLOCK_MONOTONIC and CLOCK_MONOTONIC_RAW to CLOCK_REALTIME, which is guaranteed to return a timestamp since the epoch as expected by mg_now().