### PR TITLE
unbreak fatfs

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -3122,9 +3122,9 @@ static void *ff_open(const char *path, int flags) {
   if (flags & MG_FS_WRITE) {
     mode |= FA_WRITE;
     if (flags & MG_FS_EXCL) {
-      mode |= FA_OPEN_ALWAYS | FA_OPEN_APPEND;
-    } else {
       mode |= FA_CREATE_NEW;
+    } else {
+      mode |= FA_OPEN_ALWAYS | FA_OPEN_APPEND;
     }
   }
   if ((fp = mg_calloc(1, sizeof(*fp))) != NULL &&

--- a/src/fs_fat.c
+++ b/src/fs_fat.c
@@ -50,9 +50,9 @@ static void *ff_open(const char *path, int flags) {
   if (flags & MG_FS_WRITE) {
     mode |= FA_WRITE;
     if (flags & MG_FS_EXCL) {
-      mode |= FA_OPEN_ALWAYS | FA_OPEN_APPEND;
-    } else {
       mode |= FA_CREATE_NEW;
+    } else {
+      mode |= FA_OPEN_ALWAYS | FA_OPEN_APPEND;
     }
   }
   if ((fp = mg_calloc(1, sizeof(*fp))) != NULL &&


### PR DESCRIPTION
When dealing with 
> - mg_file_write temp file opened without O_EXCL

the branches were reversed.

That explains the symptom in #3612: `mg_http_upload()` removes the target for offset zero, then opens with `MG_FS_WRITE`; the first chunk succeeds because the file is absent. For the next chunk it opens the now-existing file, still with `MG_FS_WRITE`, and the inverted code selects `FA_CREATE_NEW`, so `f_open()` fails. The threshold is therefore their receive/chunk buffer size, not RAM or FAT fragmentation. 

closes #3612 