### PR TITLE
Reject malformed input in mg_json_get_hex

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -5078,15 +5078,18 @@ char *mg_json_get_b64(struct mg_str json, const char *path, int *slen) {
 char *mg_json_get_hex(struct mg_str json, const char *path, int *slen) {
   char *result = NULL;
   int len = 0, off = mg_json_get(json, path, &len);
-  if (off >= 0 && json.buf[off] == '"' && len > 1 &&
+  if (off >= 0 && json.buf[off] == '"' && len > 1 && (len - 2) % 2 == 0 &&
       (result = (char *) mg_calloc(1, (size_t) len / 2)) != NULL) {
     int i;
     for (i = 0; i < len - 2; i += 2) {
-      mg_str_to_num(mg_str_n(json.buf + off + 1 + i, 2), 16, &result[i >> 1],
-                    sizeof(uint8_t));
+      if (!mg_str_to_num(mg_str_n(json.buf + off + 1 + i, 2), 16,
+                         &result[i >> 1], sizeof(uint8_t))) break;
     }
-    result[len / 2 - 1] = '\0';
-    if (slen != NULL) *slen = len / 2 - 1;
+    if (i < len - 2) mg_free(result), result = NULL;
+    if (result != NULL) {
+      result[len / 2 - 1] = '\0';
+      if (slen != NULL) *slen = len / 2 - 1;
+    }
   }
   return result;
 }

--- a/mongoose.h
+++ b/mongoose.h
@@ -4104,7 +4104,7 @@ char *mg_json_get_str(struct mg_str json, const char *path);
 
 // Decodes a hex-encoded JSON string at path into a heap-allocated byte array.
 // Sets *len to the decoded byte count. Caller must mg_free() the result.
-// Returns NULL if not found or not a string.
+// Returns NULL if not found, not a string, or not valid hexadecimal.
 char *mg_json_get_hex(struct mg_str json, const char *path, int *len);
 
 // Decodes a base64-encoded JSON string at path into a heap-allocated byte

--- a/src/json.c
+++ b/src/json.c
@@ -363,15 +363,18 @@ char *mg_json_get_b64(struct mg_str json, const char *path, int *slen) {
 char *mg_json_get_hex(struct mg_str json, const char *path, int *slen) {
   char *result = NULL;
   int len = 0, off = mg_json_get(json, path, &len);
-  if (off >= 0 && json.buf[off] == '"' && len > 1 &&
+  if (off >= 0 && json.buf[off] == '"' && len > 1 && (len - 2) % 2 == 0 &&
       (result = (char *) mg_calloc(1, (size_t) len / 2)) != NULL) {
     int i;
     for (i = 0; i < len - 2; i += 2) {
-      mg_str_to_num(mg_str_n(json.buf + off + 1 + i, 2), 16, &result[i >> 1],
-                    sizeof(uint8_t));
+      if (!mg_str_to_num(mg_str_n(json.buf + off + 1 + i, 2), 16,
+                         &result[i >> 1], sizeof(uint8_t))) break;
     }
-    result[len / 2 - 1] = '\0';
-    if (slen != NULL) *slen = len / 2 - 1;
+    if (i < len - 2) mg_free(result), result = NULL;
+    if (result != NULL) {
+      result[len / 2 - 1] = '\0';
+      if (slen != NULL) *slen = len / 2 - 1;
+    }
   }
   return result;
 }

--- a/src/json.h
+++ b/src/json.h
@@ -57,7 +57,7 @@ char *mg_json_get_str(struct mg_str json, const char *path);
 
 // Decodes a hex-encoded JSON string at path into a heap-allocated byte array.
 // Sets *len to the decoded byte count. Caller must mg_free() the result.
-// Returns NULL if not found or not a string.
+// Returns NULL if not found, not a string, or not valid hexadecimal.
 char *mg_json_get_hex(struct mg_str json, const char *path, int *len);
 
 // Decodes a base64-encoded JSON string at path into a heap-allocated byte

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -3741,12 +3741,22 @@ static void test_json(void) {
     ASSERT(b == true);
     ASSERT(mg_json_get(json, "$.b[2]", &len) < 0);
 
-    json = mg_str("[\"YWJj\", \"0100026869\"]");
+    json = mg_str("[\"YWJj\", \"0100026869\", \"\", \"abc\", \"0g\"]");
     ASSERT((str = mg_json_get_b64(json, "$[0]", &len)) != NULL);
     ASSERT(len == 3 && memcmp(str, "abc", (size_t) len) == 0);
     mg_free(str);
     ASSERT((str = mg_json_get_hex(json, "$[1]", &len)) != NULL);
     ASSERT(len == 5 && memcmp(str, "\x01\x00\x02hi", (size_t) len) == 0);
+    mg_free(str);
+    ASSERT((str = mg_json_get_hex(json, "$[2]", &len)) != NULL);
+    ASSERT(len == 0 && str[0] == '\0');
+    mg_free(str);
+    len = 42;
+    str = mg_json_get_hex(json, "$[3]", &len);
+    ASSERT(str == NULL && len == 42);
+    mg_free(str);
+    str = mg_json_get_hex(json, "$[4]", &len);
+    ASSERT(str == NULL && len == 42);
     mg_free(str);
 
     json = mg_str("{\"a\":[1,2,3], \"ab\": 2}");


### PR DESCRIPTION
`mg_json_get_hex()` currently ignores failed `mg_str_to_num()` calls and processes odd-length strings in two-character steps. As a result, `0g` succeeds as byte `0x00`, and `abc` succeeds as byte `0xab` instead of reporting invalid input.

Reject odd-length and non-hex strings while preserving valid input and the existing empty-string behavior. The unit tests now cover empty, odd-length, and non-hex inputs.

Testing:
- `make -B -C test test TFLAGS=-DLOCALHOST_ONLY` (ASan/UBSan, 1796 tests)
- `make -B -C test unamalgamated TFLAGS=-DLOCALHOST_ONLY`, then `unit_test` (ASan/UBSan, 1796 tests)
- Regenerated `mongoose.c` and `mongoose.h` with the repository Makefile; no diff