### PR TITLE
Allow exact-size buffers in mg_url_encode

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -4269,8 +4269,9 @@ size_t mg_url_encode(const char *s, size_t sl, char *buf, size_t len) {
   size_t i, n = 0;
   for (i = 0; i < sl; i++) {
     int c = *(unsigned char *) &s[i];
-    if (n + 4 >= len) return 0;
-    if (mg_is_url_safe(c)) {
+    bool safe = mg_is_url_safe(c);
+    if (n >= len || len - n < (safe ? 2 : 4)) return 0;
+    if (safe) {
       buf[n++] = s[i];
     } else {
       mg_snprintf(&buf[n], 4, "%%%M", mg_print_hex, 1, &s[i]);

--- a/src/http.c
+++ b/src/http.c
@@ -909,8 +909,9 @@ size_t mg_url_encode(const char *s, size_t sl, char *buf, size_t len) {
   size_t i, n = 0;
   for (i = 0; i < sl; i++) {
     int c = *(unsigned char *) &s[i];
-    if (n + 4 >= len) return 0;
-    if (mg_is_url_safe(c)) {
+    bool safe = mg_is_url_safe(c);
+    if (n >= len || len - n < (safe ? 2 : 4)) return 0;
+    if (safe) {
       buf[n++] = s[i];
     } else {
       mg_snprintf(&buf[n], 4, "%%%M", mg_print_hex, 1, &s[i]);

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -2881,6 +2881,12 @@ static void test_util(void) {
     ASSERT((n = mg_url_encode("a", 1, buf, 0)) == 0);
     ASSERT((n = mg_url_encode("a", 1, buf, sizeof(buf))) == 1);
     ASSERT(strncmp(buf, "a", n) == 0);
+    ASSERT((n = mg_url_encode("a", 1, buf, 2)) == 1);
+    ASSERT(strcmp(buf, "a") == 0);
+    ASSERT(mg_url_encode("a", 1, buf, 1) == 0);
+    ASSERT((n = mg_url_encode("@", 1, buf, 4)) == 3);
+    ASSERT(strcmp(buf, "%40") == 0);
+    ASSERT(mg_url_encode("@", 1, buf, 3) == 0);
     ASSERT((n = mg_url_encode("._-~", 4, buf, sizeof(buf))) == 4);
     ASSERT(strncmp(buf, "._-~", n) == 0);
     ASSERT((n = mg_url_encode("a@%>", 4, buf, sizeof(buf))) == 10);


### PR DESCRIPTION
`mg_url_encode()` currently reserves four bytes before every input byte and rejects exact-size output buffers. `a` with 2 bytes and `@` with 4 bytes both return 0.

Use the actual encoded width (1 or 3 bytes) while reserving one byte for the terminator. Add exact-fit and one-byte-short coverage.

Tests: Linux unit suite with ASan/UBSan (`LOCALHOST_ONLY`, 1802 tests); MinGW GCC 8 boundary harness.